### PR TITLE
Logging #7

### DIFF
--- a/src/Finbuckle.MultiTenant.AspNetCore/BasePathMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/BasePathMultiTenantStrategy.cs
@@ -4,11 +4,19 @@ using Finbuckle.MultiTenant.AspNetCore;
 using Finbuckle.MultiTenant.Core;
 using Finbuckle.MultiTenant.Core.Abstractions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Finbuckle.MultiTenant.AspNetCore
 {
     public class BasePathMultiTenantStrategy : IMultiTenantStrategy
     {
+        private readonly ILogger<BasePathMultiTenantStrategy> logger;
+
+        public BasePathMultiTenantStrategy(ILogger<BasePathMultiTenantStrategy> logger = null)
+        {
+            this.logger = logger;
+        }
+
         public string GetIdentifier(object context)
         {
             if(!typeof(HttpContext).IsAssignableFrom(context.GetType()))
@@ -16,14 +24,26 @@ namespace Finbuckle.MultiTenant.AspNetCore
                     new ArgumentException("\"context\" type must be of type HttpContext", nameof(context)));
 
             var path = (context as HttpContext).Request.Path;
+
+            if (logger != null)
+            {
+                logger.LogInformation($"Path:  \"{path.Value ?? "<null>"}\"");
+            }
+
             var pathSegments =
-                path.Value.Split(new char[] { '/' },
-                                  StringSplitOptions.RemoveEmptyEntries);
+                path.Value.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
             if (pathSegments.Length == 0)
                 return null;
 
-            return pathSegments[0];
+            string identifier = pathSegments[0];
+
+            if (logger != null)
+            {
+                logger.LogInformation($"Found identifier:  \"{identifier}\"");
+            }
+
+            return identifier;
         }
     }
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/BasePathMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/BasePathMultiTenantStrategy.cs
@@ -25,10 +25,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
 
             var path = (context as HttpContext).Request.Path;
 
-            if (logger != null)
-            {
-                logger.LogInformation($"Path:  \"{path.Value ?? "<null>"}\"");
-            }
+            Utilities.TryLogInfo(logger, $"Path:  \"{path.Value ?? "<null>"}\"");
 
             var pathSegments =
                 path.Value.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
@@ -38,10 +35,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
 
             string identifier = pathSegments[0];
 
-            if (logger != null)
-            {
-                logger.LogInformation($"Found identifier:  \"{identifier}\"");
-            }
+            Utilities.TryLogInfo(logger, $"Found identifier:  \"{identifier}\"");
 
             return identifier;
         }

--- a/src/Finbuckle.MultiTenant.AspNetCore/HostMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/HostMultiTenantStrategy.cs
@@ -19,27 +19,21 @@ namespace Finbuckle.MultiTenant.AspNetCore
 
         public string GetIdentifier(object context)
         {
-            if(!typeof(HttpContext).IsAssignableFrom(context.GetType()))
+            if (!typeof(HttpContext).IsAssignableFrom(context.GetType()))
                 throw new MultiTenantException(null,
                     new ArgumentException("\"context\" type must be of type HttpContext", nameof(context)));
 
             var host = (context as HttpContext).Request.Host;
 
-            if (logger != null)
-            {
-                logger.LogInformation($"Host:  \"{host.Host ?? "<null>"}\"");
-            }
+            Utilities.TryLogInfo(logger, $"Host:  \"{host.Host ?? "<null>"}\"");
 
             if (host.HasValue == false)
                 return null;
-            
-            var hostSegments = host.Host.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
+
+            var hostSegments = host.Host.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
             string identifier = hostSegments[0];
 
-            if (logger != null)
-            {
-                logger.LogInformation($"Found identifier:  \"{identifier}\"");
-            }
+            Utilities.TryLogInfo(logger, $"Found identifier:  \"{identifier}\"");
 
             return identifier;
         }

--- a/src/Finbuckle.MultiTenant.AspNetCore/HostMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/HostMultiTenantStrategy.cs
@@ -4,11 +4,19 @@ using Finbuckle.MultiTenant.AspNetCore;
 using Microsoft.AspNetCore.Http;
 using Finbuckle.MultiTenant.Core;
 using Finbuckle.MultiTenant.Core.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Finbuckle.MultiTenant.AspNetCore
 {
     public class HostMultiTenantStrategy : IMultiTenantStrategy
     {
+        private readonly ILogger<HostMultiTenantStrategy> logger;
+
+        public HostMultiTenantStrategy(ILogger<HostMultiTenantStrategy> logger = null)
+        {
+            this.logger = logger;
+        }
+
         public string GetIdentifier(object context)
         {
             if(!typeof(HttpContext).IsAssignableFrom(context.GetType()))
@@ -16,12 +24,24 @@ namespace Finbuckle.MultiTenant.AspNetCore
                     new ArgumentException("\"context\" type must be of type HttpContext", nameof(context)));
 
             var host = (context as HttpContext).Request.Host;
+
+            if (logger != null)
+            {
+                logger.LogInformation($"Host:  \"{host.Host ?? "<null>"}\"");
+            }
+
             if (host.HasValue == false)
                 return null;
             
-            var hostSegments = host.Host.Split('.');
+            var hostSegments = host.Host.Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries);
+            string identifier = hostSegments[0];
 
-            return hostSegments[0];
+            if (logger != null)
+            {
+                logger.LogInformation($"Found identifier:  \"{identifier}\"");
+            }
+
+            return identifier;
         }
     }
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantBuilder.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantBuilder.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
 
 namespace Finbuckle.MultiTenant.AspNetCore
 {
@@ -16,11 +17,11 @@ namespace Finbuckle.MultiTenant.AspNetCore
     /// </summary>
     public class MultiTenantBuilder
     {
-        internal readonly IServiceCollection _services;
+        internal readonly IServiceCollection services;
 
         public MultiTenantBuilder(IServiceCollection services)
         {
-            _services = services;
+            this.services = services;
         }
 
         /// <summary>
@@ -30,7 +31,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// <returns>The same <c>MultiTenantBuilder</c> passed into the method.</returns>
         public MultiTenantBuilder WithPerTenantOptionsConfig<TOptions>(Action<TOptions, TenantContext> tenantConfig) where TOptions : class
         {
-            _services.TryAddSingleton<IOptionsMonitorCache<TOptions>>(sp =>
+            services.TryAddSingleton<IOptionsMonitorCache<TOptions>>(sp =>
                 {
                     return (MultiTenantOptionsCache<TOptions>)
                         ActivatorUtilities.CreateInstance(sp, typeof(MultiTenantOptionsCache<TOptions>), new[] { tenantConfig });
@@ -52,9 +53,9 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// <returns>The same <c>MultiTenantBuilder</c> passed into the method.</returns>
         public MultiTenantBuilder WithInMemoryStore(Action<InMemoryMultiTenantStoreOptions> config)
         {
-            _services.AddOptions();
-            _services.Configure<InMemoryMultiTenantStoreOptions>(config);
-            _services.TryAddSingleton<IMultiTenantStore>(StoreFactory);
+            services.AddOptions();
+            services.Configure<InMemoryMultiTenantStoreOptions>(config);
+            services.TryAddSingleton<IMultiTenantStore>(StoreFactory);
 
             return this;
         }
@@ -66,9 +67,9 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// <returns>The same <c>MultiTenantBuilder</c> passed into the method.</returns>
         public MultiTenantBuilder WithInMemoryStore(IConfigurationSection configurationSection)
         {
-            _services.AddOptions();
-            _services.Configure<InMemoryMultiTenantStoreOptions>(o => configurationSection.Bind(o));
-            _services.TryAddSingleton<IMultiTenantStore>(StoreFactory);
+            services.AddOptions();
+            services.Configure<InMemoryMultiTenantStoreOptions>(o => configurationSection.Bind(o));
+            services.TryAddSingleton<IMultiTenantStore>(StoreFactory);
 
             return this;
         }
@@ -128,7 +129,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// <returns>The same <c>MultiTenantBuilder</c> passed into the method.</returns>
         public MultiTenantBuilder WithStaticStrategy(string identifier)
         {
-            _services.TryAddSingleton<IMultiTenantStrategy>(sp => new StaticMultiTenantStrategy(identifier));
+            services.TryAddSingleton<IMultiTenantStrategy>(sp => new StaticMultiTenantStrategy(identifier));
 
             return this;
         }
@@ -139,7 +140,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// <returnsThe same <c>MultiTenantBuilder</c> passed into the method.></returns>
         public MultiTenantBuilder WithBasePathStrategy()
         {
-            _services.TryAddSingleton<IMultiTenantStrategy, BasePathMultiTenantStrategy>();
+            services.TryAddSingleton<IMultiTenantStrategy, BasePathMultiTenantStrategy>();
 
             return this;
         }
@@ -151,7 +152,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// <returns>The same <c>MultiTenantBuilder</c> passed into the method.</returns>
         public MultiTenantBuilder WithRouteStrategy(string tenantParam = "__tenant__")
         {
-            _services.TryAddSingleton<IMultiTenantStrategy>(sp => new RouteMultiTenantStrategy(tenantParam));
+            services.TryAddSingleton<IMultiTenantStrategy>(sp => new RouteMultiTenantStrategy(tenantParam, sp.GetRequiredService<ILogger<RouteMultiTenantStrategy>>()));
 
             return this;
         }
@@ -162,7 +163,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// <returns>The same <c>MultiTenantBuilder</c> passed into the method.</returns>
         public MultiTenantBuilder WithHostStrategy()
         {
-            _services.TryAddSingleton<IMultiTenantStrategy, HostMultiTenantStrategy>();
+            services.TryAddSingleton<IMultiTenantStrategy, HostMultiTenantStrategy>();
 
             return this;
         }

--- a/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantMiddleware.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantMiddleware.cs
@@ -11,18 +11,18 @@ namespace Finbuckle.MultiTenant.AspNetCore
     /// </summary>
     public class MultiTenantMiddleware
     {
-        private readonly RequestDelegate _next;
-        private readonly IRouter _router;
+        private readonly RequestDelegate next;
+        private readonly IRouter router;
 
         public MultiTenantMiddleware(RequestDelegate next)
         {
-            this._next = next;
+            this.next = next;
         }
 
         public MultiTenantMiddleware(RequestDelegate next, IRouter router)
         {
-            this._next = next;
-            this._router = router;
+            this.next = next;
+            this.router = router;
         }
 
         public async Task Invoke(HttpContext context)
@@ -32,9 +32,9 @@ namespace Finbuckle.MultiTenant.AspNetCore
                 var sp = context.RequestServices;
                 var resolver = sp.GetRequiredService<TenantResolver>();
 
-                if(_router != null)
+                if(router != null)
                 {
-                    await _router.RouteAsync(new RouteContext(context)).ConfigureAwait(false);
+                    await router.RouteAsync(new RouteContext(context)).ConfigureAwait(false);
                 }
                 
                 var tc = await resolver.ResolveAsync(context).ConfigureAwait(false);
@@ -42,8 +42,8 @@ namespace Finbuckle.MultiTenant.AspNetCore
                     context.Items.Add(Constants.HttpContextTenantContext, tc);
             }
 
-            if(_next != null)
-                await _next(context);
+            if(next != null)
+                await next(context);
         }
     }
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantOptionsCache.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantOptionsCache.cs
@@ -16,19 +16,19 @@ namespace Finbuckle.MultiTenant.AspNetCore
     /// </summary>
     public class MultiTenantOptionsCache<TOptions> : OptionsCache<TOptions> where TOptions : class
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly Action<TOptions, TenantContext> _tenantConfig;
+        private readonly IHttpContextAccessor httpContextAccessor;
+        private readonly Action<TOptions, TenantContext> tenantConfig;
 
         // Note: the object is just a dummy because there is no ConcurrentSet<T> class.
         private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, object>> _adjustedOptionsNames =
             new ConcurrentDictionary<string, ConcurrentDictionary<string, object>>();
 
-        private TenantContext TenantContext { get => _httpContextAccessor.HttpContext?.GetTenantContextAsync().Result; }
+        private TenantContext TenantContext { get => httpContextAccessor.HttpContext?.GetTenantContextAsync().Result; }
 
         public MultiTenantOptionsCache(IHttpContextAccessor httpContextAccessor, Action<TOptions, TenantContext> tenantConfig)
         {
-            _httpContextAccessor = httpContextAccessor;
-            _tenantConfig = tenantConfig ?? throw new ArgumentNullException(nameof(tenantConfig));
+            this.httpContextAccessor = httpContextAccessor;
+            this.tenantConfig = tenantConfig ?? throw new ArgumentNullException(nameof(tenantConfig));
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
         {
             if (TenantContext != null)
             {
-                _tenantConfig(options, TenantContext);
+                tenantConfig(options, TenantContext);
             }
         }
     }

--- a/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantOptionsCache.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantOptionsCache.cs
@@ -19,7 +19,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly Action<TOptions, TenantContext> tenantConfig;
 
-        // Note: the object is just a dummy because there is no ConcurrentSet<T> class.
+        // The object is just a dummy because there is no ConcurrentSet<T> class.
         private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, object>> _adjustedOptionsNames =
             new ConcurrentDictionary<string, ConcurrentDictionary<string, object>>();
 

--- a/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantRouteHandler.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantRouteHandler.cs
@@ -25,11 +25,11 @@ namespace Finbuckle.MultiTenant.AspNetCore
 
         public Task RouteAsync(RouteContext context)
         {
-            // set the context Handler so route matching will stop
+            // Set the context Handler so route matching will stop.
             context.Handler = requestDelegate;
 
-            // set the HttpContext feature so that a Route based TenantResolver can use it
-            // note: this may be overwritten by later middleware
+            // Set the HttpContext feature so that a route based TenantResolver can use it.
+            // This may be overwritten by later MVC or other middleware.
             context.HttpContext.Features[typeof(IRoutingFeature)] = new RoutingFeature()
             {
                 RouteData = context.RouteData,

--- a/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantRouteHandler.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantRouteHandler.cs
@@ -11,11 +11,11 @@ namespace Finbuckle.MultiTenant.AspNetCore
     /// </summary>
     public class MultiTenantRouteHandler : IRouteHandler, IRouter
     {
-        private RequestDelegate _requestDelegate = (HttpContext) => null;
+        private RequestDelegate requestDelegate = (HttpContext) => null;
 
         public RequestDelegate GetRequestHandler(HttpContext httpContext, RouteData routeData)
         {
-            return _requestDelegate;
+            return requestDelegate;
         }
 
         public VirtualPathData GetVirtualPath(VirtualPathContext context)
@@ -26,7 +26,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
         public Task RouteAsync(RouteContext context)
         {
             // set the context Handler so route matching will stop
-            context.Handler = _requestDelegate;
+            context.Handler = requestDelegate;
 
             // set the HttpContext feature so that a Route based TenantResolver can use it
             // note: this may be overwritten by later middleware

--- a/src/Finbuckle.MultiTenant.AspNetCore/RouteMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/RouteMultiTenantStrategy.cs
@@ -10,17 +10,17 @@ namespace Finbuckle.MultiTenant.AspNetCore
 {
     public class RouteMultiTenantStrategy : IMultiTenantStrategy
     {
-        private readonly string _tenantParam;
+        private readonly string tenantParam;
         private readonly ILogger<RouteMultiTenantStrategy> logger;
 
-        public RouteMultiTenantStrategy(string tenantParam, ILogger<RouteMultiTenantStrategy> logger)
+        public RouteMultiTenantStrategy(string tenantParam, ILogger<RouteMultiTenantStrategy> logger = null)
         {
             if (string.IsNullOrWhiteSpace(tenantParam))
             {
                 throw new MultiTenantException(null, new ArgumentException($"\"{nameof(tenantParam)}\" must not be null or whitespace", nameof(tenantParam)));
             }
 
-            _tenantParam = tenantParam;
+            this.tenantParam = tenantParam;
             this.logger = logger;
         }
 
@@ -31,12 +31,9 @@ namespace Finbuckle.MultiTenant.AspNetCore
                     new ArgumentException("\"context\" type must be of type HttpContext", nameof(context)));
 
             object identifier = null;
-            (context as HttpContext).GetRouteData()?.Values.TryGetValue(_tenantParam, out identifier);
+            (context as HttpContext).GetRouteData()?.Values.TryGetValue(tenantParam, out identifier);
 
-            if (logger != null)
-            {
-                logger.LogInformation($"Found identifier:  \"{(string)identifier ?? "<null>"}\"");
-            }
+            Utilities.TryLogInfo(logger, $"Found identifier:  \"{identifier}\"");
             
             return identifier as string;
         }

--- a/src/Finbuckle.MultiTenant.AspNetCore/RouteMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/RouteMultiTenantStrategy.cs
@@ -4,14 +4,16 @@ using Finbuckle.MultiTenant.Core;
 using Finbuckle.MultiTenant.Core.Abstractions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 
 namespace Finbuckle.MultiTenant.AspNetCore
 {
     public class RouteMultiTenantStrategy : IMultiTenantStrategy
     {
         private readonly string _tenantParam;
+        private readonly ILogger<RouteMultiTenantStrategy> logger;
 
-        public RouteMultiTenantStrategy(string tenantParam)
+        public RouteMultiTenantStrategy(string tenantParam, ILogger<RouteMultiTenantStrategy> logger)
         {
             if (string.IsNullOrWhiteSpace(tenantParam))
             {
@@ -19,6 +21,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
             }
 
             _tenantParam = tenantParam;
+            this.logger = logger;
         }
 
         public string GetIdentifier(object context)
@@ -30,6 +33,11 @@ namespace Finbuckle.MultiTenant.AspNetCore
             object identifier = null;
             (context as HttpContext).GetRouteData()?.Values.TryGetValue(_tenantParam, out identifier);
 
+            if (logger != null)
+            {
+                logger.LogInformation($"Found identifier:  \"{(string)identifier ?? "<null>"}\"");
+            }
+            
             return identifier as string;
         }
     }

--- a/src/Finbuckle.MultiTenant.Core/Finbuckle.MultiTenant.Core.csproj
+++ b/src/Finbuckle.MultiTenant.Core/Finbuckle.MultiTenant.Core.csproj
@@ -7,4 +7,8 @@
     <Title>Finbuckle.MultiTenant.Core</Title>
     <Description>Core package for Finbuckle.MultiTenant.</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+          <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0-rc1-final" />
+  </ItemGroup>
 </Project>

--- a/src/Finbuckle.MultiTenant.Core/StaticMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant.Core/StaticMultiTenantStrategy.cs
@@ -26,10 +26,7 @@ namespace Finbuckle.MultiTenant.Core
 
         public string GetIdentifier(object context)
         {
-            if (logger != null)
-            {
-                logger.LogInformation($"Found identifier:  \"{identifier}\"");
-            }
+            Utilities.TryLogInfo(logger, $"Found identifier:  \"{identifier}\"");
 
             return identifier;
         }

--- a/src/Finbuckle.MultiTenant.Core/StaticMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant.Core/StaticMultiTenantStrategy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Finbuckle.MultiTenant.Core.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Finbuckle.MultiTenant.Core
 {
@@ -9,18 +10,28 @@ namespace Finbuckle.MultiTenant.Core
     /// </summary>
     public class StaticMultiTenantStrategy : IMultiTenantStrategy
     {
-        private readonly string _identifier;
+        private readonly string identifier;
+        private readonly ILogger<StaticMultiTenantStrategy> logger;
 
-        public StaticMultiTenantStrategy(string identifier)
+        public StaticMultiTenantStrategy(string identifier, ILogger<StaticMultiTenantStrategy> logger = null)
         {
             if (string.IsNullOrWhiteSpace(identifier))
             {
                 throw new MultiTenantException(null, new ArgumentException("\"identifier\" must not be null or whitespace", nameof(identifier)));
             }
-            
-            _identifier = identifier;
+
+            this.identifier = identifier;
+            this.logger = logger;
         }
 
-        public string GetIdentifier(object context) => _identifier;
+        public string GetIdentifier(object context)
+        {
+            if (logger != null)
+            {
+                logger.LogInformation($"Found identifier:  \"{identifier}\"");
+            }
+
+            return identifier;
+        }
     }
 }

--- a/src/Finbuckle.MultiTenant.Core/Utilities.cs
+++ b/src/Finbuckle.MultiTenant.Core/Utilities.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging;
+
+namespace Finbuckle.MultiTenant.Core
+{
+    public class Utilities
+    {
+        public static void TryLogInfo(ILogger logger, string message)
+        {
+            if (logger != null)
+            {
+                logger.LogInformation(message);
+            }
+        }
+    }
+}

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
@@ -18,7 +18,7 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
     public class MultiTenantDbContext : DbContext
     {
         private readonly TenantContext _tenantContext;
-        private ImmutableList<IEntityType> _tenantScopeEntityTypes = null;
+        private ImmutableList<IEntityType> _multiTenantEntityTypes = null;
 
         protected string ConnectionString => _tenantContext.ConnectionString;
 
@@ -40,14 +40,14 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
         {
             get
             {
-                if (_tenantScopeEntityTypes == null)
+                if (_multiTenantEntityTypes == null)
                 {
-                    _tenantScopeEntityTypes = Model.GetEntityTypes().
+                    _multiTenantEntityTypes = Model.GetEntityTypes().
                        Where(t => t.ClrType.GetCustomAttribute<MultiTenantAttribute>() != null).
                        ToImmutableList();
                 }
 
-                return _tenantScopeEntityTypes;
+                return _multiTenantEntityTypes;
             }
         }
 

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
@@ -17,19 +17,19 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
     /// </summary>
     public class MultiTenantDbContext : DbContext
     {
-        private readonly TenantContext _tenantContext;
-        private ImmutableList<IEntityType> _multiTenantEntityTypes = null;
+        private readonly TenantContext tenantContext;
+        private ImmutableList<IEntityType> multiTenantEntityTypes = null;
 
-        protected string ConnectionString => _tenantContext.ConnectionString;
+        protected string ConnectionString => tenantContext.ConnectionString;
 
         public MultiTenantDbContext(TenantContext tenantContext, DbContextOptions options) : base(options)
         {
-            _tenantContext = tenantContext;
+            this.tenantContext = tenantContext;
         }
 
         public MultiTenantDbContext(string connectionString, DbContextOptions options) : base(options)
         {
-            _tenantContext = new TenantContext(null, null, null, connectionString, null, null);
+            tenantContext = new TenantContext(null, null, null, connectionString, null, null);
         }
 
         public TenantMismatchMode TenantMismatchMode { get; set; } = TenantMismatchMode.Throw;
@@ -40,20 +40,20 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
         {
             get
             {
-                if (_multiTenantEntityTypes == null)
+                if (multiTenantEntityTypes == null)
                 {
-                    _multiTenantEntityTypes = Model.GetEntityTypes().
+                    multiTenantEntityTypes = Model.GetEntityTypes().
                        Where(t => t.ClrType.GetCustomAttribute<MultiTenantAttribute>() != null).
                        ToImmutableList();
                 }
 
-                return _multiTenantEntityTypes;
+                return multiTenantEntityTypes;
             }
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            Shared.SetupModel(modelBuilder, _tenantContext);
+            Shared.SetupModel(modelBuilder, tenantContext);
         }
 
         public override int SaveChanges(bool acceptAllChangesOnSuccess)
@@ -61,7 +61,7 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
             if (ChangeTracker.AutoDetectChangesEnabled)
                 ChangeTracker.DetectChanges();
 
-            Shared.EnforceTenantId(_tenantContext, ChangeTracker, TenantNotSetMode, TenantMismatchMode);
+            Shared.EnforceTenantId(tenantContext, ChangeTracker, TenantNotSetMode, TenantMismatchMode);
 
             var origAutoDetectChange = ChangeTracker.AutoDetectChangesEnabled;
             ChangeTracker.AutoDetectChangesEnabled = false;
@@ -79,7 +79,7 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
             if (ChangeTracker.AutoDetectChangesEnabled)
                 ChangeTracker.DetectChanges();
 
-            Shared.EnforceTenantId(_tenantContext, ChangeTracker, TenantNotSetMode, TenantMismatchMode);
+            Shared.EnforceTenantId(tenantContext, ChangeTracker, TenantNotSetMode, TenantMismatchMode);
 
             var origAutoDetectChange = ChangeTracker.AutoDetectChangesEnabled;
             ChangeTracker.AutoDetectChangesEnabled = false;

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
@@ -19,19 +19,19 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
     /// </summary>
     public class MultiTenantIdentityDbContext<TUser> : IdentityDbContext<TUser> where TUser : IdentityUser
     {
-        private readonly TenantContext _tenantContext;
-        private ImmutableList<IEntityType> _tenantScopeEntityTypes = null;
+        private readonly TenantContext tenantContext;
+        private ImmutableList<IEntityType> tenantScopeEntityTypes = null;
 
-        protected string ConnectionString => _tenantContext.ConnectionString;
+        protected string ConnectionString => tenantContext.ConnectionString;
 
         public MultiTenantIdentityDbContext(TenantContext tenantContext, DbContextOptions options) : base(options)
         {
-            _tenantContext = tenantContext;
+            this.tenantContext = tenantContext;
         }
 
         public MultiTenantIdentityDbContext(string connectionString, DbContextOptions options) : base(options)
         {
-            _tenantContext = new TenantContext(null, null, null, connectionString, null, null);
+            tenantContext = new TenantContext(null, null, null, connectionString, null, null);
         }
 
         public TenantMismatchMode TenantMismatchMode { get; set; } = TenantMismatchMode.Throw;
@@ -42,14 +42,14 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
         {
             get
             {
-                if (_tenantScopeEntityTypes == null)
+                if (tenantScopeEntityTypes == null)
                 {
-                    _tenantScopeEntityTypes = Model.GetEntityTypes().
+                    tenantScopeEntityTypes = Model.GetEntityTypes().
                        Where(t => t.ClrType.GetCustomAttribute<MultiTenantAttribute>() != null).
                        ToImmutableList();
                 }
 
-                return _tenantScopeEntityTypes;
+                return tenantScopeEntityTypes;
             }
         }
 
@@ -57,7 +57,7 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
         {
             base.OnModelCreating(builder);
 
-            Shared.SetupModel(builder, _tenantContext);
+            Shared.SetupModel(builder, tenantContext);
         }
 
         public override int SaveChanges(bool acceptAllChangesOnSuccess)
@@ -65,7 +65,7 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
             if (ChangeTracker.AutoDetectChangesEnabled)
                 ChangeTracker.DetectChanges();
 
-            Shared.EnforceTenantId(_tenantContext, ChangeTracker, TenantNotSetMode, TenantMismatchMode);
+            Shared.EnforceTenantId(tenantContext, ChangeTracker, TenantNotSetMode, TenantMismatchMode);
 
             var origAutoDetectChange = ChangeTracker.AutoDetectChangesEnabled;
             ChangeTracker.AutoDetectChangesEnabled = false;
@@ -83,7 +83,7 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
             if (ChangeTracker.AutoDetectChangesEnabled)
                 ChangeTracker.DetectChanges();
 
-            Shared.EnforceTenantId(_tenantContext, ChangeTracker, TenantNotSetMode, TenantMismatchMode);
+            Shared.EnforceTenantId(tenantContext, ChangeTracker, TenantNotSetMode, TenantMismatchMode);
 
             var origAutoDetectChange = ChangeTracker.AutoDetectChangesEnabled;
             ChangeTracker.AutoDetectChangesEnabled = false;


### PR DESCRIPTION
Closes #7 

Added logging to the tenant resolver, strategies, and stores. Determined that adding logging to EF Core contexts was prohibitive because the internal logger isn't exposed--the standard EF Core logging is partially sufficient though because the query filters are shown as where clauses in the SQL statements.