### PR TITLE
Feature/89 reset tenant options cache

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,8 +1,9 @@
 # Per-Tenant Options
+Finbuckle.MultiTenant integrates with the standard ASP.NET Core [Options pattern](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options) and lets apps customize options distinctly for each tenant. The current tenant determines which options are retrieved via the `IOptions<TOptions>` (or derived) instance's `Value` property and `Get(string name)` method.
 
-Finbuckle.MultiTenant integrates with the standard ASP.NET Core [Options pattern](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options) and lets apps customize options distinctly for each tenant. A specialized variation of this is [per-tenant authentication](Authentication).
+ A specialized variation of this is [per-tenant authentication](Authentication).
 
-Per-tenant options will work with *any* options class when using `IOptions<TOptions>`, `IOptionsSnapshot<TOptions>`, or `IOptionsMonitor<TOptions>` for dependency injection or service resolution. This includes an app's own code *and* code internal to ASP.NET Core or other libraries that use the Options pattern. Use with caution: ASP.NET Core and other libraries may internally cache options or exhibit other unexpected behavior resulting in the wrong option values!
+Per-tenant options will work with *any* options class when using `IOptions<TOptions>`, `IOptionsSnapshot<TOptions>`, or `IOptionsMonitor<TOptions>` with dependency injection or service resolution. This includes an app's own code *and* code internal to ASP.NET Core or other libraries that use the Options pattern. Use with caution: ASP.NET Core and other libraries may internally cache options or exhibit other unexpected behavior resulting in the wrong option values!
 
 Consider a typical scenario in ASP.Net Core, starting with a simple class:
 
@@ -44,7 +45,6 @@ public MyController : Controller
 ```
 
 ## Customizing Options Per Tenant
-
 This sections assumes Finbuckle.MultiTenant is installed and configured. See [Getting Started](GettingStarted) for details.
 
 Call `WithPerTenantOptions<TOptions>` after `AddMultiTenant` in the `ConfigureServices` method:
@@ -75,3 +75,21 @@ public MyController : Controller
     }
 }
 ```
+
+## Named Options
+Both named and unnamed options are modified per-tenant. The same delegate passed to `WithPerTenantOptions<TOptions>` is applied to all options generated of type `TOptions` regardless of the option name.
+
+## Options Caching
+Internally ASP.NET Core caches options, and Finbuckle.MultiTenant extends this to cache options per tenant. Caching occurs when a `TOptions` instance is retreived via `Value` or `Get` on the injected `IOptions<TOptions>` (or derived) instance for the first time for a tenant.
+
+`IOptions<TOptions>` instances are always regenerated when injected so any caching only lasts as long as the specific instance.
+
+`IOptionsSnapshot<TOptions>` instances are generated once per HTTP request and caching will last throughout the entire request.
+
+`IOptionsMonitor<TOptions>` instances persist across HTTP requests and caching can persist for long periods of time.
+
+In some situations cached options may need to be cleared so that the options can be regenerated.
+
+When using per-tenant options via `IOptions<TOptions>` and `IOptionsSnapshot<TOptions>` the injected instance is of type `MultiTenantOptionsManager<TOptions>`. Casting to this type exposes the `Reset()` method which clears any internal caching for the current tenant and cause the options to be regenerated when next accessed via `Value` or `Get(string name)`.
+
+When using per-tenant options with `IOptionsMonitor<TOptions>` each injected instance uses a shared persistent cache. This cache can be retreived by injecting or resolving an instance of `IOptionsMonitorCache<TOptions>` which has a `Clear()` method that will clear the cache for the current tenant. Casting the `IOptionsMonitorCache<TOptions>` instance to `MultiTenantOptionsCache<TOptions>` exposes the `Clear(string tenantId)` and `ClearAll()` methods. `Clear(string tenantId)` clears cached options for a specific tenant (or the regular non per-tenant options if the parameter is empty or null). `ClearAll()` clears all cached options (including regular non per-tenant options).

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -1,6 +1,6 @@
 # MultiTenant Stores
 
-A multiTenant store is responsible for retrieving information about the tenant based on an identifier string produced by the [multiTenant strategy](Strategies). The retrieved information is then used to create a `TenantContext` object.
+A multiTenant store is responsible for retrieving information about the tenant based on an identifier string produced by the [MultiTenant strategy](Strategies). The retrieved information is then used to create a `TenantContext` object.
 
 Finbuckle.MultiTenant provides a simple thread safe in-memory implementation based on `ConcurrentDictionary<string, object>` which can be configured from an `appSettings.json` file. Custom stores can be created by implementing `IMultiTenantStore`.
 

--- a/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantOptionsManager.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantOptionsManager.cs
@@ -16,6 +16,7 @@
 //    https://github.com/aspnet/Options/blob/dev/src/Microsoft.Extensions.Options/OptionsManager.cs
 
 using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Finbuckle.MultiTenant.AspNetCore
@@ -51,8 +52,13 @@ namespace Finbuckle.MultiTenant.AspNetCore
         {
             name = name ?? Options.DefaultName;
 
-            // Store the options in our instance cache
+            // Store the options in our instance cache.
             return _cache.GetOrAdd(name, () => _factory.Create(name));
+        }
+
+        public void Reset()
+        {
+            _cache.Clear();
         }
     }
 }

--- a/src/Finbuckle.MultiTenant.Core/Stores/MultiTenantStoreWrapper.cs
+++ b/src/Finbuckle.MultiTenant.Core/Stores/MultiTenantStoreWrapper.cs
@@ -71,6 +71,11 @@ namespace Finbuckle.MultiTenant.Stores
 
         public async Task<TenantInfo> TryGetByIdentifierAsync(string identifier)
         {
+            if (identifier == null)
+            {
+                throw new ArgumentNullException(nameof(identifier));
+            }
+
             TenantInfo result = null;
 
             try

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/AssemblyInfo.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+//    Copyright 2018 Andrew White
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.Runtime.CompilerServices;
+[assembly:InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantOptionsFactoryShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantOptionsFactoryShould.cs
@@ -13,18 +13,10 @@
 //    limitations under the License.
 
 using System;
-using System.Collections;
-using System.Collections.Concurrent;
-using System.Reflection;
-using System.Threading.Tasks;
 using Finbuckle.MultiTenant;
 using Finbuckle.MultiTenant.AspNetCore;
-using Finbuckle.MultiTenant.Core;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
-using Moq;
 using Xunit;
 
 public class MultiTenantOptionsFactoryShould

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantOptionsManagerShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantOptionsManagerShould.cs
@@ -12,4 +12,67 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-// Note: MultiTenantOptionsManager is a trivial tweak of Microsoft's OptionsManager implementation.
+using System;
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.AspNetCore;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+public partial class MultiTenantOptionsManagerShould
+{
+    [Theory]
+    [InlineData("OptionName1")]
+    [InlineData("OptionName2")]
+    public void GetOptionByName(string optionName)
+    {
+        var mock = new Mock<IOptionsMonitorCache<Object>>();
+        mock.Setup(c => c.GetOrAdd(It.IsAny<string>(), It.IsAny<Func<Object>>())).Returns(new Object());
+
+        var manager = new MultiTenantOptionsManager<Object>(null, mock.Object);
+
+        manager.Get(optionName);
+
+        mock.Verify(c => c.GetOrAdd(It.Is<String>(p => p == optionName), It.IsAny<Func<Object>>()), Times.Once);
+    }
+
+    [Fact]
+    public void GetOptionByDefaultNameIfNameNull()
+    {
+        var mock = new Mock<IOptionsMonitorCache<Object>>();
+        mock.Setup(c => c.GetOrAdd(It.IsAny<string>(), It.IsAny<Func<Object>>())).Returns(new Object());
+
+        var manager = new MultiTenantOptionsManager<Object>(null, mock.Object);
+
+        manager.Get(null);
+
+        mock.Verify(c => c.GetOrAdd(It.Is<String>(p => p == Options.DefaultName), It.IsAny<Func<Object>>()), Times.Once);
+    }
+
+    [Fact]
+    public void GetOptionByDefaultNameIfGettingValueProp()
+    {
+        var mock = new Mock<IOptionsMonitorCache<Object>>();
+        mock.Setup(c => c.GetOrAdd(It.IsAny<string>(), It.IsAny<Func<Object>>())).Returns(new Object());
+
+        var manager = new MultiTenantOptionsManager<Object>(null, mock.Object);
+
+        var dummy = manager.Value;
+
+        mock.Verify(c => c.GetOrAdd(It.Is<String>(p => p == Options.DefaultName), It.IsAny<Func<Object>>()), Times.Once);
+    }
+
+    [Fact]
+    public void ClearCacheOnReset()
+    {
+        var mock = new Mock<TestOptionsCache<Object>>();
+        mock.Setup(i => i.Clear());
+
+        var manager = new MultiTenantOptionsManager<Object>(null, mock.Object);
+        manager.Reset();
+
+        mock.Verify(i => i.Clear(), Times.Once);
+    }
+}

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/TestOptionsCache.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/TestOptionsCache.cs
@@ -1,0 +1,40 @@
+//    Copyright 2018 Andrew White
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using Microsoft.Extensions.Options;
+
+/// Virtual methods so mocking can be used.
+internal class TestOptionsCache<TOptions> : IOptionsMonitorCache<TOptions> where TOptions : class
+{
+    public virtual void Clear()
+    {
+        throw new NotImplementedException();
+    }
+
+    public virtual TOptions GetOrAdd(string name, Func<TOptions> createOptions)
+    {
+        throw new NotImplementedException();
+    }
+
+    public virtual bool TryAdd(string name, TOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public virtual bool TryRemove(string name)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Refactored `MultiTenantOptionsCache` to a simpler internal implementation and add new methods.

This modifies the `Clear()` method on `MultiTenantOptionsCache` to only clear options for the current tenant **this is a breaking change** since the prior implementation cleared all options. It also adds a `Clear(string tenantId)` method to specify a tenant cache (or null/empty parameter to clear the normal non per-tenant cache) to clear and a `ClearAll()` method which clears **all** cached options.

Adds the `Reset` method to `MultiTenantOptionsManager` which calls `Clear()` on its internal cache.

Also includes unit tests and doc updates.