### PR TITLE
fix: clean out old references to TenantContext

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -32,13 +32,13 @@ public class Startup
 }
  ```
 
-Call `WithPerTenantOptions<CookieAuthenticationOptions>` after `AddMultiTenant` in the `ConfigureServices` method. The generic type parameter `CookieAuthenticationOptions` is the options type we are customizing. The method parameter is an `Action<TOptions, CookieAuthenticationOptions>` which will modify the options instance using information from the `TenantContext`. In this case we are appending the tenant's ID to the cookie name:
+Call `WithPerTenantOptions<CookieAuthenticationOptions>` after `AddMultiTenant` in the `ConfigureServices` method. The generic type parameter `CookieAuthenticationOptions` is the options type we are customizing. The method parameter is an `Action<TOptions, CookieAuthenticationOptions>` which will modify the options instance using information from the `TenantInfo`. In this case we are appending the tenant's ID to the cookie name:
 
 ```cs
 services.AddMultiTenant()...
-    .WithPerTenantOptions<CookieAuthenticationOptions>((o, tenantContext) =>
+    .WithPerTenantOptions<CookieAuthenticationOptions>((o, tenantInfo) =>
     {
-        o.Cookie.Name += tenantContext.Id;
+        o.Cookie.Name += tenantInfo.Id;
     });
 ```
 
@@ -62,14 +62,14 @@ These customizations apply to all authentication schemes using `AuthenticationCo
 
 In the `Startup` class, configure JWT Bearer authentication as usual. The ASP.NET Core documentation does not cover this, but the official code repository contains a [sample project](https://github.com/aspnet/Security/tree/master/samples/JwtBearerSample).
 
- Call `WithPerTenantOptions<JwtBearerOptions>` after `AddMultiTenant` in the `ConfigureServices` method. The generic type parameter `JwtBearerOptions` is the options type we are customizing. The method parameter is an `Action<TOptions, JwtBearerOptions>` which will modify the options instance using information from the `TenantContext`. In this case we are setting the authority from the `Items` collection in the `TenantContext`:
+ Call `WithPerTenantOptions<JwtBearerOptions>` after `AddMultiTenant` in the `ConfigureServices` method. The generic type parameter `JwtBearerOptions` is the options type we are customizing. The method parameter is an `Action<TOptions, JwtBearerOptions>` which will modify the options instance using information from the `TenantInfo`. In this case we are setting the authority from the `Items` collection in the `TenantInfo`:
 
 ```cs
 services.AddMultiTenant()...
-    .WithPerTenantOptions<JwtBearerOptions>((o, tenantContext) =>
+    .WithPerTenantOptions<JwtBearerOptions>((o, tenantInfo) =>
     {
         // Assume tenants are configured with an authority string to use here.
-        o.Authority = (string)tenantContext.Items["JwtAuthority"];
+        o.Authority = (string)tenantInfo.Items["JwtAuthority"];
     });
 ```
 The following properties should be especially considered for per-tenant customization:
@@ -87,18 +87,18 @@ See the [AuthenticationOptionsSamples](https://github.com/Finbuckle/Finbuckle.Mu
 
 In the `Startup` class, configure OpenID Connect authentication as usual. The ASP.NET Core documentation does not cover this, but the official code repository contains a [sample project](https://github.com/aspnet/Security/tree/master/samples/OpenIdConnectSample).
 
- Call `WithRemoteAuthentication` and `WithPerTenantOptions<OpenIdConnectOptions>` after `AddMultiTenant` in the `ConfigureServices` method. The generic type parameter `OpenIdConnectOptions` is the options type we are customizing. The method parameter is an `Action<TOptions, OpenIdConnectOptions>` which will modify the options instance using information from the `TenantContext`. In this case we are setting the authority from the `Items` collection in the `TenantContext`:
+ Call `WithRemoteAuthentication` and `WithPerTenantOptions<OpenIdConnectOptions>` after `AddMultiTenant` in the `ConfigureServices` method. The generic type parameter `OpenIdConnectOptions` is the options type we are customizing. The method parameter is an `Action<TOptions, OpenIdConnectOptions>` which will modify the options instance using information from the `TenantInfo`. In this case we are setting the authority from the `Items` collection in the `TenantInfo`:
 
 ```cs
 services.AddMultiTenant()...
     .WithRemoteAuthentication() // Important!
-    .WithPerTenantOptions<OpenIdConnectOptions>((o, tenantContext) =>
+    .WithPerTenantOptions<OpenIdConnectOptions>((o, tenantInfo) =>
     {
         // Assume tenants are configured with a client Id string to use here.
-        o.ClientId = (string)tenantContext.Items["ClientId"];
+        o.ClientId = (string)tenantInfo.Items["ClientId"];
 
         // Assume tenants are configured with an authority string to use here.
-        o.Authority = (string)tenantContext.Items["Authority"];
+        o.Authority = (string)tenantInfo.Items["Authority"];
     });
 ```
 The following properties should be especially considered for per-tenant customization:

--- a/docs/Identity.md
+++ b/docs/Identity.md
@@ -12,13 +12,13 @@ Add the `Finbuckle.MultiTenant.EntityFrameworkCore` and package to the project:
 dotnet add package Finbuckle.MultiTenant.EntityFrameworkCore
 ```
 
-Derive the database context from `MultiTenantIdentityDbContext<TUser>` instead of `IdentityDbContext<TUser>`. Make sure to forward the `TenantContext` and `DbContextOptions<T>` into the base constructor:
+Derive the database context from `MultiTenantIdentityDbContext<TUser>` instead of `IdentityDbContext<TUser>`. Make sure to forward the `TenantInfo` and `DbContextOptions<T>` into the base constructor:
 
 ```
 public class MyIdentityDbContext : MultiTenantIdentityDbContext<appUser>
 {
-    public MyIdentityDbContext(TenantContext tenantContext, DbContextOptions<MyIdentityDbContext> options) :
-        base(tenantContext, options)
+    public MyIdentityDbContext(TenantInfo tenantInfo, DbContextOptions<MyIdentityDbContext> options) :
+        base(tenantInfo, options)
     { }
     ...
 }

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -51,14 +51,14 @@ Call `WithPerTenantOptions<TOptions>` after `AddMultiTenant` in the `ConfigureSe
 
 ```cs
 services.AddMultiTenant()...
-    .WithPerTenantOptions<MyOptions>((options, tenantContext) =>
+    .WithPerTenantOptions<MyOptions>((options, tenantInfo) =>
     {
-        options.MyOption1 = (int)tenantContext.Items["someValue"];
-        options.MyOption2 = (int)tenantContext.Items["anotherValue"];
+        options.MyOption1 = (int)tenantInfo.Items["someValue"];
+        options.MyOption2 = (int)tenantInfo.Items["anotherValue"];
     });
 ```
 
-The type parameter `TOptions` is the options type being customized per-tenant. The method parameter is an `Action<TOptions, TenantContext>`. This action will modify the options instance *after* the options normal configuration and *before* its [post configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?#ipostconfigureoptions).
+The type parameter `TOptions` is the options type being customized per-tenant. The method parameter is an `Action<TOptions, TenantInfo>`. This action will modify the options instance *after* the options normal configuration and *before* its [post configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?#ipostconfigureoptions).
 
 
 Now with the same controller example from above, the option values will be specific to the current tenant:

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -1,12 +1,12 @@
 # MultiTenant Stores
 
-A multiTenant store is responsible for retrieving information about the tenant based on an identifier string produced by the [MultiTenant strategy](Strategies). The retrieved information is then used to create a `TenantContext` object.
+A multiTenant store is responsible for retrieving information about the tenant based on an identifier string produced by the [MultiTenant strategy](Strategies). The retrieved information is then used to create a `TenantInfo` object.
 
 Finbuckle.MultiTenant provides a simple thread safe in-memory implementation based on `ConcurrentDictionary<string, object>` which can be configured from an `appSettings.json` file. Custom stores can be created by implementing `IMultiTenantStore`.
 
 ## Accessing the Store at Runtime
 
-The multitenant store can be accessed at runtime to add, remote, or retreieve a `TenantContext` in addition to any startup configuration the store implementation may offer (such as the `appSettings.json` configuration supported by the In-Memory Store).
+The multitenant store can be accessed at runtime to add, remote, or retreieve a `TenantInfo` in addition to any startup configuration the store implementation may offer (such as the `appSettings.json` configuration supported by the In-Memory Store).
 
 The multitenant store is registered as a singleton in the app's service collection. Access it via dependecy injection by including an `IMultiTenantStore` constructor parameter, action method parameter marked with `[FromService]`, or the `HttpContext.RequestServices` service provider instance.
 
@@ -24,7 +24,7 @@ services.AddMultiTenant().WithStore( sp => return new MyStore());
 ```
 
 ## In-Memory Store
-Uses a `ConcurrentDictionary<string, TenantContext>` as the underlying store. By default the tenant identifier matching is case insensitive. This can be overridden by passing false to the constructor's `ignoreCase` paramater.
+Uses a `ConcurrentDictionary<string, TenantInfo>` as the underlying store. By default the tenant identifier matching is case insensitive. This can be overridden by passing false to the constructor's `ignoreCase` paramater.
 
 If using with `Finbuckle.MultiTenant.AspNetCore`, configure by calling `WithInMemoryStore` after `AddMultiTenant` in the `ConfigureServices` method of the `Startup` class.
 

--- a/docs/Strategies.md
+++ b/docs/Strategies.md
@@ -1,13 +1,13 @@
 # MultiTenant Strategies
 
-A multitenant strategy is responsible for defining how the tenant is determined. It ultimately produces an identifier string which is used to create a `TenantContext` object with information from the [MultiTenant store](Stores).
+A multitenant strategy is responsible for defining how the tenant is determined. It ultimately produces an identifier string which is used to create a `TenantInfo` object with information from the [MultiTenant store](Stores).
 
 Finbuckle.MultiTenant supports several "out-of-the-box" strategies for resolving the tenant. Custom strategies can be created by implementing `IMultiTenantStrategy`. Internally strategies are registered as singleton services.
 
 ## IMultiTenantStrategy
 All multitenant strategies derive from `IMultiTenantStrategy` and must implement the `GetIdentifier` method. 
 
-If an identifier can't be determined, `GetIdentifierAsync` should return null which will ultimately result in a null `TenantContext`.
+If an identifier can't be determined, `GetIdentifierAsync` should return null which will ultimately result in a null `TenantInfo`.
 
 Configure a custom implementation of `IMultiTenantStrategy` by calling `WithStrategy<T>` or `WithStrategy` after `AddMultiTenant` in the `ConfigureServices` method of the `Startup` class. The templated version will use dependency injection and any passed parameters to construct the implementation instance. The non-templated version accepts a `Func<IServiceProvider, IMultiTenantStrategy>` factory method for even more customization.
 
@@ -29,7 +29,7 @@ services.AddMultiTenant().WithStaticStrategy("MyTenant")...
 ```
 
 ## Base Path Strategy 
-Uses the base (i.e. first) path segment to determine the tenant. For example, a request to "https://www.example.com/contoso" would use "contoso" as the identifier when retreiving the `TenantContext`.
+Uses the base (i.e. first) path segment to determine the tenant. For example, a request to "https://www.example.com/contoso" would use "contoso" as the identifier when retreiving the `TenantInfo`.
 
 Configure by calling `WithBasePathStrategy` after `AddMultiTenant` in the `ConfigureServices` method of the `Startup` class:
 
@@ -81,7 +81,7 @@ public class Startup
 ``` 
 
 ## Host Strategy
-Uses request's host value to determine the tenant. By default the first host segment is used. For example, a request to "https://contoso.example.com/abc123" would use "contoso" as the identifier when retrieving the `TenantContext`. This strategy is included in `Finbuckle.MultiTenant.AspNetCore`. This strategy can be difficult to use in a development environment. Make sure the development system is configured properly to allow subdomains on `localhost`.
+Uses request's host value to determine the tenant. By default the first host segment is used. For example, a request to "https://contoso.example.com/abc123" would use "contoso" as the identifier when retrieving the `TenantInfo`. This strategy is included in `Finbuckle.MultiTenant.AspNetCore`. This strategy can be difficult to use in a development environment. Make sure the development system is configured properly to allow subdomains on `localhost`.
 
 The host strategy uses a template string which defines how the strategy will find the tenant identifier. The pattern specifies the location for the tenant identifer using "\_\_tenant\_\_" and can contain other valid domain characters. It can also use '?' and '\*' characters to represent one or "zero or more" segments. For example:
   - `__tenant__.*` is the default if no pattern is provided and selects the first domain segment for the tenant identifier.

--- a/samples/AuthenticationOptionsSample/Startup.cs
+++ b/samples/AuthenticationOptionsSample/Startup.cs
@@ -66,22 +66,22 @@ namespace AuthenticationOptionsSample
                 WithInMemoryStore(Configuration.GetSection("Finbuckle:MultiTenant:InMemoryStore")).
                 WithRouteStrategy(ConfigRoutes).
                 WithRemoteAuthentication(). // Important!
-                WithPerTenantOptions<AuthenticationOptions>((options, tenantContext) =>
+                WithPerTenantOptions<AuthenticationOptions>((options, tenantInfo) =>
                 {
                     // Allow each tenant to have a different default challenge scheme.
-                    if (tenantContext.Items.TryGetValue("ChallengeScheme", out object challengeScheme))
+                    if (tenantInfo.Items.TryGetValue("ChallengeScheme", out object challengeScheme))
                     {
                         options.DefaultChallengeScheme = (string)challengeScheme;
                     }
                 }).
-                WithPerTenantOptions<CookieAuthenticationOptions>((options, tenantContext) =>
+                WithPerTenantOptions<CookieAuthenticationOptions>((options, tenantInfo) =>
                 {
                     // Set a unique cookie name for this tenant.
-                    options.Cookie.Name = tenantContext.Id + "-cookie";
+                    options.Cookie.Name = tenantInfo.Id + "-cookie";
 
                     // Note the paths set take our routing strategy into account.
-                    options.LoginPath = "/" + tenantContext.Identifier + "/Home/Login";
-                    options.Cookie.Path = "/" + tenantContext.Identifier;
+                    options.LoginPath = "/" + tenantInfo.Identifier + "/Home/Login";
+                    options.Cookie.Path = "/" + tenantInfo.Identifier;
                 });
         }
 

--- a/samples/IdentityDataIsolationSample/Data/ApplicationDbContext.cs
+++ b/samples/IdentityDataIsolationSample/Data/ApplicationDbContext.cs
@@ -9,8 +9,8 @@ namespace IdentityDataIsolationSample.Data
 {
     public class ApplicationDbContext : MultiTenantIdentityDbContext
     {
-        public ApplicationDbContext(TenantInfo tenantContext, DbContextOptions<ApplicationDbContext> options)
-            : base(tenantContext, options)
+        public ApplicationDbContext(TenantInfo tenantInfo, DbContextOptions<ApplicationDbContext> options)
+            : base(tenantInfo, options)
         {
         }
 

--- a/samples/SharedLoginSample/Data/ApplicationDbContext.cs
+++ b/samples/SharedLoginSample/Data/ApplicationDbContext.cs
@@ -9,8 +9,8 @@ namespace SharedLoginSample.Data
 {
     public class ApplicationDbContext : MultiTenantIdentityDbContext
     {
-        public ApplicationDbContext(TenantInfo tenantContext, DbContextOptions<ApplicationDbContext> options)
-            : base(tenantContext, options)
+        public ApplicationDbContext(TenantInfo tenantInfo, DbContextOptions<ApplicationDbContext> options)
+            : base(tenantInfo, options)
         {
         }
 

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -25,16 +25,16 @@ namespace Finbuckle.MultiTenant
     public static class HttpContextExtensions
     {
         /// <summary>
-        /// Returns the current TenantContext or null if there is none.
+        /// Returns the current MultiTenantContext or null if there is none.
         /// </summary>
         /// <param name="context">The HttpContext<c/> instance the extension method applies to.</param>
-        /// <returns>The TenantContext instance for the current tenant.</returns>
+        /// <returns>The MultiTenantContext instance for the current tenant.</returns>
         public static MultiTenantContext GetMultiTenantContext(this HttpContext context)
         {
-            object tenantContext = null;
-            context.Items.TryGetValue(Constants.HttpContextMultiTenantContext, out tenantContext);
+            object multiTenantContext = null;
+            context.Items.TryGetValue(Constants.HttpContextMultiTenantContext, out multiTenantContext);
             
-            return (MultiTenantContext)tenantContext;
+            return (MultiTenantContext)multiTenantContext;
         }
     }
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantOptionsCache.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantOptionsCache.cs
@@ -35,9 +35,9 @@ namespace Finbuckle.MultiTenant.AspNetCore
 
         private readonly ConcurrentDictionary<string, IOptionsMonitorCache<TOptions>> map = new ConcurrentDictionary<string, IOptionsMonitorCache<TOptions>>();
 
-        public MultiTenantOptionsCache(IMultiTenantContextAccessor tenantContextAccessor)
+        public MultiTenantOptionsCache(IMultiTenantContextAccessor multiTenantContextAccessor)
         {
-            this.multiTenantContextAccessor = tenantContextAccessor ?? throw new ArgumentNullException(nameof(tenantContextAccessor));
+            this.multiTenantContextAccessor = multiTenantContextAccessor ?? throw new ArgumentNullException(nameof(multiTenantContextAccessor));
         }
 
         /// <summary>

--- a/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantOptionsFactory.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantOptionsFactory.cs
@@ -38,11 +38,11 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// </summary>
         /// <param name="setups">The configuration actions to run.</param>
         /// <param name="postConfigures">The initialization actions to run.</param>
-        public MultiTenantOptionsFactory(IEnumerable<IConfigureOptions<TOptions>> setups, IEnumerable<IPostConfigureOptions<TOptions>> postConfigures, Action<TOptions, TenantInfo> tenantConfig, IMultiTenantContextAccessor tenantContextAccessor)
+        public MultiTenantOptionsFactory(IEnumerable<IConfigureOptions<TOptions>> setups, IEnumerable<IPostConfigureOptions<TOptions>> postConfigures, Action<TOptions, TenantInfo> tenantConfig, IMultiTenantContextAccessor multiTenantContextAccessor)
         {
             _setups = setups;
             this.tenantConfig = tenantConfig;
-            this.multiTenantContextAccessor = tenantContextAccessor;
+            this.multiTenantContextAccessor = multiTenantContextAccessor;
             _postConfigures = postConfigures;
         }
 

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/TestMultiTenantContextAccessor.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/TestMultiTenantContextAccessor.cs
@@ -18,12 +18,12 @@ using Finbuckle.MultiTenant.Core;
 
 public class TestMultiTenantContextAccessor : IMultiTenantContextAccessor
 {
-    private readonly MultiTenantContext tenantContext;
+    private readonly MultiTenantContext multiTenantContext;
 
-    public TestMultiTenantContextAccessor(MultiTenantContext tenantContext)
+    public TestMultiTenantContextAccessor(MultiTenantContext multiTenantContext)
     {
-        this.tenantContext = tenantContext;
+        this.multiTenantContext = multiTenantContext;
     }
 
-    public MultiTenantContext MultiTenantContext => tenantContext;
+    public MultiTenantContext MultiTenantContext => multiTenantContext;
 }

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/TestEntitities.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/TestEntitities.cs
@@ -129,52 +129,52 @@ public class ThingWithHigherTenantIdMaxLength
 
 public class TestIdentityDbContext : MultiTenantIdentityDbContext
 {
-    public TestIdentityDbContext(TenantInfo tenantContext)
-        : base(tenantContext)
+    public TestIdentityDbContext(TenantInfo tenantInfo)
+        : base(tenantInfo)
     {
     }
 
-    public TestIdentityDbContext(TenantInfo tenantContext, DbContextOptions options)
-        : base(tenantContext, options)
+    public TestIdentityDbContext(TenantInfo tenantInfo, DbContextOptions options)
+        : base(tenantInfo, options)
     {
     }
 }
 
 public class TestIdentityDbContext_TUser : MultiTenantIdentityDbContext<MultiTenantIdentityUser>
 {
-    public TestIdentityDbContext_TUser(TenantInfo tenantContext)
-        : base(tenantContext)
+    public TestIdentityDbContext_TUser(TenantInfo tenantInfo)
+        : base(tenantInfo)
     {
     }
 
-    public TestIdentityDbContext_TUser(TenantInfo tenantContext, DbContextOptions options)
-        : base(tenantContext, options)
+    public TestIdentityDbContext_TUser(TenantInfo tenantInfo, DbContextOptions options)
+        : base(tenantInfo, options)
     {
     }
 }
 
 public class TestIdentityDbContext_TUser_TRole_String : MultiTenantIdentityDbContext<MultiTenantIdentityUser, MultiTenantIdentityRole, string>
 {
-    public TestIdentityDbContext_TUser_TRole_String(TenantInfo tenantContext)
-        : base(tenantContext)
+    public TestIdentityDbContext_TUser_TRole_String(TenantInfo tenantInfo)
+        : base(tenantInfo)
     {
     }
 
-    public TestIdentityDbContext_TUser_TRole_String(TenantInfo tenantContext, DbContextOptions options)
-        : base(tenantContext, options)
+    public TestIdentityDbContext_TUser_TRole_String(TenantInfo tenantInfo, DbContextOptions options)
+        : base(tenantInfo, options)
     {
     }
 }
 
 public class TestIdentityDbContext_AllGenericParams : MultiTenantIdentityDbContext<MultiTenantIdentityUser, MultiTenantIdentityRole, string, MultiTenantIdentityUserClaim<string>, MultiTenantIdentityUserRole<string>, MultiTenantIdentityUserLogin<string>, MultiTenantIdentityRoleClaim<string>, MultiTenantIdentityUserToken<string>>
 {
-    public TestIdentityDbContext_AllGenericParams(TenantInfo tenantContext)
-        : base(tenantContext)
+    public TestIdentityDbContext_AllGenericParams(TenantInfo tenantInfo)
+        : base(tenantInfo)
     {
     }
 
-    public TestIdentityDbContext_AllGenericParams(TenantInfo tenantContext, DbContextOptions options)
-        : base(tenantContext, options)
+    public TestIdentityDbContext_AllGenericParams(TenantInfo tenantInfo, DbContextOptions options)
+        : base(tenantInfo, options)
     {
     }
 }


### PR DESCRIPTION
Cleaned out old references to `TenantContext` in variable names and in docs. Usually change to `TenantInfo` or similar.