### PR TITLE
Set TenantInfo implementation and tests.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "licenser.author": "Andrew White",
     "licenser.license": "AL2",
-    "licenser.projectName": "Finbuckle.MultiTenant"
+    "licenser.projectName": "Finbuckle.MultiTenant",
+    "cSpell.enabled": false
 }

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -1,6 +1,6 @@
 # Per-Tenant Authentication
 
-Finbuckle.MultiTenant's support for [per-tenant options](Options) is enhanced specifically to let apps customize ASP.NET Core 2.0+ authentication options. For example, `CookieAuthenticationOptions` or `OpenIdConnectOptions` can be configured separately per tenant to provide unique cookie names or OpenID Connect providers. This prevents sessions under a tenant from spilling over to another tenant if the same user-agent is used to access both. This design also prevents the need for a separate authentication schemes for every tenant.
+Finbuckle.MultiTenant's support for [per-tenant options](Options) is enhanced specifically to let apps customize ASP.NET Core 2.1+ authentication options. For example, `CookieAuthenticationOptions` or `OpenIdConnectOptions` can be configured separately per tenant to provide unique cookie names or OpenID Connect providers. This prevents sessions under a tenant from spilling over to another tenant if the same user-agent is used to access both. This design also prevents the need for a separate authentication schemes for every tenant.
 
 This functionality works by giving each tenant an opportunity to customize options as they are first created, and caching the resulting options for each tenant. The options are only created once an app initiates an authentication related activity such as when `UseAuthentication` is called in the app pipeline.
 
@@ -10,11 +10,30 @@ The sections below assume Finbuckle.MultiTenant is installed and configured. See
 
 ## General Authentication Options
 
+General authentication options such as `DefaultScheme` and `DefaultChallenge` schemes can be configured per-tenant. This can be useful if some tenants prefer local sign-in and other prefer to use OpenID Connect. See the [AuthenticationOptionsSamples](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/AuthenticationOptionsSample) for a complete example.
+
+```cs
+services.AddMultiTenant().
+    WithStore(...).
+    WithStrategy(...).
+    WithRemoteAuthentication().
+    WithPerTenantOptions<AuthenticationOptions>((options, tenantInfo) =>
+    {
+        // Allow each tenant to have a different default challenge scheme.
+        // Here the scheme is assumed to be configured in the TenantInfo's 
+        // Items property.
+        if (tenantInfo.Items.TryGetValue("ChallengeScheme", out object challengeScheme))
+        {
+            options.DefaultChallengeScheme = (string)challengeScheme;
+        }
+    })...
+```
+
 ## Cookie Authentication Options
 
 See the [AuthenticationOptionsSamples](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/AuthenticationOptionsSample) in the Finbuckle.MultiTenant GitHub repository for a complete demonstration of per-tenant cookie options.
 
-In the `Startup` class, [configure cookie authentication as usual](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/cookie) for ASP.NET Core 2.0+:
+In the `Startup` class, [configure cookie authentication as usual](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/cookie) for ASP.NET Core 2.1+:
 
 ```cs
 public class Startup
@@ -42,7 +61,7 @@ services.AddMultiTenant()...
     });
 ```
 
-This will cause the ASP.NET Core 2.0+ authentication middleware to only process the cookie for the specific tenant. All of the other cookie options are set normally, but each tenant's version of the options will be customized accordingly.
+This will cause the ASP.NET Core 2.1+ authentication middleware to only process the cookie for the specific tenant. All of the other cookie options are set normally, but each tenant's version of the options will be customized accordingly.
 
 Depending on the [multitenant strategy](Strategies) being used, the following properties should be especially considered for per-tenant customization:
 
@@ -116,4 +135,4 @@ These customizations apply to all authentication schemes using `OpenIdConnectOpt
 
 See the [AuthenticationOptionsSamples](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/AuthenticationOptionsSample) in the Finbuckle.MultiTenant GitHub repository for a complete demonstration of per-tenant Facebook authentication options.
 
-Finbuckle.MultiTenant per-tenant options work with most of the [built-in ASP.NET Core 2.0+ authentication methods](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/), with the exception of Twitter which is not derived from the internal OAuth-based authentication handler. Social login and other external providers require that `WithRemoteAuthentication` be called after `AddMultiTenant` in the `ConfigureServices` method. Each authentication method has its own options class, but the general approach is the same.
+Finbuckle.MultiTenant per-tenant options work with most of the [built-in ASP.NET Core 2.1+ authentication methods](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/), with the exception of Twitter which is not derived from the internal OAuth-based authentication handler. Social login and other external providers require that `WithRemoteAuthentication` be called after `AddMultiTenant` in the `ConfigureServices` method. Each authentication method has its own options class, but the general approach is the same.

--- a/docs/ConfigurationAndUsage.md
+++ b/docs/ConfigurationAndUsage.md
@@ -1,0 +1,66 @@
+# Configuration and Usage
+
+## Configuration
+Finbuckle.MultiTenant uses the standard builder pattern for its configuration in the `ConfigureServices` method of the app's `Startup` class. Order doesn't matter, but both a multitenant store and a multitenant strategy are required.
+
+```cs
+public void ConfigureServices(IServiceCollection services)
+{
+    ...
+    services.AddMultiTenant().WithStore(...).WithStrategy(...)...
+    ...
+}
+```
+
+### AddMultiTenant
+`AddMultiTenant` is an extension method on `IServiceCollection` which registers the basic dependencies needed by the library. It returns a `MultiTenantBuilder` instance on which the methods below can be called for further configuration. Each of these methods returns the same `MultiTenantBuilder` instance allowing for chaining method calls.
+
+### WithStore Variants
+Adds and configures an IMultiTenantStore to the application. Only a the last store configured will be used. See [MultiTenant Stores](Stores) for more information on each type.
+
+- WithStore&lt;TStore&gt;
+- WithEFCoreStore
+- WithInMemoryStore
+
+### WithStrategy Variants
+Adds and configures an IMultiTenantStore to the application. Only a the last strategy configured will be used with the exception of the fallback strategy. See [MultiTenant Strategies](Strategies) for more information on each type.
+
+- WithStrategy&lt;TStrategy&gt;
+- WithBasePathStrategy
+- WithDelegateStrategy
+- WithFallbackStrategy
+- WithHostStrategy
+- WithRouteStrategy
+- WithStaticStrategy
+
+### WithPerTenantOptions<TOptions>
+Adds per-tenant configuration for an options class. See [Per-Tenant Options](Options) for more details.
+
+### WithRemoteAuthentication
+Configures support for multitenant OAuth and OpenIdConnect. See the relevant sections in [Per-Tenant Authentication](Authentication) for more details.
+
+## Usage
+Most of the capability enabled by Finbuckle.MultiTenant is utilized through its middleware and use the [Options pattern with per-tenant options](Options). The middleware will resolve the app's current tenant on each request using the configured strategies and stores, and the per-tenant options will alter the app's behavior as dependency injection passes the options to app components.
+
+In addition, there are a few methods available for directly accessing and settings the tenant information if needed.
+
+### UseMultiTenant
+Configures the middleware handling tenant resolution via the multitenant strategy and the multitenant store. `UseMultiTenant` should be called before `UseAuthentication` and `UseMvc` in the `Configure` method of the app's `Startup` class. Additionally, if any other middleware uses per-tenant options then that middleware should come after `UseMultiTenant`.
+
+```cs
+public void Configure(IApplicationBuilder app)
+{
+    ...
+    app.UseMultiTenant(); // Before UseAuthentication and UseMvc!
+    ...
+    app.UseAuthentication();
+    ...
+    app.UseMvc();
+}
+```
+
+### HttpContext.GetMultiTenantContext
+This extension method returns the `MultiTenantContext` instance for the current request. If there is no current tenant the `TenantInfo` property will be null;
+
+### HttpContext.TrySetTenantInfo
+Tries to set the current tenant to the provided `TenantInfo`. Returns true if successful. Optionally it can also reset the service provider scope so that any services already resolved will be resolved again under the current tenant when needed. Setting the `TenantInfo` with this method sets both the `StoreInfo` and `StrategyInfo` properties on the `MultiTenantContext` to null.

--- a/docs/ConfigurationAndUsage.md
+++ b/docs/ConfigurationAndUsage.md
@@ -60,7 +60,32 @@ public void Configure(IApplicationBuilder app)
 ```
 
 ### GetMultiTenantContext
-Extension method of `HttpContext` that returns the `MultiTenantContext` instance for the current request. If there is no current tenant the `TenantInfo` property will be null;
+Extension method of `HttpContext` that returns the `MultiTenantContext` instance for the current request. If there is no current tenant the `TenantInfo` property will be null.
+
+```cs
+var tenantInfo = HttpContext.GetMultiTenantContext().TenantInfo;
+
+if(tenantInfo != null)
+{
+    var tenantId = tenantInfo.Id;
+    var identifier = tenantInfo.Identifier;
+    var name = tenantInfo.Name;
+    var something = tenantInfo.Items["something"];
+}
+```
 
 ### TrySetTenantInfo
-Extension method of `HttpContext` that tries to set the current tenant to the provided `TenantInfo`. Returns true if successful. Optionally it can also reset the service provider scope so that any services already resolved will be resolved again under the current tenant when needed. Setting the `TenantInfo` with this method sets both the `StoreInfo` and `StrategyInfo` properties on the `MultiTenantContext` to null.
+Extension method of `HttpContext` that tries to set the current tenant to the provided `TenantInfo`. Returns true if successful. Optionally it can also reset the service provider scope so that any scoped services already resolved will be resolved again under the current tenant when needed. This has no effect on singleton or transient services. Setting the `TenantInfo` with this method sets both the `StoreInfo` and `StrategyInfo` properties on the `MultiTenantContext` to null.
+
+```cs
+var newTenantInfo = new TenantInfo(...);
+
+if(HttpContext.TrySetTenantInfo(newTenantInfo, resetServiceProvider: true))
+{
+    // This will be the new tenant.
+    var tenant = HttpContext.GetMultiTenantContext().TenantIno;
+
+    // This will regenerate the options class.
+    var optionsProvider = HttpContext.RequestServices.GetService<IOptions<MyScopedOptions>>();
+}
+```

--- a/docs/ConfigurationAndUsage.md
+++ b/docs/ConfigurationAndUsage.md
@@ -16,14 +16,14 @@ public void ConfigureServices(IServiceCollection services)
 `AddMultiTenant` is an extension method on `IServiceCollection` which registers the basic dependencies needed by the library. It returns a `MultiTenantBuilder` instance on which the methods below can be called for further configuration. Each of these methods returns the same `MultiTenantBuilder` instance allowing for chaining method calls.
 
 ### WithStore Variants
-Adds and configures an IMultiTenantStore to the application. Only a the last store configured will be used. See [MultiTenant Stores](Stores) for more information on each type.
+Adds and configures an IMultiTenantStore to the application. Only the last store configured will be used. See [MultiTenant Stores](Stores) for more information on each type.
 
 - WithStore&lt;TStore&gt;
 - WithEFCoreStore
 - WithInMemoryStore
 
 ### WithStrategy Variants
-Adds and configures an IMultiTenantStore to the application. Only a the last strategy configured will be used with the exception of the fallback strategy. See [MultiTenant Strategies](Strategies) for more information on each type.
+Adds and configures an IMultiTenantStore to the application. Only the last strategy configured will be used with the exception of the fallback strategy. See [MultiTenant Strategies](Strategies) for more information on each type.
 
 - WithStrategy&lt;TStrategy&gt;
 - WithBasePathStrategy
@@ -59,8 +59,8 @@ public void Configure(IApplicationBuilder app)
 }
 ```
 
-### HttpContext.GetMultiTenantContext
-This extension method returns the `MultiTenantContext` instance for the current request. If there is no current tenant the `TenantInfo` property will be null;
+### GetMultiTenantContext
+Extension method of `HttpContext` that returns the `MultiTenantContext` instance for the current request. If there is no current tenant the `TenantInfo` property will be null;
 
-### HttpContext.TrySetTenantInfo
-Tries to set the current tenant to the provided `TenantInfo`. Returns true if successful. Optionally it can also reset the service provider scope so that any services already resolved will be resolved again under the current tenant when needed. Setting the `TenantInfo` with this method sets both the `StoreInfo` and `StrategyInfo` properties on the `MultiTenantContext` to null.
+### TrySetTenantInfo
+Extension method of `HttpContext` that tries to set the current tenant to the provided `TenantInfo`. Returns true if successful. Optionally it can also reset the service provider scope so that any services already resolved will be resolved again under the current tenant when needed. Setting the `TenantInfo` with this method sets both the `StoreInfo` and `StrategyInfo` properties on the `MultiTenantContext` to null.

--- a/docs/CoreConcepts.md
+++ b/docs/CoreConcepts.md
@@ -1,6 +1,6 @@
 # Core Concepts
 
-The framework uses standard ASP.Net Core conventions and most of the internal details are abstracted away from app code. However, there are a few important specifics to be aware of.
+The library uses standard ASP.Net Core conventions and most of the internal details are abstracted away from app code. However, there are a few important specifics to be aware of.
 
 ## MultiTenantContext
 Contains information about a the current multitenant environment. The `MultiTenantContext` for the current request can be obtained by calling the `GetMultiTenantContext()` method on the `HttpContext` object.
@@ -8,21 +8,21 @@ Contains information about a the current multitenant environment. The `MultiTena
 * Includes `TenantInfo`, `StrategyInfo`, and `StoreInfo` properties with details on the current tenant, how it was determined, and where its information came from.
 
 ## TenantInfo
-Contains information about a tenant. Usually an app will get the current `TenantInfo` object from the `MultiTenantContext` instance for that request. Instances of `TenantInfo` can alse be passed to multitenant stores for adding, removing, updating the store.
+Contains information about a tenant. Usually an app will get the current `TenantInfo` object from the `MultiTenantContext` instance for that request. Instances of `TenantInfo` can also be passed to multitenant stores for adding, removing, updating the store.
 
 Includes properties for `Id`, `Identifier`, `Name`, `ConnectionString`, and `Items`.
 
-* `Id` is a unique id for a tenant in your app and should never change.
-* `Identifier` is the value used to actually resolve a tenant and should have a syntax compatibile for the app (i.e. no crazy symbols in a web app where the identifier will be part of the URL). Unlike `Id`, `Identifier` can be changed if necessary.
+* `Id` is a unique id for a tenant in the app and should never change.
+* `Identifier` is the value used to actually resolve a tenant and should have a syntax compatible for the app (i.e. no crazy symbols in a web app where the identifier will be part of the URL). Unlike `Id`, `Identifier` can be changed if necessary.
 * `Name` is a display name for the tenant.
-* `ConnectionString` is a connection string that should be used for database operations for this tenant. It might conntect to a shared database or a dedicated database for the single tenant.
+* `ConnectionString` is a connection string that should be used for database operations for this tenant. It might connect to a shared database or a dedicated database for the single tenant.
 * The `Items` object is a general purpose `IDictionary<string, object>` container.
 
 ## StrategyInfo
-Contains information about the multitenant strategy used to create the `MultiTenantContext`. Accessable as a property on `MultiTenantContext`.
+Contains information about the multitenant strategy used to create the `MultiTenantContext`. Accessible as a property on `MultiTenantContext`.
 
 ## StoreInfo
-Contains information about the multitenant store used to create the `MultiTenantContext`. Accessable as a property on `MultiTenantContext`.
+Contains information about the multitenant store used to create the `MultiTenantContext`. Accessible as a property on `MultiTenantContext`.
 
 ## MultiTenant Strategies
 Responsible for determining and returning a tenant identifier string for the current request.

--- a/docs/EFCore.md
+++ b/docs/EFCore.md
@@ -15,7 +15,7 @@ dotnet add package Finbuckle.MultiTenant.EntityFrameworkCore
 
 Derive the database context from `MultiTenantDbContext`. Make sure to forward the `TenantInfo` and `DbContextOptions<T>` into the base constructor:
 
-```
+```cs
 public class BloggingDbContext : MultiTenantDbContext
 {
     public BloggingDbContext(TenantInfo tenantInfo, DbContextOptions<BloggingDbContext> options) :
@@ -30,7 +30,7 @@ There is also a base constructor which takes a connection string parameter inste
 
 If using multiple databases and relying on the `ConnectionString` property of the `TenantInfo` then the database context will need to configures itself in its `OnConfiguring` method using its inherited `ConnectionString` property. This property returns the connection string for the current `TenantInfo`:
 
-```
+```cs
 public class BloggingDbContext : MultiTenantDbContext
 {
    ...
@@ -48,7 +48,7 @@ public class BloggingDbContext : MultiTenantDbContext
 
 Finally, add the `[MultiTenant]` attribute to entity classes which should be isolated per tenant. If an entity is common to all tenants, then do not apply the attribute:
 
-```
+```cs
 [MultiTenant]
 public class Blog
 {
@@ -68,9 +68,9 @@ When the context is initialized, a shadow property named `TenantId` is added to 
 
 If using ASP.NET Core [configure Finbuckle.MultiTenant](GettingStarted) as desired.
 
-Next, add the desired services in the `ConfigureServices` method of your `Startup` class. If using dependency injection for the database context make sure to call `AddDbContext<T>`. Dependency injection will also inject the `TenantInfo` into the database context constructor:
+Next, add the desired services in the `ConfigureServices` method of the app's `Startup` class. If using dependency injection for the database context make sure to call `AddDbContext<T>`. Dependency injection will also inject the `TenantInfo` into the database context constructor:
 
-```
+```cs
 public class Startup
 {
     ...
@@ -93,7 +93,7 @@ Do not use any of the configuration methods that sets a database provider or con
 ## Adding Data
 Added entities are automatically associated with the current `TenantInfo`. If an entity is associated with a different `TenantInfo` then a `MultiTenantException` is thrown in `SaveChanges` or `SaveChangesAsync`:
 
-```
+```cs
 // Add a blog for a tenant.
 Blog  myBlog = new Blog{ Title = "My Blog" };;
 var db = new BloggingDbContext(myTenantInfo, null);
@@ -110,7 +110,7 @@ await db.SaveChangesAsync(); // Throws MultiTenantException.
 ## Querying Data
 Queries only return results associated to the `TenantInfo`:
 
-```
+```cs
 // Will only return "My Blog".
 var db = new BloggingDbContext(myTenantInfo, null);
 var tenantBlog = db.Blogs.First();
@@ -122,7 +122,7 @@ var tenantBlogs = db.Blogs.First();
 
 `IgnoreQueryFilters` can be used to bypass the filter for LINQ queries:
 
-```
+```cs
 // TenantBlogs will contain all blogs, regardless of tenant.
 var db = new BloggingDbContext(myTenantInfo, null);
 var tenantBlogs = db.Blogs.IgnoreQueryFilters().ToList(); 
@@ -133,7 +133,7 @@ The query filter is applied only at the root level of a query. Any entity classe
 ## Updating and Deleting Data
 Updated or deleted entities are checked to make sure they are associated with the `TenantInfo`. If an entity is associated with a different `TenantInfo` then a `MultiTenantException` is thrown in `SaveChanges` or `SaveChangesAsync`:
 
-```
+```cs
 // Add a blog for a tenant.
 Blog  myBlog = new Blog{ Title = "My Blog" };
 var db = new BloggingDbContext(myTenantInfo);

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -42,9 +42,6 @@ public void Configure(IApplicationBuilder app)
 With the services and middleware configured, access information for the current tenant from the `TenantInfo` property on the `MultiTenantContext` object accessed from the `GetMultiTenantContext` extension method. If the current tenant could not be determined then `TenantInfo` will be null.
 
 ```cs
-using Finbuckle.MultiTenant;
-...
-
 var tenantInfo = HttpContext.GetMultiTenantContext().TenantInfo;
 
 if(tenantInfo != null)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Install the Finbuckle.MultiTenant NuGet package with your method of choice.
+Install the Finbuckle.MultiTenant NuGet package.
 
 .NET Core CLI
 ```bash
@@ -14,20 +14,20 @@ Package Manager
 > Install-Package Finbuckle.MultiTenant
 ```
 
-## Usage
+## Basics
 
-Configure the services by calling `AddMultiTenant` followed by its builder methods in your app's `ConfigureServices` method. Here we are using the host strategy and in-memory store, but Finbuckle.MultiTenant comes with several other multitenant [strategies](Strategies) and [stores](Stores).
+Configure the services by calling `AddMultiTenant` followed by its builder methods in the app's `ConfigureServices` method. Here we are using the host strategy and in-memory store, but Finbuckle.MultiTenant comes with several other multitenant [strategies](Strategies) and [stores](Stores).
 
 ```cs
 public void ConfigureServices(IServiceCollection services)
 {
     ...
-    services.AddMultiTenant().WithHostStrategy().WithInMemoryStore();
+    services.AddMultiTenant().WithStrategy(...).WithInMemoryStore(...);
     ...
 }
 ```
 
-Configure the middleware by calling `UseMultiTenant` in your app's `Configure` method. Be sure to call it before calling `UseMvc` and other middleware which will use per-tenant funtionality.
+Configure the middleware by calling `UseMultiTenant` in the app's `Configure` method. Be sure to call it before calling `UseMvc` and other middleware which will use per-tenant functionality.
 
 ```cs
 public void Configure(IApplicationBuilder app)
@@ -56,7 +56,7 @@ if(tenantInfo != null)
 }
 ```
 
-The `TenantInfo` property holds basic details about a tenant and enables customization of your app on a on a per-tenant basis in any way you want.
+The `TenantInfo` property holds basic details about a tenant and enables customization of the app on a on a per-tenant basis in any way you want.
 
 Finbuckle.MultiTenant uses `TenantInfo` internally to provide built-in functionality such as [per-tenant options](Options), [per-tenant authentication](Authentication), and [per-tenant data isolation](EFCore).
 

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -4,6 +4,8 @@
 
 [Core Concepts](CoreConcepts)
 
+[Configuration and Usage](ConfigurationAndUsage)
+
 [MultiTenant Strategies](Strategies)
 
 [MultiTenant Stores](Stores)

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -8,7 +8,7 @@ Finbuckle.MultiTenant is a multitenancy library for ASP.NET Core 2.1+. It provid
 Check out the [GitHub repository](https://github.com/Finbuckle/Finbuckle.MultiTenant) to ask a question, make a request, or check out the code!
 
 ## Sample Projects
-In addition to this documentation a variey of sample projects are available. Be sure to read the information on the index page of each
+In addition to this documentation a variety of sample projects are available. Be sure to read the information on the index page of each
 sample and the code comments in the `Startup` class.
 
 [Authentication Options Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/AuthenticationOptionsSample)

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -80,7 +80,7 @@ public MyController : Controller
 Both named and unnamed options are modified per-tenant. The same delegate passed to `WithPerTenantOptions<TOptions>` is applied to all options generated of type `TOptions` regardless of the option name.
 
 ## Options Caching
-Internally ASP.NET Core caches options, and Finbuckle.MultiTenant extends this to cache options per tenant. Caching occurs when a `TOptions` instance is retreived via `Value` or `Get` on the injected `IOptions<TOptions>` (or derived) instance for the first time for a tenant.
+Internally ASP.NET Core caches options, and Finbuckle.MultiTenant extends this to cache options per tenant. Caching occurs when a `TOptions` instance is retrieved via `Value` or `Get` on the injected `IOptions<TOptions>` (or derived) instance for the first time for a tenant.
 
 `IOptions<TOptions>` instances are always regenerated when injected so any caching only lasts as long as the specific instance.
 
@@ -92,4 +92,4 @@ In some situations cached options may need to be cleared so that the options can
 
 When using per-tenant options via `IOptions<TOptions>` and `IOptionsSnapshot<TOptions>` the injected instance is of type `MultiTenantOptionsManager<TOptions>`. Casting to this type exposes the `Reset()` method which clears any internal caching for the current tenant and cause the options to be regenerated when next accessed via `Value` or `Get(string name)`.
 
-When using per-tenant options with `IOptionsMonitor<TOptions>` each injected instance uses a shared persistent cache. This cache can be retreived by injecting or resolving an instance of `IOptionsMonitorCache<TOptions>` which has a `Clear()` method that will clear the cache for the current tenant. Casting the `IOptionsMonitorCache<TOptions>` instance to `MultiTenantOptionsCache<TOptions>` exposes the `Clear(string tenantId)` and `ClearAll()` methods. `Clear(string tenantId)` clears cached options for a specific tenant (or the regular non per-tenant options if the parameter is empty or null). `ClearAll()` clears all cached options (including regular non per-tenant options).
+When using per-tenant options with `IOptionsMonitor<TOptions>` each injected instance uses a shared persistent cache. This cache can be retrieved by injecting or resolving an instance of `IOptionsMonitorCache<TOptions>` which has a `Clear()` method that will clear the cache for the current tenant. Casting the `IOptionsMonitorCache<TOptions>` instance to `MultiTenantOptionsCache<TOptions>` exposes the `Clear(string tenantId)` and `ClearAll()` methods. `Clear(string tenantId)` clears cached options for a specific tenant (or the regular non per-tenant options if the parameter is empty or null). `ClearAll()` clears all cached options (including regular non per-tenant options).

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -6,9 +6,9 @@ Finbuckle.MultiTenant provides a simple thread safe in-memory implementation bas
 
 ## Accessing the Store at Runtime
 
-The multitenant store can be accessed at runtime to add, remote, or retreieve a `TenantInfo` in addition to any startup configuration the store implementation may offer (such as the `appSettings.json` configuration supported by the In-Memory Store).
+The multitenant store can be accessed at runtime to add, remote, or retrieve a `TenantInfo` in addition to any startup configuration the store implementation may offer (such as the `appSettings.json` configuration supported by the In-Memory Store).
 
-The multitenant store is registered as a singleton in the app's service collection. Access it via dependecy injection by including an `IMultiTenantStore` constructor parameter, action method parameter marked with `[FromService]`, or the `HttpContext.RequestServices` service provider instance.
+The multitenant store is registered as a singleton in the app's service collection. Access it via dependency injection by including an `IMultiTenantStore` constructor parameter, action method parameter marked with `[FromService]`, or the `HttpContext.RequestServices` service provider instance.
 
 ## IMultiTenantStore and Custom Stores
 All multitenant stores derive from `IMultiTenantStore` and must implement `TryAdd`, `TryRemove`, and `GetByIdentifierAsync` methods. `GetByIdentifierAsync` should return null if there is no suitable tenant match.
@@ -24,7 +24,7 @@ services.AddMultiTenant().WithStore( sp => return new MyStore());
 ```
 
 ## In-Memory Store
-Uses a `ConcurrentDictionary<string, TenantInfo>` as the underlying store. By default the tenant identifier matching is case insensitive. This can be overridden by passing false to the constructor's `ignoreCase` paramater.
+Uses a `ConcurrentDictionary<string, TenantInfo>` as the underlying store. By default the tenant identifier matching is case insensitive. This can be overridden by passing false to the constructor's `ignoreCase` parameter.
 
 If using with `Finbuckle.MultiTenant.AspNetCore`, configure by calling `WithInMemoryStore` after `AddMultiTenant` in the `ConfigureServices` method of the `Startup` class.
 
@@ -43,7 +43,7 @@ A `ConfigurationSection` can also be used to configure the store:
 services.AddMultiTenant().WithInMemoryStore(Configuration.GetSection("InMemoryStoreConfig"))...
 ```
 
-The configuration section should use this json format:
+The configuration section should use this JSON format:
 
 ```json
 {

--- a/docs/Strategies.md
+++ b/docs/Strategies.md
@@ -83,12 +83,12 @@ public class Startup
         routes.MapRoute("Defaut", "{__tenant__}/{controller=Home}/{action=Index}");
     }
 }
-``` 
+```
 
 ## Host Strategy
 Uses request's host value to determine the tenant. By default the first host segment is used. For example, a request to "https://contoso.example.com/abc123" would use "contoso" as the identifier when resolving the tenant. This strategy can be difficult to use in a development environment. Make sure the development system is configured properly to allow subdomains on `localhost`.
 
-The host strategy uses a template string which defines how the strategy will find the tenant identifier. The pattern specifies the location for the tenant identifer using "\_\_tenant\_\_" and can contain other valid domain characters. It can also use '?' and '\*' characters to represent one or "zero or more" segments. For example:
+The host strategy uses a template string which defines how the strategy will find the tenant identifier. The pattern specifies the location for the tenant identifier using "\_\_tenant\_\_" and can contain other valid domain characters. It can also use '?' and '\*' characters to represent one or "zero or more" segments. For example:
   - `__tenant__.*` is the default if no pattern is provided and selects the first domain segment for the tenant identifier.
   - `*.__tenant__.?` selects the main domain as the tenant identifier and ignores any subdomains and the top level domain.
   - `__tenant__.example.com` will always use the subdomain for the tenant identifier, but only if there are no prior subdomains and the overall host ends with "example.com".

--- a/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantBuilder.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantBuilder.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds and configures a IMultiTenantStrategy to the application using default dependency injection.
+        /// Adds and configures a IMultiTenantStore to the application using default dependency injection.
         /// </summary>>
         /// <param name="lifetime">The service lifetime.</param>
         /// <param name="parameters">a paramter list for any constructor paramaters not covered by dependency injection.</param>
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.DependencyInjection
             => WithStore<TStore>(lifetime, sp => ActivatorUtilities.CreateInstance<TStore>(sp, parameters));
 
         /// <summary>
-        /// Adds and configures a IMultiTenantStrategy to the application using a factory method.
+        /// Adds and configures a IMultiTenantStore to the application using a factory method.
         /// </summary>
         /// <param name="lifetime">The service lifetime.</param>
         /// <param name="factory">A delegate that will create and configure the strategy.</param>
@@ -125,7 +125,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds and configures a IMultiTenantStrategy to the application using a factory method.
+        /// Adds and configures a IMultiTenantStore to the application using a factory method.
         /// </summary>
         /// <param name="lifetime">The service lifetime.</param>
         /// <param name="factory">A delegate that will create and configure the strategy.</param>

--- a/src/Finbuckle.MultiTenant.Core/MultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant.Core/MultiTenantContext.cs
@@ -19,7 +19,7 @@ using Finbuckle.MultiTenant.Core;
 namespace Finbuckle.MultiTenant
 {
     /// <summary>
-    /// Contains information for a specific tenant.
+    /// Contains information for the multitenant tenant, store, and strategy.
     /// </summary>
     public class MultiTenantContext
     {

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/HttpContextExtensionShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/HttpContextExtensionShould.cs
@@ -1,0 +1,171 @@
+//    Copyright 2019 Andrew White
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.AspNetCore;
+using Finbuckle.MultiTenant.Core;
+using Finbuckle.MultiTenant.Stores;
+using Finbuckle.MultiTenant.Strategies;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+public class HttpContextExtensionShould
+{
+    [Fact]
+    public void GetTenantContextIfExists()
+    {
+        var items = new Dictionary<object, object>();
+        var ti = new TenantInfo("test", null, null, null, null);
+        var tc = new MultiTenantContext();
+        tc.TenantInfo = ti;
+        items.Add(Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext, tc);
+
+        var httpContextMock = new Mock<HttpContext>();
+        httpContextMock.Setup(c => c.Items).Returns(items);
+
+        var mtc = httpContextMock.Object.GetMultiTenantContext();
+
+        Assert.Same(tc, mtc);
+    }
+
+    [Fact]
+    public void ReturnNullIfNoMultiTenantContext()
+    {
+        var items = new Dictionary<object, object>();
+        var httpContextMock = new Mock<HttpContext>();
+        httpContextMock.Setup(c => c.Items).Returns(items);
+
+        var mtc = httpContextMock.Object.GetMultiTenantContext();
+
+        Assert.Null(mtc);
+    }
+
+    [Fact]
+    public void SetTenantInfo()
+    {
+        var items = new Dictionary<object, object>();
+        var ti = new TenantInfo("test", null, null, null, null);
+        var tc = new MultiTenantContext();
+        tc.TenantInfo = ti;
+        items.Add(Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext, tc);
+        var httpContextMock = new Mock<HttpContext>();
+        httpContextMock.Setup(c => c.Items).Returns(items);
+
+        var ti2 = new TenantInfo("tenant2", null, null, null, null);
+
+        var res = httpContextMock.Object.TrySetTenantInfo(ti2, false);
+
+        Assert.True(res);
+        Assert.Same(ti2, httpContextMock.Object.GetMultiTenantContext().TenantInfo);
+    }
+
+    [Fact]
+    public void NotSetTenantInfoIfNoMultiTenantContext()
+    {
+        var items = new Dictionary<object, object>();
+        var httpContextMock = new Mock<HttpContext>();
+        httpContextMock.Setup(c => c.Items).Returns(items);
+
+        var ti2 = new TenantInfo("tenant2", null, null, null, null);
+
+        var res = httpContextMock.Object.TrySetTenantInfo(ti2, false);
+
+        Assert.False(res);
+        Assert.Null(httpContextMock.Object.GetMultiTenantContext());
+    }
+
+    [Fact]
+    public void SetStoreInfoAndStrategyInfoNull()
+    {
+        var items = new Dictionary<object, object>();
+        var ti = new TenantInfo("test", null, null, null, null);
+        var tc = new MultiTenantContext();
+        tc.TenantInfo = ti;
+        tc.StrategyInfo = new StrategyInfo();
+        tc.StoreInfo = new StoreInfo();
+        items.Add(Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext, tc);
+        var httpContextMock = new Mock<HttpContext>();
+        httpContextMock.Setup(c => c.Items).Returns(items);
+
+        var ti2 = new TenantInfo("tenant2", null, null, null, null);
+
+        var res = httpContextMock.Object.TrySetTenantInfo(ti2, false);
+
+        Assert.Null(httpContextMock.Object.GetMultiTenantContext().StoreInfo);
+        Assert.Null(httpContextMock.Object.GetMultiTenantContext().StrategyInfo);
+    }
+
+    [Fact]
+    public void ResetScopeIfApplicable()
+    {
+        var items = new Dictionary<object, object>();
+        var ti = new TenantInfo("test", null, null, null, null);
+        var tc = new MultiTenantContext();
+        tc.TenantInfo = ti;
+        items.Add(Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext, tc);
+        var httpContextMock = new Mock<HttpContext>();
+        httpContextMock.Setup(c => c.Items).Returns(items);
+
+        httpContextMock.SetupProperty(c => c.RequestServices);
+
+        var sc = new ServiceCollection();
+        sc.AddScoped<object>(_sp => DateTime.Now);
+        var sp = sc.BuildServiceProvider();
+        httpContextMock.Object.RequestServices = sp;
+        
+        var ti2 = new TenantInfo("tenant2", null, null, null, null);
+        var res = httpContextMock.Object.TrySetTenantInfo(ti2, true);
+
+        Assert.NotSame(sp, httpContextMock.Object.RequestServices);
+        Assert.NotStrictEqual<DateTime>((DateTime)sp.GetService<object>(),
+            (DateTime)httpContextMock.Object.RequestServices.GetService<object>());
+    }
+
+    [Fact]
+    public void NotResetScopeIfNotApplicable()
+    {
+        var items = new Dictionary<object, object>();
+        var ti = new TenantInfo("test", null, null, null, null);
+        var tc = new MultiTenantContext();
+        tc.TenantInfo = ti;
+        items.Add(Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext, tc);
+        var httpContextMock = new Mock<HttpContext>();
+        httpContextMock.Setup(c => c.Items).Returns(items);
+
+        httpContextMock.SetupProperty(c => c.RequestServices);
+
+        var sc = new ServiceCollection();
+        sc.AddScoped<object>(_sp => DateTime.Now);
+        var sp = sc.BuildServiceProvider();
+        httpContextMock.Object.RequestServices = sp;
+        
+        var ti2 = new TenantInfo("tenant2", null, null, null, null);
+        var res = httpContextMock.Object.TrySetTenantInfo(ti2, false);
+
+        Assert.Same(sp, httpContextMock.Object.RequestServices);
+        Assert.StrictEqual<DateTime>((DateTime)sp.GetService<object>(),
+            (DateTime)httpContextMock.Object.RequestServices.GetService<object>());
+    }
+}


### PR DESCRIPTION
This PR allows setting the `TenantInfo` using the `TrySetTenantInfo` extension method on HttpContext. It also has an option to reset the service provider scope so that any services already resolved will be recreated for the new tenant if they are needed again.

- [x] Implementation
- [x] Tests
- [x] Docs

Closes #113