### PR TITLE
feat: expose inner stores and strategies

### DIFF
--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -8,7 +8,9 @@ Finbuckle.MultiTenant provides a simple thread safe in-memory implementation bas
 
 The multitenant store can be accessed at runtime to add, remote, or retrieve a `TenantInfo` in addition to any startup configuration the store implementation may offer (such as the `appSettings.json` configuration supported by the In-Memory Store).
 
-The multitenant store is registered as a singleton in the app's service collection. Access it via dependency injection by including an `IMultiTenantStore` constructor parameter, action method parameter marked with `[FromService]`, or the `HttpContext.RequestServices` service provider instance.
+There are two ways to access the store. First, via the `Store` property on the `StoreInfo` member of `MultiTenantContext` instance returned by `HttpContext.GetMultiTenantContext()`. This property returns the actual store used to retrieve the tenant information for the current context.
+
+Second, the multitenant store is registered in the app's service collection. Access it via dependency injection by including an `IMultiTenantStore` constructor parameter, action method parameter marked with `[FromService]`, or the `HttpContext.RequestServices` service provider instance.
 
 ## IMultiTenantStore and Custom Stores
 All multitenant stores derive from `IMultiTenantStore` and must implement `TryAdd`, `TryRemove`, and `GetByIdentifierAsync` methods. `GetByIdentifierAsync` should return null if there is no suitable tenant match.

--- a/docs/Strategies.md
+++ b/docs/Strategies.md
@@ -4,6 +4,8 @@ A multitenant strategy is responsible for defining how the tenant is determined.
 
 Finbuckle.MultiTenant supports several "out-of-the-box" strategies for resolving the tenant. Custom strategies can be created by implementing `IMultiTenantStrategy` or using `DelegateStrategy`. Internally strategies are registered as singleton services.
 
+The `Strategy` property on the `StrategyInfo` member of `MultiTenantContext` instance returned by `HttpContext.GetMultiTenantContext()` returns the actual strategy used to resolve the tenant information for the current context.
+
 ## IMultiTenantStrategy and Custom Strategies
 All multitenant strategies derive from `IMultiTenantStrategy` and must implement the `GetIdentifierAsync` method. 
 

--- a/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantMiddleware.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantMiddleware.cs
@@ -96,10 +96,12 @@ namespace Finbuckle.MultiTenant.AspNetCore
                     if (store.GetType().IsGenericType &&
                         store.GetType().GetGenericTypeDefinition() == typeof(MultiTenantStoreWrapper<>))
                     {
+                        storeInfo.Store = (IMultiTenantStore)store.GetType().GetProperty("Store").GetValue(store);
                         storeInfo.StoreType = store.GetType().GetGenericArguments().First();
                     }
                     else
                     {
+                        storeInfo.Store = store;
                         storeInfo.StoreType = store.GetType();
                     }
                     multiTenantContext.StoreInfo = storeInfo;
@@ -120,10 +122,12 @@ namespace Finbuckle.MultiTenant.AspNetCore
             if (strategy.GetType().IsGenericType &&
                 strategy.GetType().GetGenericTypeDefinition() == typeof(MultiTenantStrategyWrapper<>))
             {
+                strategyInfo.Strategy = (IMultiTenantStrategy)strategy.GetType().GetProperty("Strategy").GetValue(strategy);
                 strategyInfo.StrategyType = strategy.GetType().GetGenericArguments().First();
             }
             else
             {
+                strategyInfo.Strategy = strategy;
                 strategyInfo.StrategyType = strategy.GetType();
             }
             multiTenantContext.StrategyInfo = strategyInfo;

--- a/src/Finbuckle.MultiTenant.Core/Stores/MultiTenantStoreWrapper.cs
+++ b/src/Finbuckle.MultiTenant.Core/Stores/MultiTenantStoreWrapper.cs
@@ -30,12 +30,12 @@ namespace Finbuckle.MultiTenant.Stores
     public class MultiTenantStoreWrapper<TStore> : IMultiTenantStore
         where TStore : IMultiTenantStore
     {
-        private readonly TStore store;
+        public TStore Store { get; }
         private readonly ILogger logger;
 
         public MultiTenantStoreWrapper(TStore store, ILogger<TStore> logger)
         {
-            this.store = store;
+            this.Store = store;
             this.logger = logger;
         }
 
@@ -50,7 +50,7 @@ namespace Finbuckle.MultiTenant.Stores
 
             try
             {
-                result = await store.TryGetAsync(id);
+                result = await Store.TryGetAsync(id);
             }
             catch (Exception e)
             {
@@ -81,7 +81,7 @@ namespace Finbuckle.MultiTenant.Stores
 
             try
             {
-                result = await store.TryGetByIdentifierAsync(identifier);
+                result = await Store.TryGetByIdentifierAsync(identifier);
             }
             catch (Exception e)
             {
@@ -136,7 +136,7 @@ namespace Finbuckle.MultiTenant.Stores
                     goto end;
                 }
 
-                result = await store.TryAddAsync(tenantInfo);
+                result = await Store.TryAddAsync(tenantInfo);
 
             }
             catch (Exception e)
@@ -169,7 +169,7 @@ namespace Finbuckle.MultiTenant.Stores
 
             try
             {
-                result = await store.TryRemoveAsync(id);
+                result = await Store.TryRemoveAsync(id);
             }
             catch (Exception e)
             {
@@ -212,7 +212,7 @@ namespace Finbuckle.MultiTenant.Stores
                     goto end;
                 }
 
-                result = await store.TryUpdateAsync(tenantInfo);
+                result = await Store.TryUpdateAsync(tenantInfo);
 
             }
             catch (Exception e)

--- a/src/Finbuckle.MultiTenant.Core/Strategies/MultiTenantStrategyWrapper.cs
+++ b/src/Finbuckle.MultiTenant.Core/Strategies/MultiTenantStrategyWrapper.cs
@@ -22,12 +22,13 @@ namespace Finbuckle.MultiTenant.Strategies
     public class MultiTenantStrategyWrapper<TStrategy> : IMultiTenantStrategy
         where TStrategy : IMultiTenantStrategy
     {
-        internal readonly TStrategy strategy;
+        public TStrategy Strategy { get; }
+
         private readonly ILogger logger;
 
         public MultiTenantStrategyWrapper(TStrategy strategy, ILogger<TStrategy> logger)
         {
-            this.strategy = strategy;
+            this.Strategy = strategy;
             this.logger = logger;
         }
 
@@ -42,7 +43,7 @@ namespace Finbuckle.MultiTenant.Strategies
 
             try
             {
-                identifier = await strategy.GetIdentifierAsync(context);
+                identifier = await Strategy.GetIdentifierAsync(context);
             }
             catch (Exception e)
             {
@@ -53,7 +54,7 @@ namespace Finbuckle.MultiTenant.Strategies
 
             if(identifier != null)
             {
-                identifier = await strategy.GetIdentifierAsync(context);
+                identifier = await Strategy.GetIdentifierAsync(context);
                 Utilities.TryLogInfo(logger, $"{typeof(TStrategy)}.GetIdentifierAsync: Found identifier: \"{identifier}\".");
             }
             else

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantMiddlewareShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantMiddlewareShould.cs
@@ -72,12 +72,16 @@ public class MultiTenantMiddlewareShould
         var mw = new MultiTenantMiddleware(null);
         mw.Invoke(context).Wait();
 
-        var resolvedTenantContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
+        var resolvedContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
         
-        Assert.NotNull(resolvedTenantContext.StrategyInfo);
-        Assert.NotNull(resolvedTenantContext.StrategyInfo.Strategy);
-        Assert.Equal(typeof(StaticStrategy), resolvedTenantContext.StrategyInfo.StrategyType);
-        Assert.NotNull(resolvedTenantContext.StrategyInfo.MultiTenantContext);
+        Assert.NotNull(resolvedContext.StrategyInfo);
+        Assert.NotNull(resolvedContext.StrategyInfo.Strategy);
+
+        // Test that the wrapper strategy was "unwrapped"
+        Assert.Equal(typeof(StaticStrategy), resolvedContext.StrategyInfo.StrategyType);
+        Assert.IsType<StaticStrategy>(resolvedContext.StrategyInfo.Strategy);
+        
+        Assert.NotNull(resolvedContext.StrategyInfo.MultiTenantContext);
     }
 
     [Fact]
@@ -94,12 +98,16 @@ public class MultiTenantMiddlewareShould
         var mw = new MultiTenantMiddleware(null);
         mw.Invoke(context).Wait();
 
-        var resolvedTenantContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
+        var resolvedContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
         
-        Assert.NotNull(resolvedTenantContext.StoreInfo);
-        Assert.NotNull(resolvedTenantContext.StoreInfo.Store);
-        Assert.Equal(typeof(InMemoryStore), resolvedTenantContext.StoreInfo.StoreType);
-        Assert.NotNull(resolvedTenantContext.StoreInfo.MultiTenantContext);
+        Assert.NotNull(resolvedContext.StoreInfo);
+        Assert.NotNull(resolvedContext.StoreInfo.Store);
+
+         // Test that the wrapper store was "unwrapped"
+        Assert.Equal(typeof(InMemoryStore), resolvedContext.StoreInfo.StoreType);
+        Assert.IsType<InMemoryStore>(resolvedContext.StoreInfo.Store);
+
+        Assert.NotNull(resolvedContext.StoreInfo.MultiTenantContext);
     }
 
     [Fact]


### PR DESCRIPTION
The library wraps stores and strategies internally for common logging and fucntionality.
This changed allows access to the actual instances.

Closes #159