### PR TITLE
Feat/multiple strategies

### DIFF
--- a/docs/ConfigurationAndUsage.md
+++ b/docs/ConfigurationAndUsage.md
@@ -23,7 +23,7 @@ Adds and configures an IMultiTenantStore to the application. Only the last store
 - WithInMemoryStore
 
 ### WithStrategy Variants
-Adds and configures an IMultiTenantStore to the application. Only the last strategy configured will be used with the exception of the fallback strategy. See [MultiTenant Strategies](Strategies) for more information on each type.
+Adds and configures an IMultiTenantStore to the application. Multiple strategies can be registered and each will be used in the order configured, with the exception of the fallback strategy which is always last. See [MultiTenant Strategies](Strategies) for more information on each type.
 
 - WithStrategy&lt;TStrategy&gt;
 - WithBasePathStrategy
@@ -45,11 +45,12 @@ Most of the capability enabled by Finbuckle.MultiTenant is utilized through its 
 In addition, there are a few methods available for directly accessing and settings the tenant information if needed.
 
 ### UseMultiTenant
-Configures the middleware handling tenant resolution via the multitenant strategy and the multitenant store. `UseMultiTenant` should be called before `UseAuthentication` and `UseMvc` in the `Configure` method of the app's `Startup` class. Additionally, if any other middleware uses per-tenant options then that middleware should come after `UseMultiTenant`.
+Configures the middleware handling tenant resolution via the multitenant strategy and the multitenant store. `UseMultiTenant` should be called before `UseAuthentication` and `UseMvc` in the `Configure` method of the app's `Startup` class. Additionally, if any other middleware uses per-tenant options then that middleware should come after `UseMultiTenant`. In ASP.NET Core 3 or later `UseRouting` should come before `UseMultiTenant` if the route strategy is used.
 
 ```cs
 public void Configure(IApplicationBuilder app)
 {
+    app.UseRouting(); // In ASP.NET Core 3 this should be before UseMultiTenant!
     ...
     app.UseMultiTenant(); // Before UseAuthentication and UseMvc!
     ...

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -2,7 +2,9 @@
 Current version: 3.2.0
 [Version History](https://github.com/Finbuckle/Finbuckle.MultiTenant/blob/master/CHANGELOG.md)
 
-Finbuckle.MultiTenant is a multitenancy library for ASP.NET Core 2.1+. It provides functionality for tenant resolution, per-tenant app configuration, and per-tenant data isolation.
+Finbuckle.MultiTenant is a multitenancy library for ASP.NET%20Core. It provides functionality for tenant resolution, per-tenant app configuration, and per-tenant data isolation.
+
+ASP.NET Core 2.1, 2.2, and 3.0 are supported.
 
 ## Community
 Check out the [GitHub repository](https://github.com/Finbuckle/Finbuckle.MultiTenant) to ask a question, make a request, or check out the code!
@@ -11,24 +13,30 @@ Check out the [GitHub repository](https://github.com/Finbuckle/Finbuckle.MultiTe
 In addition to this documentation a variety of sample projects are available. Be sure to read the information on the index page of each
 sample and the code comments in the `Startup` class.
 
-[Authentication Options Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/AuthenticationOptionsSample)
+**ASP.NET Core 3.0 Samples**
 
-[Base Path Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/BasePathStrategySample)
+[Route Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/RouteStrategySample)  
 
-[Data Isolation Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/DataIsolationSample) 
+**ASP.NET Core 2.2 Samples**
 
-[EFCore Store Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/EFCoreStoreSample)
+[Authentication Options Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/AuthenticationOptionsSample)
 
-[Fallback Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/FallbackStrategySample)
+[Base Path Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/BasePathStrategySample)
 
-[Delegate Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/DelegateStrategySample)
+[Data Isolation Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/DataIsolationSample) 
 
-[Host Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/HostStrategySample)
+[EFCore Store Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/EFCoreStoreSample)
 
-[Identity DataIsolation Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/IdentityDataIsolationSample)
+[Fallback Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/FallbackStrategySample)
 
-[Route Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/RouteStrategySample)  
+[Delegate Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/DelegateStrategySample)
 
-[Shared Login Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/SharedLoginSample)  
+[Host Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/HostStrategySample)
 
-[Static Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/StaticStrategySample)
+[Identity DataIsolation Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/IdentityDataIsolationSample)
+
+[Route Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/RouteStrategySample)  
+
+[Shared Login Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/SharedLoginSample)  
+
+[Static Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/StaticStrategySample)

--- a/samples/ASP.NET Core 3/RouteStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 3/RouteStrategySample/Startup.cs
@@ -33,7 +33,6 @@ namespace RouteStrategySample
             app.UseRouting();
             app.UseMultiTenant();
 
-            // Note this is the same route delegate used in WithRouteStrategy()
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute("default", "{__tenant__=}/{controller=Home}/{action=Index}");

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="builder">The IApplicationBuilder<c/> instance the extension method applies to.</param>
         /// <returns>The same IApplicationBuilder passed into the method.</returns>
         public static IApplicationBuilder UseMultiTenant(this IApplicationBuilder builder)
-            => builder.UseMiddleware<MultiTenantMiddleware>(builder.ApplicationServices);
+            => builder.UseMiddleware<MultiTenantMiddleware>();
         
     }
 }

--- a/src/Finbuckle.MultiTenant.Core/DependencyInjection/MultiTenantBuilder.cs
+++ b/src/Finbuckle.MultiTenant.Core/DependencyInjection/MultiTenantBuilder.cs
@@ -13,16 +13,13 @@
 //    limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using Finbuckle.MultiTenant.Strategies;
 using Finbuckle.MultiTenant.Stores;
 using Finbuckle.MultiTenant;
-using System.Threading.Tasks;
 using Finbuckle.MultiTenant.Options;
-using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -132,25 +129,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
             Services.TryAdd(ServiceDescriptor.Describe(typeof(IMultiTenantStrategy),
                 sp => new MultiTenantStrategyWrapper<TStrategy>(factory(sp), sp.GetService<ILogger<TStrategy>>()), lifetime));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds and configures a IMultiTenantStrategy to the application using a factory method.
-        /// </summary>
-        /// <param name="lifetime">The service lifetime.</param>
-        /// <param name="factory">A delegate that will create and configure the strategy.</param>
-        /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        [Obsolete]
-        public FinbuckleMultiTenantBuilder WithStrategy(ServiceLifetime lifetime, Func<IServiceProvider, IMultiTenantStrategy> factory)
-        {
-            if (factory == null)
-            {
-                throw new ArgumentNullException(nameof(factory));
-            }
-
-            Services.TryAdd(ServiceDescriptor.Describe(typeof(IMultiTenantStrategy), factory, lifetime));
 
             return this;
         }

--- a/src/Finbuckle.MultiTenant.Core/DependencyInjection/MultiTenantBuilder.cs
+++ b/src/Finbuckle.MultiTenant.Core/DependencyInjection/MultiTenantBuilder.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            Services.TryAdd(ServiceDescriptor.Describe(typeof(IMultiTenantStrategy),
+            Services.Add(ServiceDescriptor.Describe(typeof(IMultiTenantStrategy),
                 sp => new MultiTenantStrategyWrapper<TStrategy>(factory(sp), sp.GetService<ILogger<TStrategy>>()), lifetime));
 
             return this;

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantMiddlewareShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantMiddlewareShould.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Finbuckle.MultiTenant;
 using Finbuckle.MultiTenant.AspNetCore;
@@ -37,6 +38,125 @@ public class MultiTenantMiddlewareShould
         return mock;
     }
 
+    public class TestStrat2 : DelegateStrategy
+    {
+        public TestStrat2(Func<object, Task<string>> doStrategy) : base(doStrategy)
+        {
+        }
+    }
+
+    public class TestStrat3 : DelegateStrategy
+    {
+        public TestStrat3(Func<object, Task<string>> doStrategy) : base(doStrategy)
+        {
+        }
+    }
+
+    public class TestStrat1 : DelegateStrategy
+    {
+        public TestStrat1(Func<object, Task<string>> doStrategy) : base(doStrategy)
+        {
+        }
+    }
+
+    [Fact]
+    public void CycleThroughStrategies()
+    {
+        var services = new ServiceCollection();
+        int count1 = 0;
+        int count2 = 0;
+        int count3 = 0;
+        DateTime time1 = DateTime.Now;
+        DateTime time2 = DateTime.Now;
+        DateTime time3 = DateTime.Now;
+
+        services.AddMultiTenant().WithInMemoryStore()
+            .WithStrategy<TestStrat1>(ServiceLifetime.Singleton, _ =>
+            new TestStrat1(c => 
+            {
+                count1++;
+                time1 = DateTime.Now;
+                Thread.Sleep(100);
+                return Task.FromResult<string>(null);
+            }))
+            .WithStrategy<TestStrat2>(ServiceLifetime.Singleton, _ =>
+            new TestStrat2(c => 
+            {
+                count2++;
+                time2 = DateTime.Now;
+                Thread.Sleep(100);
+                return Task.FromResult<string>(null);
+            }))
+            .WithStrategy<TestStrat3>(ServiceLifetime.Singleton, _ =>
+            new TestStrat3(c => 
+            {
+                count3++;
+                time3 = DateTime.Now;
+                Thread.Sleep(100);
+                return Task.FromResult<string>(null);
+            }));
+
+        var sp = services.BuildServiceProvider();
+        var context = CreateHttpContextMock(sp).Object;
+
+        var mw = new MultiTenantMiddleware(null);
+        mw.Invoke(context).Wait();
+
+        Assert.Equal(1, count1);
+        Assert.Equal(1, count2);
+        Assert.Equal(1, count3);
+        Assert.True(time1 < time2 && time2 < time3);
+    }
+
+    [Fact]
+    public void StopCycleThroughStrategiesWhenOneFound()
+    {
+        var services = new ServiceCollection();
+        int count1 = 0;
+        int count2 = 0;
+        int count3 = 0;
+        DateTime time1 = DateTime.Now;
+        DateTime time2 = DateTime.Now;
+        DateTime time3 = DateTime.Now;
+
+        services.AddMultiTenant().WithInMemoryStore()
+            .WithStrategy<TestStrat1>(ServiceLifetime.Singleton, _ =>
+            new TestStrat1(c => 
+            {
+                count1++;
+                time1 = DateTime.Now;
+                Thread.Sleep(100);
+                return Task.FromResult<string>(null);
+            }))
+            .WithStrategy<TestStrat2>(ServiceLifetime.Singleton, _ =>
+            new TestStrat2(c => 
+            {
+                count2++;
+                time2 = DateTime.Now;
+                Thread.Sleep(100);
+                return Task.FromResult<string>("found");
+            }))
+            .WithStrategy<TestStrat3>(ServiceLifetime.Singleton, _ =>
+            new TestStrat3(c => 
+            {
+                count3++;
+                time3 = DateTime.Now;
+                Thread.Sleep(100);
+                return Task.FromResult<string>(null);
+            }));
+
+        var sp = services.BuildServiceProvider();
+        var context = CreateHttpContextMock(sp).Object;
+
+        var mw = new MultiTenantMiddleware(null);
+        mw.Invoke(context).Wait();
+
+        Assert.Equal(1, count1);
+        Assert.Equal(1, count2);
+        Assert.Equal(0, count3);
+        Assert.True(time1 < time2 && time3 < time2);
+    }
+
     [Fact]
     public void SetTenantInfo()
     {
@@ -48,7 +168,7 @@ public class MultiTenantMiddlewareShould
 
         var context = CreateHttpContextMock(sp).Object;
 
-        var mw = new MultiTenantMiddleware(null, null);
+        var mw = new MultiTenantMiddleware(null);
         mw.Invoke(context).Wait();
 
         var resolvedTenantContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
@@ -68,7 +188,7 @@ public class MultiTenantMiddlewareShould
         sp.GetService<IMultiTenantStore>().TryAddAsync(ti).Wait();
 
         var context = CreateHttpContextMock(sp).Object;
-        var mw = new MultiTenantMiddleware(null, null);
+        var mw = new MultiTenantMiddleware(null);
         mw.Invoke(context).Wait();
 
         var resolvedContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
@@ -94,7 +214,7 @@ public class MultiTenantMiddlewareShould
 
         var context = CreateHttpContextMock(sp).Object;
 
-        var mw = new MultiTenantMiddleware(null, null);
+        var mw = new MultiTenantMiddleware(null);
         mw.Invoke(context).Wait();
 
         var resolvedContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
@@ -120,7 +240,7 @@ public class MultiTenantMiddlewareShould
         var mock = CreateHttpContextMock(sp);
         var context = mock.Object;
 
-        var mw = new MultiTenantMiddleware(null, null);
+        var mw = new MultiTenantMiddleware(null);
         mw.Invoke(context).Wait();
 
         var multiTenantContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
@@ -140,7 +260,7 @@ public class MultiTenantMiddlewareShould
         var mock = CreateHttpContextMock(sp);
         var context = mock.Object;
 
-        var mw = new MultiTenantMiddleware(null, null);
+        var mw = new MultiTenantMiddleware(null);
         mw.Invoke(context).Wait();
 
         var multiTenantContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
@@ -160,7 +280,30 @@ public class MultiTenantMiddlewareShould
         var mock = CreateHttpContextMock(sp);
         var context = mock.Object;
 
-        var mw = new MultiTenantMiddleware(null, null);
+        var mw = new MultiTenantMiddleware(null);
+        mw.Invoke(context).Wait();
+
+        var multiTenantContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
+        Assert.Null(multiTenantContext.TenantInfo);
+        Assert.Null(multiTenantContext.StoreInfo);
+        Assert.NotNull(multiTenantContext.StrategyInfo);
+        Assert.IsType<FallbackStrategy>(multiTenantContext.StrategyInfo.Strategy);
+    }
+
+    [Fact]
+    public void AlwaysHandleFallbackStrategyLast()
+    {
+        var services = new ServiceCollection();
+        services.AddAuthentication();
+        services.AddMultiTenant().WithInMemoryStore()
+            .WithFallbackStrategy("default")
+            .WithDelegateStrategy(async o => await Task.FromResult<string>(null));
+        var sp = services.BuildServiceProvider();
+
+        var mock = CreateHttpContextMock(sp);
+        var context = mock.Object;
+
+        var mw = new MultiTenantMiddleware(null);
         mw.Invoke(context).Wait();
 
         var multiTenantContext = (MultiTenantContext)context.Items[Finbuckle.MultiTenant.AspNetCore.Constants.HttpContextMultiTenantContext];
@@ -190,7 +333,7 @@ public class MultiTenantMiddlewareShould
         var mock = CreateHttpContextMock(sp);
         var context = mock.Object;
 
-        var mw = new MultiTenantMiddleware(null, null);
+        var mw = new MultiTenantMiddleware(null);
         mw.Invoke(context).Wait();
         remoteResolverMock.Verify(r => r.GetIdentifierAsync(context));
 


### PR DESCRIPTION
Allows multiple strategies to be attempted, in the order registered, until a non-null identifier is found. Fallback strategy always goes last.