### PR TITLE
release: v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 ## Version
+**5.0.0**
+* Added support for ASP.NET Core 3.1.
+* Major refactor of how Entity Framework multitenant data isolation works. No longer need to derive from `MultiTenantDbContext` greatly improving flexibility. `IdentityMultiTenantDbContext` reworked under this new model and no longer requires or recommends use of multitenant support classes, e.g. `MultiTenantIdentityUser`. Attempted to minimize impact, but if using `IdentityMultiTenantDbContext` **this may be a breaking change!** Thanks **@GordonBlahut**!
+* Simplified `EFCoreStore` to use `TenantInfo` directly. **This is a breaking change!**
+* Fixed a bug with user id not being set correctly in legacy 'IdentityMultiTenantDbContext'.
+* Added `ConfigurationStore` to load tenant information from app configuration. The store is read-only in code, but changes in configuration (e.g. appsettings.json) are picked up at runtime. Updated most sample projects to use this store.
+* Deprecated `InMemoryStore` functionality that reads from configuration.
+* Added `HttpRemoteStore` which will make an http request to get a `TenantInfo` object. It can be extended with `DelegatingHandler`s (i.e. to add authentication headers). Added sample projects for this store. Thanks to **@colindekker**!
+* Fixed an exception with OpenIdConnect remote authentication if "state" is not returned from the identity provider. The new behavior will result in no tenant found for the request.
+* Updated samples.
+* Updated documentation.
+* Updated unit tests.
+
 **4.0.0**
 * Added support for ASP.NET Core 3! Valid project targets are `netcoreapp3.0`, `netcoreapp2.0`, and `netcoreapp2.1`.
 * Added a sample app for ASP.NET 3 highlighting the route strategy improvements due to the endpoint routing mechanism.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,8 @@
 <Project>
     <PropertyGroup>
-        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-        <Version>4.0.0</Version>
+        <Version>5.0.0</Version>
         <Authors>Andrew White</Authors>
-        <Copyright>Copyright ©2019 Andrew White</Copyright>
+        <Copyright>Copyright ©2020 Andrew White</Copyright>
         <PackageIconUrl>https://www.finbuckle.com/images/favicon-64x64.png</PackageIconUrl>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageProjectUrl>https://www.finbuckle.com</PackageProjectUrl>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Finbuckle.MultiTenant 4.0.0
+# Finbuckle.MultiTenant 5.0.0
 
 Finbuckle.MultiTenant is a multitenancy library for ASP.NET Core. It provides functionality for tenant resolution, per-tenant app configuration, and per-tenant data isolation.
 
-ASP.NET Core 3.0, 2.2, and 2.1 are supported.
+ASP.NET Core 3.1, 3.0, and 2.1 are actively supported.
 
 See [https://www.finbuckle.com](https://www.finbuckle.com) for more details and documentation.  
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -1,19 +1,18 @@
 # Finbuckle.MultiTenant Docs
-Current version: 4.0.0
+Current version: 5.0.0
 [Version History](https://github.com/Finbuckle/Finbuckle.MultiTenant/blob/master/CHANGELOG.md)
 
 Finbuckle.MultiTenant is a multitenancy library for ASP.NET Core. It provides functionality for tenant resolution, per-tenant app configuration, and per-tenant data isolation.
 
-ASP.NET Core 3.0, 2.2, and 2.1 are supported.
+ASP.NET Core 3.1, 3.0, and 2.1 are actively supported.
 
 ## Community
 Check out the [GitHub repository](https://github.com/Finbuckle/Finbuckle.MultiTenant) to ask a question, make a request, or check out the code!
 
 ## Sample Projects
-In addition to this documentation a variety of sample projects are available. Be sure to read the information on the index page of each
-sample and the code comments in the `Startup` class.
+In addition to this documentation a variety of sample projects are available. Be sure to read the information on the index page of each sample and the code comments in the `Startup` class.
 
-**ASP.NET Core 3.0 Samples**
+**ASP.NET Core 3.1 Samples**
 
 [Authentication Options Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/AuthenticationOptionsSample)
 
@@ -27,13 +26,15 @@ sample and the code comments in the `Startup` class.
 
 [Host Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/HostStrategySample)
 
+[Http Remote Store Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/HttpRemoteStoreSample)
+
 [Identity DataIsolation Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/IdentityDataIsolationSample)
 
 [Route Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/RouteStrategySample)
 
 [Static Strategy Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/StaticStrategySample)
 
-**ASP.NET Core 2.2 Samples**
+**ASP.NET Core 2.1 Samples**
 
 [Authentication Options Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%202/AuthenticationOptionsSample)
 

--- a/samples/ASP.NET Core 2/AuthenticationOptionsSample/AuthenticationOptionsSample.csproj
+++ b/samples/ASP.NET Core 2/AuthenticationOptionsSample/AuthenticationOptionsSample.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+        <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 2/AuthenticationOptionsSample/Views/Home/Index.cshtml
+++ b/samples/ASP.NET Core 2/AuthenticationOptionsSample/Views/Home/Index.cshtml
@@ -66,7 +66,7 @@ else
         </p>
         <pre><code>services.AddMultiTenant()... // Setup host and strategy...
     WithRemoteAuthentication(). // Important!
-    WithPerTenantOptions<AuthenticationOptions>((options, tenantInfo) =>
+    WithPerTenantOptions&lt;AuthenticationOptions&gt;((options, tenantInfo) =>
     {
         // Allow each tenant to have a different default challenge scheme.
         if (tenantInfo.Items.TryGetValue("ChallengeScheme", out object challengeScheme))
@@ -74,7 +74,7 @@ else
             options.DefaultChallengeScheme = (string)challengeScheme;
         }
     }).
-    WithPerTenantOptions<CookieAuthenticationOptions>((options, tenantInfo) =>
+    WithPerTenantOptions&lt;CookieAuthenticationOptions&gt;((options, tenantInfo) =>
     {
         // Set a unique cookie name for this tenant.
         options.Cookie.Name = tenantInfo.Id + "-cookie";

--- a/samples/ASP.NET Core 2/BasePathStrategySample/BasePathStrategySample.csproj
+++ b/samples/ASP.NET Core 2/BasePathStrategySample/BasePathStrategySample.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 2/DataIsolationSample/DataIsolationSample.csproj
+++ b/samples/ASP.NET Core 2/DataIsolationSample/DataIsolationSample.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 2/DelegateStrategySample/DelegateStrategySample.csproj
+++ b/samples/ASP.NET Core 2/DelegateStrategySample/DelegateStrategySample.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 2/EFCoreStoreSample/EFCoreStoreSample.csproj
+++ b/samples/ASP.NET Core 2/EFCoreStoreSample/EFCoreStoreSample.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.14" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 2/FallbackStrategySample/FallbackStrategySample.csproj
+++ b/samples/ASP.NET Core 2/FallbackStrategySample/FallbackStrategySample.csproj
@@ -6,6 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 2/HostStrategySample/HostStrategySample.csproj
+++ b/samples/ASP.NET Core 2/HostStrategySample/HostStrategySample.csproj
@@ -6,11 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
   
 </Project>

--- a/samples/ASP.NET Core 2/IdentityDataIsolationSample/IdentityDataIsolationSample.csproj
+++ b/samples/ASP.NET Core 2/IdentityDataIsolationSample/IdentityDataIsolationSample.csproj
@@ -8,11 +8,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.14" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 
 </Project>

--- a/samples/ASP.NET Core 2/RouteStrategySample/RouteStrategySample.csproj
+++ b/samples/ASP.NET Core 2/RouteStrategySample/RouteStrategySample.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 2/SharedLoginSample/SharedLoginSample.csproj
+++ b/samples/ASP.NET Core 2/SharedLoginSample/SharedLoginSample.csproj
@@ -8,11 +8,11 @@
     <PackageReference Include="Microsoft.AspNetCore.App"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" PrivateAssets="All" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 
 </Project>

--- a/samples/ASP.NET Core 2/StaticStrategySample/StaticStrategySample.csproj
+++ b/samples/ASP.NET Core 2/StaticStrategySample/StaticStrategySample.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 3/AuthenticationOptionsSample/AuthenticationOptionsSample.csproj
+++ b/samples/ASP.NET Core 3/AuthenticationOptionsSample/AuthenticationOptionsSample.csproj
@@ -9,10 +9,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.0" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 3/AuthenticationOptionsSample/Views/Home/Index.cshtml
+++ b/samples/ASP.NET Core 3/AuthenticationOptionsSample/Views/Home/Index.cshtml
@@ -66,7 +66,7 @@ else
         </p>
         <pre><code>services.AddMultiTenant()... // Setup host and strategy...
     WithRemoteAuthentication(). // Important!
-    WithPerTenantOptions<AuthenticationOptions>((options, tenantInfo) =>
+    WithPerTenantOptions&lt;AuthenticationOptions&gt;((options, tenantInfo) =>
     {
         // Allow each tenant to have a different default challenge scheme.
         if (tenantInfo.Items.TryGetValue("ChallengeScheme", out object challengeScheme))
@@ -74,7 +74,7 @@ else
             options.DefaultChallengeScheme = (string)challengeScheme;
         }
     }).
-    WithPerTenantOptions<CookieAuthenticationOptions>((options, tenantInfo) =>
+    WithPerTenantOptions&lt;CookieAuthenticationOptions&gt;((options, tenantInfo) =>
     {
         // Set a unique cookie name for this tenant.
         options.Cookie.Name = tenantInfo.Id + "-cookie";

--- a/samples/ASP.NET Core 3/BasePathStrategySample/BasePathStrategySample.csproj
+++ b/samples/ASP.NET Core 3/BasePathStrategySample/BasePathStrategySample.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 3/DataIsolationSample/DataIsolationSample.csproj
+++ b/samples/ASP.NET Core 3/DataIsolationSample/DataIsolationSample.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 3/DelegateStrategySample/DelegateStrategySample.csproj
+++ b/samples/ASP.NET Core 3/DelegateStrategySample/DelegateStrategySample.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 3/EFCoreStoreSample/EFCoreStoreSample.csproj
+++ b/samples/ASP.NET Core 3/EFCoreStoreSample/EFCoreStoreSample.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 3/HostStrategySample/HostStrategySample.csproj
+++ b/samples/ASP.NET Core 3/HostStrategySample/HostStrategySample.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
   
 </Project>

--- a/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSample/HttpRemoteStoreSample.csproj
+++ b/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSample/HttpRemoteStoreSample.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.0" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSampleServer/HttpRemoteStoreSampleServer.csproj
+++ b/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSampleServer/HttpRemoteStoreSampleServer.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
   
 </Project>

--- a/samples/ASP.NET Core 3/IdentityDataIsolationSample/IdentityDataIsolationSample.csproj
+++ b/samples/ASP.NET Core 3/IdentityDataIsolationSample/IdentityDataIsolationSample.csproj
@@ -10,10 +10,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" PrivateAssets="All" />
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 3/RouteStrategySample/RouteStrategySample.csproj
+++ b/samples/ASP.NET Core 3/RouteStrategySample/RouteStrategySample.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>

--- a/samples/ASP.NET Core 3/StaticStrategySample/StaticStrategySample.csproj
+++ b/samples/ASP.NET Core 3/StaticStrategySample/StaticStrategySample.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- <PackageReference Include="Finbuckle.MultiTenant" Version="4.0.0" /> -->
+    <PackageReference Include="Finbuckle.MultiTenant" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    <!-- <ProjectReference Include="..\..\..\src\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" /> -->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**5.0.0**
* Added support for ASP.NET Core 3.1.
* Major refactor of how Entity Framework multitenant data isolation works. No longer need to derive from `MultiTenantDbContext` greatly improving flexibility. `IdentityMultiTenantDbContext` reworked under this new model and no longer requires or recommends use of multitenant support classes, e.g. `MultiTenantIdentityUser`. Attempted to minimize impact, but if using `IdentityMultiTenantDbContext` **this may be a breaking change!** Thanks **@GordonBlahut**!
* Simplified `EFCoreStore` to use `TenantInfo` directly. **This is a breaking change!**
* Fixed a bug with user id not being set correctly in legacy 'IdentityMultiTenantDbContext'.
* Added `ConfigurationStore` to load tenant information from app configuration. The store is read-only in code, but changes in configuration (e.g. appsettings.json) are picked up at runtime. Updated most sample projects to use this store.
* Deprecated `InMemoryStore` functionality that reads from configuration.
* Added `HttpRemoteStore` which will make an http request to get a `TenantInfo` object. It can be extended with `DelegatingHandler`s (i.e. to add authentication headers). Added sample projects for this store. Thanks to **@colindekker**!
* Fixed an exception with OpenIdConnect remote authentication if "state" is not returned from the identity provider. The new behavior will result in no tenant found for the request.
* Updated samples.
* Updated documentation.
* Updated unit tests.