### PR TITLE
feat: factor out abstract IMultiTenantContext

### DIFF
--- a/docs/CoreConcepts.md
+++ b/docs/CoreConcepts.md
@@ -2,10 +2,12 @@
 
 The library uses standard ASP.Net Core conventions and most of the internal details are abstracted away from app code. However, there are a few important specifics to be aware of.
 
-## MultiTenantContext
-Contains information about a the current multitenant environment. The `MultiTenantContext` for the current request can be obtained by calling the `GetMultiTenantContext()` method on the `HttpContext` object.
+## IMultiTenantContext
+Interface for a type containing information about the current multitenant environment.
 
-* Includes `TenantInfo`, `StrategyInfo`, and `StoreInfo` properties with details on the current tenant, how it was determined, and where its information came from.
+* Includes `TenantInfo`, `StrategyInfo`, and `StoreInfo` properties with details on the current tenant, how it was determined, and from where its information was retrieved.
+* Can be obtained in ASP.NET Core by calling the `GetMultiTenantContext()` method on the current request's `HttpContext` object. The implementation used with ASP.NET Core middleware has read only properties. The `HttpContext` extension method `TrySetTenantInfo` can be used to manually set the current tenant, but normally the middleware handles this. 
+* A custom implementation can be defined for more advanced use cases.
 
 ## TenantInfo
 Contains information about a tenant. Usually an app will get the current `TenantInfo` object from the `MultiTenantContext` instance for that request. Instances of `TenantInfo` can also be passed to multitenant stores for adding, removing, updating the store.

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -24,14 +24,14 @@ namespace Finbuckle.MultiTenant
     public static class FinbuckleHttpContextExtensions
     {
         /// <summary>
-        /// Returns the current MultiTenantContext or null if there is none.
+        /// Returns the current IMultiTenantContext or null if there is none.
         /// </summary>
-        public static MultiTenantContext GetMultiTenantContext(this HttpContext httpContext)
+        public static IMultiTenantContext GetMultiTenantContext(this HttpContext httpContext)
         {
             object multiTenantContext = null;
             httpContext.Items.TryGetValue(Constants.HttpContextMultiTenantContext, out multiTenantContext);
             
-            return (MultiTenantContext)multiTenantContext;
+            return (IMultiTenantContext)multiTenantContext;
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Finbuckle.MultiTenant
         /// </summary>
         public static bool TrySetTenantInfo(this HttpContext httpContext, TenantInfo tenantInfo, bool resetServiceProvider)
         {
-            var multitenantContext = httpContext.GetMultiTenantContext();
+            var multitenantContext = httpContext.GetMultiTenantContext() as MultiTenantContext;
 
             if(multitenantContext == null)
                 return false;

--- a/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/MultiTenantContextAccessor.cs
@@ -26,6 +26,6 @@ namespace Finbuckle.MultiTenant
             this.httpContextAccessor = httpContextAccessor;
         }
 
-        public MultiTenantContext MultiTenantContext => httpContextAccessor.HttpContext?.GetMultiTenantContext();
+        public IMultiTenantContext MultiTenantContext => httpContextAccessor.HttpContext?.GetMultiTenantContext();
     }
 }

--- a/src/Finbuckle.MultiTenant.Core/Abstractions/IMultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant.Core/Abstractions/IMultiTenantContext.cs
@@ -1,4 +1,4 @@
-//    Copyright 2018 Andrew White
+//    Copyright 2020 Andrew White
 // 
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -12,16 +12,12 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-using Finbuckle.MultiTenant;
-
-public class TestMultiTenantContextAccessor : IMultiTenantContextAccessor
+namespace Finbuckle.MultiTenant
 {
-    private readonly MultiTenantContext multiTenantContext;
-
-    public TestMultiTenantContextAccessor(MultiTenantContext multiTenantContext)
+    public interface IMultiTenantContext
     {
-        this.multiTenantContext = multiTenantContext;
+        TenantInfo TenantInfo { get; }
+        StrategyInfo StrategyInfo { get; }
+        StoreInfo StoreInfo { get; }
     }
-
-    public IMultiTenantContext MultiTenantContext => multiTenantContext;
 }

--- a/src/Finbuckle.MultiTenant.Core/Abstractions/IMultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant.Core/Abstractions/IMultiTenantContextAccessor.cs
@@ -16,6 +16,6 @@ namespace Finbuckle.MultiTenant
 {
     public interface IMultiTenantContextAccessor
     {
-        MultiTenantContext MultiTenantContext { get; }
+        IMultiTenantContext MultiTenantContext { get; }
     }
 }

--- a/src/Finbuckle.MultiTenant.Core/MultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant.Core/MultiTenantContext.cs
@@ -14,10 +14,11 @@
 
 namespace Finbuckle.MultiTenant
 {
+
     /// <summary>
     /// Contains information for the multitenant tenant, store, and strategy.
     /// </summary>
-    public class MultiTenantContext
+    public class MultiTenantContext : IMultiTenantContext
     {
         public TenantInfo TenantInfo { get; internal set; }
         public StrategyInfo StrategyInfo { get; internal set; }

--- a/src/Finbuckle.MultiTenant.Core/StoreInfo.cs
+++ b/src/Finbuckle.MultiTenant.Core/StoreInfo.cs
@@ -20,6 +20,6 @@ namespace Finbuckle.MultiTenant
     {
         public Type StoreType { get; internal set; }
         public IMultiTenantStore Store { get; internal set; }
-        public MultiTenantContext MultiTenantContext { get; internal set; }
+        public IMultiTenantContext MultiTenantContext { get; internal set; }
     }
 }

--- a/src/Finbuckle.MultiTenant.Core/StrategyInfo.cs
+++ b/src/Finbuckle.MultiTenant.Core/StrategyInfo.cs
@@ -20,6 +20,6 @@ namespace Finbuckle.MultiTenant
     {
         public Type StrategyType { get; internal set; }
         public IMultiTenantStrategy Strategy { get; internal set; }
-        public MultiTenantContext MultiTenantContext { get; internal set; }
+        public IMultiTenantContext MultiTenantContext { get; internal set; }
     }
 }

--- a/src/Finbuckle.MultiTenant.Core/TenantInfo.cs
+++ b/src/Finbuckle.MultiTenant.Core/TenantInfo.cs
@@ -12,7 +12,6 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using Finbuckle.MultiTenant.Core;
 
@@ -61,6 +60,6 @@ namespace Finbuckle.MultiTenant
         public string Name { get; internal set; }
         public string ConnectionString { get; internal set; }
         public IDictionary<string, object> Items { get; internal set; } = new Dictionary<string, object>();
-        public MultiTenantContext MultiTenantContext { get; internal set; }
+        public IMultiTenantContext MultiTenantContext { get; internal set; }
     }
 }


### PR DESCRIPTION
Factors out `IMultiTenantContext`. The only hard dependency on `MultiTenantContext` is in the ASP.NET Core middleware.

Closes #219 