### PR TITLE
Refactor/remove state from ITenantResolver

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>6.0.0-preview2</Version>
+        <Version>6.0.0-preview3</Version>
         <Authors>Andrew White</Authors>
         <Copyright>Copyright (c) 2018 - 2020 Andrew White</Copyright>
         <PackageIconUrl>https://www.finbuckle.com/images/favicon-64x64.png</PackageIconUrl>

--- a/samples/ASP.NET Core 2/AuthenticationOptionsSample/AuthenticationOptionsSample.csproj
+++ b/samples/ASP.NET Core 2/AuthenticationOptionsSample/AuthenticationOptionsSample.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/AuthenticationOptionsSample/Startup.cs
+++ b/samples/ASP.NET Core 2/AuthenticationOptionsSample/Startup.cs
@@ -55,7 +55,7 @@ namespace AuthenticationOptionsSample
             services.AddMultiTenant<AuthenticationOptionsSampleTenantInfo>().
                 WithConfigurationStore().
                 WithRouteStrategy(ConfigRoutes).
-                WithRemoteAuthenticationStrategy(). // Important!
+                WithRemoteAuthenticationCallbackStrategy(). // Important!
                 WithPerTenantOptions<AuthenticationOptions>((options, tenantInfo) =>
                 {
                     options.DefaultChallengeScheme = tenantInfo.ChallengeScheme ?? options.DefaultChallengeScheme;
@@ -80,7 +80,7 @@ namespace AuthenticationOptionsSample
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<AuthenticationOptionsSampleTenantInfo>();
             app.UseAuthentication();
             app.UseMvc(ConfigRoutes);
         }

--- a/samples/ASP.NET Core 2/BasePathStrategySample/BasePathStrategySample.csproj
+++ b/samples/ASP.NET Core 2/BasePathStrategySample/BasePathStrategySample.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/BasePathStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 2/BasePathStrategySample/Startup.cs
@@ -31,7 +31,7 @@ namespace BasePathStrategySample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseMvc(routes => routes.MapRoute("Default", "{first_segment=}/{controller=Home}/{action=Index}"));
         }
     }

--- a/samples/ASP.NET Core 2/DataIsolationSample/DataIsolationSample.csproj
+++ b/samples/ASP.NET Core 2/DataIsolationSample/DataIsolationSample.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.14" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/DataIsolationSample/Startup.cs
+++ b/samples/ASP.NET Core 2/DataIsolationSample/Startup.cs
@@ -41,7 +41,7 @@ namespace DataIsolationSample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseMvc(ConfigRoutes);
 
             SetupDb();

--- a/samples/ASP.NET Core 2/DelegateStrategySample/DelegateStrategySample.csproj
+++ b/samples/ASP.NET Core 2/DelegateStrategySample/DelegateStrategySample.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/DelegateStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 2/DelegateStrategySample/Startup.cs
@@ -40,7 +40,7 @@ namespace DelegateStrategySample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseMvcWithDefaultRoute();
         }
     }

--- a/samples/ASP.NET Core 2/EFCoreStoreSample/EFCoreStoreSample.csproj
+++ b/samples/ASP.NET Core 2/EFCoreStoreSample/EFCoreStoreSample.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.14" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/EFCoreStoreSample/Startup.cs
+++ b/samples/ASP.NET Core 2/EFCoreStoreSample/Startup.cs
@@ -36,7 +36,7 @@ namespace EFCoreStoreSample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseMvc(ConfigRoutes);
 
             // Seed the database the multitenant store will need.

--- a/samples/ASP.NET Core 2/FallbackStrategySample/FallbackStrategySample.csproj
+++ b/samples/ASP.NET Core 2/FallbackStrategySample/FallbackStrategySample.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/FallbackStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 2/FallbackStrategySample/Startup.cs
@@ -34,7 +34,7 @@ namespace FallbackStrategySample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
 
             // Note this is the same route delegate used in WithFallbackStrategy()
             app.UseMvc(ConfigRoutes);

--- a/samples/ASP.NET Core 2/HostStrategySample/HostStrategySample.csproj
+++ b/samples/ASP.NET Core 2/HostStrategySample/HostStrategySample.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/HostStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 2/HostStrategySample/Startup.cs
@@ -32,7 +32,7 @@ namespace HostStrategySample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseMvc(routes => routes.MapRoute("Defaut", "{controller=Home}/{action=Index}"));
         }
     }

--- a/samples/ASP.NET Core 2/IdentityDataIsolationSample/IdentityDataIsolationSample.csproj
+++ b/samples/ASP.NET Core 2/IdentityDataIsolationSample/IdentityDataIsolationSample.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.14" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/IdentityDataIsolationSample/Startup.cs
+++ b/samples/ASP.NET Core 2/IdentityDataIsolationSample/Startup.cs
@@ -78,7 +78,7 @@ namespace IdentityDataIsolationSample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseAuthentication();
             app.UseMvc(ConfigRoutes);
         }

--- a/samples/ASP.NET Core 2/RouteStrategySample/RouteStrategySample.csproj
+++ b/samples/ASP.NET Core 2/RouteStrategySample/RouteStrategySample.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/RouteStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 2/RouteStrategySample/Startup.cs
@@ -34,7 +34,7 @@ namespace RouteStrategySample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
 
             // Note this is the same route delegate used in WithRouteStrategy()
             app.UseMvc(ConfigRoutes);

--- a/samples/ASP.NET Core 2/SharedLoginSample/SharedLoginSample.csproj
+++ b/samples/ASP.NET Core 2/SharedLoginSample/SharedLoginSample.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.14" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.10" PrivateAssets="All" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 2/SharedLoginSample/Startup.cs
+++ b/samples/ASP.NET Core 2/SharedLoginSample/Startup.cs
@@ -78,7 +78,7 @@ namespace SharedLoginSample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseAuthentication();
             app.UseMvc(ConfigRoutes);
         }

--- a/samples/ASP.NET Core 2/StaticStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 2/StaticStrategySample/Startup.cs
@@ -32,7 +32,7 @@ namespace StaticStrategySample
             }
 
             app.UseStaticFiles();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseMvcWithDefaultRoute();
         }
     }

--- a/samples/ASP.NET Core 2/StaticStrategySample/StaticStrategySample.csproj
+++ b/samples/ASP.NET Core 2/StaticStrategySample/StaticStrategySample.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/AuthenticationOptionsSample/AuthenticationOptionsSample.csproj
+++ b/samples/ASP.NET Core 3/AuthenticationOptionsSample/AuthenticationOptionsSample.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.1.1" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/AuthenticationOptionsSample/Startup.cs
+++ b/samples/ASP.NET Core 3/AuthenticationOptionsSample/Startup.cs
@@ -52,7 +52,7 @@ namespace AuthenticationOptionsSample
             services.AddMultiTenant<AuthenticationOptionsSampleTenantInfo>().
                 WithConfigurationStore().
                 WithRouteStrategy().
-                WithRemoteAuthenticationStrategy(). // Important!
+                WithRemoteAuthenticationCallbackStrategy(). // Important!
                 WithPerTenantOptions<AuthenticationOptions>((options, tenantInfo) =>
                 {
                     options.DefaultChallengeScheme = tenantInfo.ChallengeScheme ?? options.DefaultChallengeScheme;
@@ -77,7 +77,7 @@ namespace AuthenticationOptionsSample
 
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<AuthenticationOptionsSampleTenantInfo>();
             app.UseAuthentication();
             app.UseAuthorization();
 

--- a/samples/ASP.NET Core 3/BasePathStrategySample/BasePathStrategySample.csproj
+++ b/samples/ASP.NET Core 3/BasePathStrategySample/BasePathStrategySample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/BasePathStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 3/BasePathStrategySample/Startup.cs
@@ -32,7 +32,7 @@ namespace BasePathStrategySample
 
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
 
             app.UseEndpoints(endpoints =>
             {

--- a/samples/ASP.NET Core 3/DataIsolationSample/DataIsolationSample.csproj
+++ b/samples/ASP.NET Core 3/DataIsolationSample/DataIsolationSample.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.1" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/DataIsolationSample/Startup.cs
+++ b/samples/ASP.NET Core 3/DataIsolationSample/Startup.cs
@@ -40,7 +40,7 @@ namespace DataIsolationSample
 
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
 
             app.UseEndpoints(endpoints =>
             {

--- a/samples/ASP.NET Core 3/DelegateStrategySample/DelegateStrategySample.csproj
+++ b/samples/ASP.NET Core 3/DelegateStrategySample/DelegateStrategySample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/DelegateStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 3/DelegateStrategySample/Startup.cs
@@ -40,7 +40,7 @@ namespace DelegateStrategySample
 
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
 
             app.UseEndpoints(endpoints =>
             {

--- a/samples/ASP.NET Core 3/EFCoreStoreSample/EFCoreStoreSample.csproj
+++ b/samples/ASP.NET Core 3/EFCoreStoreSample/EFCoreStoreSample.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.1" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/EFCoreStoreSample/Startup.cs
+++ b/samples/ASP.NET Core 3/EFCoreStoreSample/Startup.cs
@@ -35,7 +35,7 @@ namespace EFCoreStoreSample
 
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
 
             app.UseEndpoints(endpoints =>
             {

--- a/samples/ASP.NET Core 3/HostStrategySample/HostStrategySample.csproj
+++ b/samples/ASP.NET Core 3/HostStrategySample/HostStrategySample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/HostStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 3/HostStrategySample/Startup.cs
@@ -34,7 +34,7 @@ namespace HostStrategySample
 
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseEndpoints(endpoints => {
                 endpoints.MapDefaultControllerRoute();
             });

--- a/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSample/HttpRemoteStoreSample.csproj
+++ b/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSample/HttpRemoteStoreSample.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.1" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSample/Startup.cs
+++ b/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSample/Startup.cs
@@ -32,7 +32,7 @@ namespace HttpRemoteStoreSample
 
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
 
             app.UseEndpoints(endpoints =>
             {

--- a/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSampleServer/HttpRemoteStoreSampleServer.csproj
+++ b/samples/ASP.NET Core 3/HttpRemoteStoreSample/HttpRemoteStoreSampleServer/HttpRemoteStoreSampleServer.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/IdentityDataIsolationSample/IdentityDataIsolationSample.csproj
+++ b/samples/ASP.NET Core 3/IdentityDataIsolationSample/IdentityDataIsolationSample.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" PrivateAssets="All" />
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/IdentityDataIsolationSample/Startup.cs
+++ b/samples/ASP.NET Core 3/IdentityDataIsolationSample/Startup.cs
@@ -73,7 +73,7 @@ namespace IdentityDataIsolationSample
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             app.UseAuthentication();
             app.UseAuthorization();
             app.UseEndpoints(endpoints =>

--- a/samples/ASP.NET Core 3/RouteStrategySample/RouteStrategySample.csproj
+++ b/samples/ASP.NET Core 3/RouteStrategySample/RouteStrategySample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ASP.NET Core 3/RouteStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 3/RouteStrategySample/Startup.cs
@@ -33,7 +33,7 @@ namespace RouteStrategySample
 
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
 
             app.UseEndpoints(endpoints =>
             {

--- a/samples/ASP.NET Core 3/StaticStrategySample/Startup.cs
+++ b/samples/ASP.NET Core 3/StaticStrategySample/Startup.cs
@@ -32,7 +32,7 @@ namespace StaticStrategySample
 
             app.UseStaticFiles();
             app.UseRouting();
-            app.UseMultiTenant();
+            app.UseMultiTenant<TenantInfo>();
             
             app.UseEndpoints(endpoints =>
             {

--- a/samples/ASP.NET Core 3/StaticStrategySample/StaticStrategySample.csproj
+++ b/samples/ASP.NET Core 3/StaticStrategySample/StaticStrategySample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview2" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.0.0-preview3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/ApplicationBuilderExtensions.cs
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using Finbuckle.MultiTenant;
 using Finbuckle.MultiTenant.AspNetCore;
 
 namespace Microsoft.AspNetCore.Builder
@@ -26,8 +27,9 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         /// <param name="builder">The IApplicationBuilder<c/> instance the extension method applies to.</param>
         /// <returns>The same IApplicationBuilder passed into the method.</returns>
-        public static IApplicationBuilder UseMultiTenant(this IApplicationBuilder builder)
-            => builder.UseMiddleware<MultiTenantMiddleware>();
+        public static IApplicationBuilder UseMultiTenant<TTenantInfo>(this IApplicationBuilder builder)
+            where TTenantInfo : class, ITenantInfo, new()
+            => builder.UseMiddleware<MultiTenantMiddleware<TTenantInfo>>();
         
     }
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
@@ -59,8 +59,8 @@ namespace Finbuckle.MultiTenant.Strategies
                 var optionsMonitor = httpContext.RequestServices.GetRequiredService(optionsMonitorType);
                 var options = optionsMonitorType.GetMethod("Get").Invoke(optionsMonitor, new[] { scheme.Name }) as RemoteAuthenticationOptions;
                 
-                var callbackPath = (PathString)optionsType.GetProperty("CallbackPath")?.GetValue(options);
-                var signedOutCallbackPath = (PathString)optionsType.GetProperty("SignedOututCallbackPath")?.GetValue(options);
+                var callbackPath = (PathString)(optionsType.GetProperty("CallbackPath")?.GetValue(options) ?? PathString.Empty);
+                var signedOutCallbackPath = (PathString)(optionsType.GetProperty("SignedOutCallbackPath")?.GetValue(options) ?? PathString.Empty);
 
                 if (callbackPath != PathString.Empty && callbackPath == httpContext.Request.Path ||
                     signedOutCallbackPath != PathString.Empty && signedOutCallbackPath == httpContext.Request.Path)

--- a/src/Finbuckle.MultiTenant.Core/Abstractions/ITenantResolver.cs
+++ b/src/Finbuckle.MultiTenant.Core/Abstractions/ITenantResolver.cs
@@ -17,17 +17,12 @@ using System.Threading.Tasks;
 
 namespace Finbuckle.MultiTenant
 {
-    public interface ITenantResolver
-    {
-        Task<object> ResolveAsync(object context);
-        void SyncMultiTenantContextAccessor();
-    }
-    
-    public interface ITenantResolver<TTenantInfo> : ITenantResolver
+    public interface ITenantResolver<TTenantInfo>
         where TTenantInfo : class, ITenantInfo, new()
     {
         IEnumerable<IMultiTenantStrategy> Strategies { get; }
         IEnumerable<IMultiTenantStore<TTenantInfo>> Stores { get; }
-        IMultiTenantContext<TTenantInfo> MultiTenantContext { get; set; }
+        
+        Task<IMultiTenantContext<TTenantInfo>> ResolveAsync(object context);
     }
 }

--- a/src/Finbuckle.MultiTenant.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Finbuckle.MultiTenant.Core/Extensions/ServiceCollectionExtensions.cs
@@ -31,9 +31,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TTenantInfo : class, ITenantInfo, new()
         {
             services.AddScoped<ITenantResolver<TTenantInfo>, TenantResolver<TTenantInfo>>();
-            services.AddScoped<ITenantResolver>(sp => sp.GetRequiredService<ITenantResolver<TTenantInfo>>());
-            services.AddScoped<IMultiTenantContext<TTenantInfo>>(sp => sp.GetRequiredService<ITenantResolver<TTenantInfo>>().MultiTenantContext);
-            services.AddScoped<ITenantInfo>(sp => sp.GetRequiredService<ITenantResolver<TTenantInfo>>().MultiTenantContext?.TenantInfo);
+            services.AddScoped<IMultiTenantContext<TTenantInfo>>(sp => sp.GetRequiredService<IMultiTenantContextAccessor<TTenantInfo>>().MultiTenantContext);
+            services.AddScoped<ITenantInfo>(sp => sp.GetRequiredService<IMultiTenantContextAccessor<TTenantInfo>>().MultiTenantContext?.TenantInfo);
             services.AddSingleton<IMultiTenantContextAccessor<TTenantInfo>, MultiTenantContextAccessor<TTenantInfo>>();
             
             return new FinbuckleMultiTenantBuilder<TTenantInfo>(services);

--- a/src/Finbuckle.MultiTenant.Core/TenantResolver.cs
+++ b/src/Finbuckle.MultiTenant.Core/TenantResolver.cs
@@ -24,35 +24,24 @@ namespace Finbuckle.MultiTenant
         where TTenantInfo : class, ITenantInfo, new()
     {
         private readonly ILoggerFactory loggerFactory;
-        private readonly IMultiTenantContextAccessor<TTenantInfo> accessor;
 
         public TenantResolver(IEnumerable<IMultiTenantStrategy> strategies, IEnumerable<IMultiTenantStore<TTenantInfo>> stores) :
-            this(strategies, stores, null, null)
+            this(strategies, stores, null)
         {
         }
 
-        public TenantResolver(IEnumerable<IMultiTenantStrategy> strategies, IEnumerable<IMultiTenantStore<TTenantInfo>> stores, IMultiTenantContextAccessor<TTenantInfo> accessor) :
-            this(strategies, stores, accessor, null)
-        {
-        }
-
-        public TenantResolver(IEnumerable<IMultiTenantStrategy> strategies, IEnumerable<IMultiTenantStore<TTenantInfo>> stores, IMultiTenantContextAccessor<TTenantInfo> accessor, ILoggerFactory loggerFactory)
+        public TenantResolver(IEnumerable<IMultiTenantStrategy> strategies, IEnumerable<IMultiTenantStore<TTenantInfo>> stores, ILoggerFactory loggerFactory)
         {
             Strategies = strategies;
             Stores = stores;
-            this.accessor = accessor;
             this.loggerFactory = loggerFactory;
         }
 
         public IEnumerable<IMultiTenantStrategy> Strategies { get; set; }
         public IEnumerable<IMultiTenantStore<TTenantInfo>> Stores { get; set; }
-        public IMultiTenantContext<TTenantInfo> MultiTenantContext { get; set; }
 
-        public async Task<object> ResolveAsync(object context)
+        public async Task<IMultiTenantContext<TTenantInfo>> ResolveAsync(object context)
         {
-            if(MultiTenantContext != null)
-                return MultiTenantContext;
-
             IMultiTenantContext<TTenantInfo> result = null;
 
             foreach (var strategy in Strategies)
@@ -82,14 +71,7 @@ namespace Finbuckle.MultiTenant
                 }
             }
 
-            MultiTenantContext = result;
             return result;
-        }
-
-        public void SyncMultiTenantContextAccessor()
-        {
-            if(accessor != null)
-                accessor.MultiTenantContext = MultiTenantContext;
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/HttpContextExtensionShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/HttpContextExtensionShould.cs
@@ -14,6 +14,7 @@
 
 using System;
 using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -29,7 +30,7 @@ public class HttpContextExtensionShould
         tc.TenantInfo = ti;
 
         var services = new ServiceCollection();
-        services.AddScoped<ITenantResolver<TenantInfo>>(_ => new TenantResolver<TenantInfo>(null, null, null){ MultiTenantContext = tc });
+        services.AddScoped<IMultiTenantContextAccessor<TenantInfo>>(_ => new MultiTenantContextAccessor<TenantInfo>{ MultiTenantContext = tc });
         var sp = services.BuildServiceProvider();
 
         var httpContextMock = new Mock<HttpContext>();
@@ -44,7 +45,7 @@ public class HttpContextExtensionShould
     public void ReturnNullIfNoMultiTenantContext()
     {
         var services = new ServiceCollection();
-        services.AddScoped<ITenantResolver<TenantInfo>>(_ => new TenantResolver<TenantInfo>(null, null, null));
+        services.AddScoped<IMultiTenantContextAccessor<TenantInfo>>(_ => new MultiTenantContextAccessor<TenantInfo>());
         var sp = services.BuildServiceProvider();
 
         var httpContextMock = new Mock<HttpContext>();
@@ -74,7 +75,7 @@ public class HttpContextExtensionShould
     }
 
     [Fact]
-    public void SyncMultiTenantContextAcccessor()
+    public void SetMultiTenantContextAcccessor()
     {
         var services = new ServiceCollection();
         services.AddMultiTenant<TenantInfo>();

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantAuthenticationSchemeProviderShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantAuthenticationSchemeProviderShould.cs
@@ -31,6 +31,10 @@ public class MultiTenantAuthenticationSchemeProviderShould
         return new WebHostBuilder()
                     .ConfigureServices(services =>
                     {
+                        services.AddAuthentication()
+                            .AddCookie("tenant1Scheme")
+                            .AddCookie("tenant2Scheme");
+                            
                         services.AddMultiTenant<TenantInfo>()
                             .WithBasePathStrategy()
                             .WithRemoteAuthenticationCallbackStrategy()
@@ -39,15 +43,12 @@ public class MultiTenantAuthenticationSchemeProviderShould
                             {
                                 ao.DefaultChallengeScheme = ti.Identifier + "Scheme";
                             });
-                        services.AddAuthentication()
-                            .AddCookie("tenant1Scheme")
-                            .AddCookie("tenant2Scheme");
 
                         services.AddMvc();
                     })
                     .Configure(app =>
                     {
-                        app.UseMultiTenant();
+                        app.UseMultiTenant<TenantInfo>();
                         app.Run(async context =>
                         {
                             if (context.GetMultiTenantContext<TenantInfo>().TenantInfo != null)

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantMiddlewareShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantMiddlewareShould.cs
@@ -41,14 +41,16 @@ public class MultiTenantMiddlewareShould
         var context = new Mock<HttpContext>();
         context.Setup(c => c.RequestServices).Returns(sp);
 
-        var mw = new MultiTenantMiddleware(null);
-        await mw.Invoke(context.Object);
+        var mw = new MultiTenantMiddleware<TenantInfo>(c => {
+            Assert.Equal("initech", context.Object.RequestServices.GetService<ITenantInfo>().Id);
+            return Task.CompletedTask;
+        });
 
-        Assert.Equal("initech", context.Object.RequestServices.GetService<ITenantInfo>().Id);
+        await mw.Invoke(context.Object);
     }
 
     [Fact]
-    async void SyncMultiTenantContextAccessor()
+    async void SetMultiTenantContextAccessor()
     {
         var services = new ServiceCollection();
         services.AddMultiTenant<TenantInfo>().
@@ -61,10 +63,10 @@ public class MultiTenantMiddlewareShould
         var context = new Mock<HttpContext>();
         context.Setup(c => c.RequestServices).Returns(sp);
 
-        var mw = new MultiTenantMiddleware(c => {
+        var mw = new MultiTenantMiddleware<TenantInfo>(c => {
             var accessor = c.RequestServices.GetRequiredService<IMultiTenantContextAccessor<TenantInfo>>();
             var resolver = c.RequestServices.GetRequiredService<ITenantResolver<TenantInfo>>();
-            Assert.Same(accessor.MultiTenantContext, resolver.MultiTenantContext);
+            Assert.NotNull(accessor.MultiTenantContext);
             return Task.CompletedTask;
         });
 

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/RouteStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/RouteStrategyShould.cs
@@ -95,7 +95,7 @@ public class RouteStrategyShould
                     })
                     .Configure(app =>
                     {
-                        app.UseMultiTenant();
+                        app.UseMultiTenant<TenantInfo>();
                         app.Run(async context =>
                         {
                             if (context.GetMultiTenantContext<TenantInfo>()?.TenantInfo != null)
@@ -182,7 +182,7 @@ public class RouteStrategyShould
                     .Configure(app =>
                     {
                         app.UseRouting();
-                        app.UseMultiTenant();
+                        app.UseMultiTenant<TenantInfo>();
                         app.UseEndpoints(endpoints =>
                         {
                             endpoints.Map(routePattern, async context =>

--- a/test/Finbuckle.MultiTenant.Core.Test/Extensions/ServiceCollectionExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.Core.Test/Extensions/ServiceCollectionExtensionsShould.cs
@@ -33,19 +33,6 @@ public class ServiceCollectionExtensionsShould
     }
 
     [Fact]
-    public void RegisterITenantResolverInDI()
-    {
-        var services = new ServiceCollection();
-        services.AddMultiTenant<TenantInfo>();
-        
-        var service = services.Where(s =>   s.Lifetime == ServiceLifetime.Scoped &&
-                                            s.ServiceType == typeof(ITenantResolver)).SingleOrDefault();
-
-        Assert.NotNull(service);
-        Assert.Equal(ServiceLifetime.Scoped, service.Lifetime);
-    }
-
-    [Fact]
     public void RegisterIMultiTenantContextInDI()
     {
         var services = new ServiceCollection();

--- a/test/Finbuckle.MultiTenant.Core.Test/TenantResolverShould.cs
+++ b/test/Finbuckle.MultiTenant.Core.Test/TenantResolverShould.cs
@@ -70,7 +70,7 @@ public class TenantResolverShould
     }
 
     [Fact]
-    void ReturnStrategyAndStoreHit()
+    void ReturnMultiTenantContext()
     {
         var configBuilder = new ConfigurationBuilder();
         configBuilder.AddJsonFile("ConfigurationStoreTestSettings.json");
@@ -91,9 +91,7 @@ public class TenantResolverShould
             Single().TryAddAsync(new TenantInfo { Id = "null", Identifier = "null" }).Wait();
 
         var resolver = sp.GetService<ITenantResolver<TenantInfo>>();
-
-        resolver.ResolveAsync(new object()).Wait();
-        var result = resolver.MultiTenantContext;
+        var result = resolver.ResolveAsync(new object()).Result;
         
         Assert.Equal("initech", result.TenantInfo.Identifier);
         Assert.IsType<StaticStrategy>(result.StrategyInfo.Strategy);
@@ -121,9 +119,7 @@ public class TenantResolverShould
             Single().TryAddAsync(new TenantInfo { Id = "null", Identifier = "null" }).Wait();
 
         var resolver = sp.GetService<ITenantResolver<TenantInfo>>();
-
-        resolver.ResolveAsync(new object()).Wait();
-        var result = resolver.MultiTenantContext;
+        var result = resolver.ResolveAsync(new object()).Result;
 
         Assert.Null(result);
     }
@@ -150,9 +146,7 @@ public class TenantResolverShould
             Single().TryAddAsync(new TenantInfo { Id = "null", Identifier = "null" }).Wait();
 
         var resolver = sp.GetService<ITenantResolver<TenantInfo>>();
-
-        resolver.ResolveAsync(new object()).Wait();
-        var result = resolver.MultiTenantContext;
+        var result = resolver.ResolveAsync(new object()).Result;
 
         Assert.Null(result);
     }


### PR DESCRIPTION
- Caching the multitenant context in the scoped ITenantResolver caused issues with Blazor. This update removes said caching and has all sources for multi tenant context use the `IMultiTenantContextAccessor`
- Fix casting bug in `RemoteAuthenticationCallbackStrategy`

