### PR TITLE
feat: ignored identifiers

### DIFF
--- a/src/Finbuckle.MultiTenant/DependencyInjection/MultiTenantBuilder.cs
+++ b/src/Finbuckle.MultiTenant/DependencyInjection/MultiTenantBuilder.cs
@@ -15,9 +15,6 @@
 using System;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Logging;
-using Finbuckle.MultiTenant.Strategies;
-using Finbuckle.MultiTenant.Stores;
 using Finbuckle.MultiTenant;
 using Finbuckle.MultiTenant.Options;
 
@@ -35,13 +32,13 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds per-tenant configuration for an options class.
         /// </summary>
-        /// <param name="tenantInfo">The configuration action to be run for each tenant.</param>
+        /// <param name="tenantConfig">The configuration action to be run for each tenant.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public FinbuckleMultiTenantBuilder<TTenantInfo> WithPerTenantOptions<TOptions>(Action<TOptions, TTenantInfo> tenantInfo) where TOptions : class, new()
+        public FinbuckleMultiTenantBuilder<TTenantInfo> WithPerTenantOptions<TOptions>(Action<TOptions, TTenantInfo> tenantConfig) where TOptions : class, new()
         {
-            if (tenantInfo == null)
+            if (tenantConfig == null)
             {
-                throw new ArgumentNullException(nameof(tenantInfo));
+                throw new ArgumentNullException(nameof(tenantConfig));
             }
 
             // Handles multiplexing cached options.
@@ -55,7 +52,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Services.TryAddTransient<IOptionsFactory<TOptions>>(sp =>
                 {
                     return (IOptionsFactory<TOptions>)ActivatorUtilities.
-                        CreateInstance(sp, typeof(MultiTenantOptionsFactory<TOptions, TTenantInfo>), new[] { tenantInfo });
+                        CreateInstance(sp, typeof(MultiTenantOptionsFactory<TOptions, TTenantInfo>), new[] { tenantConfig });
                 });
 
             Services.TryAddScoped<IOptionsSnapshot<TOptions>>(sp => BuildOptionsManager<TOptions>(sp));

--- a/src/Finbuckle.MultiTenant/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Finbuckle.MultiTenant/Extensions/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Configure Finbuckle.MultiTenant services for the application.
         /// </summary>
         /// <param name="services">The IServiceCollection<c/> instance the extension method applies to.</param>
-        /// 
+        /// <param name="config">An action to configure the MultiTenantOptions instance.</param>
         /// <returns>An new instance of MultiTenantBuilder.</returns>
         public static FinbuckleMultiTenantBuilder<TTenantInfo> AddMultiTenant<TTenantInfo>(this IServiceCollection services, Action<MultiTenantOptions> config)
             where TTenantInfo : class, ITenantInfo, new()

--- a/src/Finbuckle.MultiTenant/MultiTenantOptions.cs
+++ b/src/Finbuckle.MultiTenant/MultiTenantOptions.cs
@@ -18,6 +18,6 @@ namespace Finbuckle.MultiTenant
 {
     public class MultiTenantOptions
     {
-        public List<string> IgnoredIdentifiers = new List<string>();
+        public IList<string> IgnoredIdentifiers = new List<string>();
     }
 }


### PR DESCRIPTION
Adds an overload of `AddMultiTenant` which accepts an `MultiTenantOptions` object with a list property `IgnoredIdentifiers`. Adding strings to this list will prevent resolving tenants with the given identifier. This is useful when resolution is expensive and you commonly get unwanted identifiers in your strategy, e.g. www when using a subdomain under the hosting strategy.

Note: a prior commit inadvertently included some of this functionality.