### PR TITLE
feat: strategy priorities

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "sdk": {
+    "allowPrerelease": false
+  }
+}

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
@@ -31,6 +31,8 @@ namespace Finbuckle.MultiTenant.Strategies
     {
         internal static readonly string TenantKey = "__tenant__";
         private readonly ILogger<RemoteAuthenticationCallbackStrategy> logger;
+        
+        int Priority { get => 999; }
 
         public RemoteAuthenticationCallbackStrategy()
         {

--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantStrategy.cs
@@ -27,5 +27,10 @@ namespace Finbuckle.MultiTenant
         /// <param name="context"></param>
         /// <returns></returns>
         Task<string> GetIdentifierAsync(object context);
+
+        /// <summary>
+        ///  Method for implemenations to control how the identifier is determined.
+        /// </summary>
+        int Priority { get => 1; }
     }
 }

--- a/src/Finbuckle.MultiTenant/Strategies/StaticStrategy.cs
+++ b/src/Finbuckle.MultiTenant/Strategies/StaticStrategy.cs
@@ -19,6 +19,8 @@ namespace Finbuckle.MultiTenant.Strategies
     public class StaticStrategy : IMultiTenantStrategy
     {
         internal readonly string identifier;
+
+        int Priority { get => 1000; }
         
         public StaticStrategy(string identifier)
         {

--- a/src/Finbuckle.MultiTenant/TenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/TenantResolver.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Finbuckle.MultiTenant.Stores;
 using Finbuckle.MultiTenant.Strategies;
@@ -34,7 +35,7 @@ namespace Finbuckle.MultiTenant
 
         public TenantResolver(IEnumerable<IMultiTenantStrategy> strategies, IEnumerable<IMultiTenantStore<TTenantInfo>> stores, IOptionsMonitor<MultiTenantOptions> options, ILoggerFactory loggerFactory)
         {
-            Strategies = strategies;
+            Strategies = strategies.OrderBy(s => s.Priority);
             Stores = stores;
             this.options = options;
             this.loggerFactory = loggerFactory;

--- a/test/Finbuckle.MultiTenant.Test/TenantResolverShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/TenantResolverShould.cs
@@ -24,7 +24,7 @@ using Xunit;
 public class TenantResolverShould
 {
     [Fact]
-    void InitializeStrategiesFromDI()
+    void InitializeSortedStrategiesFromDI()
     {
         var services = new ServiceCollection();
         services.
@@ -40,8 +40,8 @@ public class TenantResolverShould
 
         Assert.Equal(3, strategies.Length);
         Assert.IsType<DelegateStrategy>(strategies[0]);
-        Assert.IsType<StaticStrategy>(strategies[1]);
-        Assert.IsType<DelegateStrategy>(strategies[2]);
+        Assert.IsType<DelegateStrategy>(strategies[1]);
+        Assert.IsType<StaticStrategy>(strategies[2]); // Note the Static stragy should be last due its priority.
     }
 
     [Fact]


### PR DESCRIPTION
Adds a default property on strategies. The resolver sorts strategies by priority (stable sort relative to how they were resistered after `AddMultiTenant`) before calling them. Default priority is 1. Static strategy priority is 1000 and RemoteAuthenticationCallbackStrategy is 999.