### PR TITLE
feat: Extended IMultiTenantStore with GetAllAsync()

### DIFF
--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStore.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStore.cs
@@ -13,6 +13,7 @@
 //    limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -35,6 +36,11 @@ namespace Finbuckle.MultiTenant.Stores
             return await dbContext.TenantInfo
                             .Where(ti => ti.Id == id)
                             .SingleOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<TTenantInfo>> GetAllAsync()
+        {
+            return await dbContext.TenantInfo.ToListAsync();
         }
 
         public async Task<TTenantInfo> TryGetByIdentifierAsync(string identifier)

--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantStore.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantStore.cs
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Finbuckle.MultiTenant
@@ -55,5 +56,12 @@ namespace Finbuckle.MultiTenant
         /// <param name="id"></param>
         /// <returns></returns>
         Task<TTenantInfo> TryGetAsync(string id);
+
+
+        /// <summary>
+        /// Retrieve all the TTenantInfo's from the store.
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<TTenantInfo>> GetAllAsync();
     }
 }

--- a/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
@@ -85,6 +85,11 @@ namespace Finbuckle.MultiTenant.Stores
             return await Task.FromResult(tenantMap.Where(kv => kv.Value.Id == id).SingleOrDefault().Value);
         }
 
+        public async Task<IEnumerable<TTenantInfo>> GetAllAsync()
+        {
+            return await Task.FromResult(tenantMap.Select(x => x.Value).ToList());
+        }
+
         public async Task<TTenantInfo> TryGetByIdentifierAsync(string identifier)
         {
             if (identifier is null)

--- a/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStore.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Finbuckle.MultiTenant.Stores
@@ -53,6 +54,11 @@ namespace Finbuckle.MultiTenant.Stores
         public Task<TTenantInfo> TryGetAsync(string id)
         {
             throw new System.NotImplementedException();
+        }
+
+        public Task<IEnumerable<TTenantInfo>> GetAllAsync()
+        {
+	        throw new NotImplementedException();
         }
 
         public async Task<TTenantInfo> TryGetByIdentifierAsync(string identifier)

--- a/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
@@ -63,6 +63,11 @@ namespace Finbuckle.MultiTenant.Stores
             return await Task.FromResult(result);
         }
 
+        public async Task<IEnumerable<TTenantInfo>> GetAllAsync()
+        {
+            return await Task.FromResult(tenantMap.Select(x => x.Value).ToList());
+        }
+
         public async Task<bool> TryAddAsync(TTenantInfo tenantInfo)
         {
             var result = tenantMap.TryAdd(tenantInfo.Identifier, tenantInfo);

--- a/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
+++ b/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
@@ -13,6 +13,7 @@
 //    limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Finbuckle.MultiTenant.Internal;
 using Microsoft.Extensions.Logging;
@@ -60,6 +61,23 @@ namespace Finbuckle.MultiTenant.Stores
             else
             {
                 Utilities.TryLogDebug(logger, $"{Store.GetType()}.TryGetAsync: Unable to find Tenant Id \"{id}\".");
+            }
+
+            return result;
+        }
+
+        public async Task<IEnumerable<TTenantInfo>> GetAllAsync()
+        {
+            IEnumerable<TTenantInfo> result = null;
+
+            try
+            {
+                result = await Store.GetAllAsync();
+            }
+            catch (Exception e)
+            {
+                var errorMessage = $"Exception in {Store.GetType()}.GetAllAsync.";
+                Utilities.TryLogError(logger, errorMessage, e);
             }
 
             return result;

--- a/test/Finbuckle.MultiTenant.Test/DependencyInjection/MultiTenantBuilderShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/DependencyInjection/MultiTenantBuilderShould.cs
@@ -13,6 +13,7 @@
 //    limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Microsoft.Extensions.Options;
@@ -291,6 +292,11 @@ public class MultiTenantBuilderShould
         public Task<TTenant> TryGetAsync(string id)
         {
             throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<TTenant>> GetAllAsync()
+        {
+	        throw new NotImplementedException();
         }
 
         public Task<TTenant> TryGetByIdentifierAsync(string identifier)

--- a/test/Finbuckle.MultiTenant.Test/Stores/ConfigurationStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/ConfigurationStoreShould.cs
@@ -13,6 +13,7 @@
 //    limitations under the License.
 
 using System;
+using System.Linq;
 using Finbuckle.MultiTenant;
 using Finbuckle.MultiTenant.Stores;
 using Microsoft.Extensions.Configuration;
@@ -93,6 +94,13 @@ public class ConfigurationStoreShould : IMultiTenantStoreTestBase<ConfigurationS
     public override void ReturnNullWhenGettingByIdIfTenantInfoNotFound()
     {
         base.ReturnNullWhenGettingByIdIfTenantInfoNotFound();
+    }
+
+    [Fact]
+    public void GetAllTenantsFromStoreAsync()
+    {
+        var store = CreateTestStore();
+        Assert.Equal(2, store.GetAllAsync().Result.Count());
     }
 
     // [Fact(Skip = "Not valid for this store.")]

--- a/test/Finbuckle.MultiTenant.Test/Stores/InMemoryStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/InMemoryStoreShould.cs
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using System.Linq;
 using Finbuckle.MultiTenant;
 using Finbuckle.MultiTenant.Stores;
 using Microsoft.Extensions.DependencyInjection;
@@ -59,6 +60,15 @@ public class InMemoryStoreShould : IMultiTenantStoreTestBase<InMemoryStore<Tenan
         var store = CreateCaseSensitiveTestStore();
         Assert.Equal("initech", store.TryGetByIdentifierAsync("initech").Result.Identifier);
         Assert.Null(store.TryGetByIdentifierAsync("iNitEch").Result);
+    }
+
+    [Fact]
+    public void GetAllTenantsFromStoreAsync()
+    {
+        var store = CreateTestStore();
+        Assert.Equal(2, store.GetAllAsync().Result.Count());
+        store.TryAddAsync(new TenantInfo() {Identifier = "test"});
+        Assert.Equal(3, store.GetAllAsync().Result.Count());
     }
 
     [Fact]


### PR DESCRIPTION
Extended the IMultiTenantStore to allow retrieve of all tenants in the store. The primary purpose being to allow switching of tenants or tenant based administration functionality. Mostly used in cases such as https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/308 where the user may need to be presented with a list to choose from.