### PR TITLE
Refactor/per tenant authentication tweaks

### DIFF
--- a/samples/ASP.NET Core 3/PerTenantAuthenticationSample/Views/Home/Index.cshtml
+++ b/samples/ASP.NET Core 3/PerTenantAuthenticationSample/Views/Home/Index.cshtml
@@ -4,7 +4,8 @@
 {
     @if(!User.Identity.IsAuthenticated)
     {
-        <a asp-controller="Home" asp-action="Authenticate" class="btn btn-primary">Login</a>
+        <p><a asp-controller="Home" asp-action="Authenticate" class="btn btn-primary">Login</a></p>
+        <p>For external login:<br/>Username: <i>alice</i> or <i>bob</i><br />Password: <i>Pass123$</i></p>
     } else
     {
         <a asp-action="Logout" class="btn btn-secondary">Logout</a>
@@ -71,7 +72,7 @@ else
                 options.Prompt = "login consent"; // For sample purposes.
             });
 
-    services.AddMultiTenant<SampleTenantInfo>()
+    services.AddMultiTenant&lt;SampleTenantInfo&gt;()
             .WithConfigurationStore()
             .WithRouteStrategy()
             .WithPerTenantAuthentication();

--- a/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantAuthenticationService.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantAuthenticationService.cs
@@ -14,6 +14,7 @@
 
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Finbuckle.MultiTenant.Internal;
 using Finbuckle.MultiTenant.Strategies;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -37,8 +38,8 @@ namespace Finbuckle.MultiTenant.AspNetCore
             if (multiTenantContext.TenantInfo != null)
             {
                 properties = properties ?? new AuthenticationProperties();
-                if(!properties.Items.Keys.Contains(RemoteAuthenticationCallbackStrategy.TenantKey))
-                    properties.Items.Add(RemoteAuthenticationCallbackStrategy.TenantKey, multiTenantContext.TenantInfo.Identifier);
+                if(!properties.Items.Keys.Contains(Constants.TenantToken))
+                    properties.Items.Add(Constants.TenantToken, multiTenantContext.TenantInfo.Identifier);
             }
         }
 

--- a/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantAuthenticationService.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantAuthenticationService.cs
@@ -35,7 +35,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
         {
             // Add tenant identifier to the properties so on the callback we can use it to set the multitenant context.
             var multiTenantContext = context.GetMultiTenantContext<TTenantInfo>();
-            if (multiTenantContext.TenantInfo != null)
+            if (multiTenantContext?.TenantInfo != null)
             {
                 properties = properties ?? new AuthenticationProperties();
                 if(!properties.Items.Keys.Contains(Constants.TenantToken))

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/ClaimStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/ClaimStrategy.cs
@@ -1,5 +1,20 @@
+//    Copyright 2020 Andrew White and Contributors
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 
 namespace Finbuckle.MultiTenant.Strategies
@@ -20,7 +35,10 @@ namespace Finbuckle.MultiTenant.Strategies
 			if (!(context is HttpContext httpContext))
 				throw new MultiTenantException(null, new ArgumentException($@"""{nameof(context)}"" type must be of type HttpContext", nameof(context)));
 
-			return await Task.FromResult(httpContext.User.FindFirst(_tenantKey)?.Value);
+			var authenicateResult = await httpContext.AuthenticateAsync();
+			var identifier = authenicateResult.Principal?.FindFirst(_tenantKey)?.Value;
+			
+			return await Task.FromResult(identifier);
 		}
 	}
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/HostStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/HostStrategy.cs
@@ -16,6 +16,7 @@ using System;
 using Microsoft.AspNetCore.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Finbuckle.MultiTenant.Internal;
 
 namespace Finbuckle.MultiTenant.Strategies
 {
@@ -26,9 +27,9 @@ namespace Finbuckle.MultiTenant.Strategies
         public HostStrategy(string template)
         {
             // New in 2.1, match whole domain if just "__tenant__".
-            if (template == "__tenant__")
+            if (template == Constants.TenantToken)
             {
-                template = template.Replace("__tenant__", @"(?<identifier>.+)");
+                template = template.Replace(Constants.TenantToken, @"(?<identifier>.+)");
             }
             else
             {
@@ -65,7 +66,7 @@ namespace Finbuckle.MultiTenant.Strategies
                 wildcardSegmentsPattern = @"([^\.]+\.)*";
                 template = template.Replace(@"*\.", wildcardSegmentsPattern);
                 template = template.Replace("?", singleSegmentPattern);
-                template = template.Replace("__tenant__", @"(?<identifier>[^\.]+)");
+                template = template.Replace(Constants.TenantToken, @"(?<identifier>[^\.]+)");
             }
 
             this.regex = $"^{template}$";

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
@@ -33,10 +33,6 @@ namespace Finbuckle.MultiTenant.Strategies
         
         public int Priority { get => -900; }
 
-        public RemoteAuthenticationCallbackStrategy()
-        {
-        }
-
         public RemoteAuthenticationCallbackStrategy(ILogger<RemoteAuthenticationCallbackStrategy> logger)
         {
             this.logger = logger;
@@ -92,7 +88,8 @@ namespace Finbuckle.MultiTenant.Strategies
 
                         if (properties == null)
                         {
-                            logger.LogWarning("A tenant could not be determined because no state paraameter passed with the remote authentication callback.");
+                            if(logger != null)
+                                logger.LogWarning("A tenant could not be determined because no state paraameter passed with the remote authentication callback.");
                             return null;
                         }
 

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Finbuckle.MultiTenant.Internal;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -28,7 +29,6 @@ namespace Finbuckle.MultiTenant.Strategies
 {
     public class RemoteAuthenticationCallbackStrategy : IMultiTenantStrategy
     {
-        internal static readonly string TenantKey = "__tenant__";
         private readonly ILogger<RemoteAuthenticationCallbackStrategy> logger;
         
         public int Priority { get => -900; }
@@ -96,7 +96,7 @@ namespace Finbuckle.MultiTenant.Strategies
                             return null;
                         }
 
-                        properties.Items.TryGetValue(TenantKey, out var identifier);
+                        properties.Items.TryGetValue(Constants.TenantToken, out var identifier);
 
                         return identifier;
                     }

--- a/src/Finbuckle.MultiTenant/Internal/Constants.cs
+++ b/src/Finbuckle.MultiTenant/Internal/Constants.cs
@@ -17,5 +17,6 @@ namespace Finbuckle.MultiTenant.Internal
     internal static class Constants
     {
         public static int TenantIdMaxLength = 64;
+        public static string TenantToken = "__tenant__";
     }
 }

--- a/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStore.cs
@@ -15,13 +15,14 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Finbuckle.MultiTenant.Internal;
 
 namespace Finbuckle.MultiTenant.Stores
 {
     public class HttpRemoteStore<TTenantInfo> : IMultiTenantStore<TTenantInfo>
         where TTenantInfo : class, ITenantInfo, new()
     {
-        internal static readonly string defaultEndpointTemplateIdentifierToken = "{__tenant__}";
+        internal static readonly string defaultEndpointTemplateIdentifierToken = $"{{{Constants.TenantToken}}}";
         private readonly HttpRemoteStoreClient<TTenantInfo> client;
         private readonly string endpointTemplate;
 

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
@@ -118,8 +118,7 @@ public partial class MultiTenantBuilderExtensionsShould
             Identifier = "identifier1",
             CookieLoginPath = "/path1",
             CookieLogoutPath = "/path2",
-            CookieAccessDeniedPath = "/path3",
-            CookiePath = "/path4"
+            CookieAccessDeniedPath = "/path3"
         };
 
         var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TestTenantInfo>>();
@@ -127,67 +126,9 @@ public partial class MultiTenantBuilderExtensionsShould
 
         var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
 
-        Assert.Equal(CookieAuthenticationDefaults.CookiePrefix + "__" + ti1.Identifier, options.Cookie.Name);
         Assert.Equal(ti1.CookieLoginPath, options.LoginPath);
         Assert.Equal(ti1.CookieLogoutPath, options.LogoutPath);
         Assert.Equal(ti1.CookieAccessDeniedPath, options.AccessDeniedPath);
-        Assert.Equal(ti1.CookiePath, options.Cookie.Path);
-    }
-
-    [Fact]
-    public void ConfigurePerTenantAuthentication_PrependExistingCookieName()
-    {
-        var services = new ServiceCollection();
-        services.AddOptions();
-        services.AddAuthentication().AddCookie(o => o.Cookie.Name = "name");
-        services.AddMultiTenant<TestTenantInfo>()
-                .WithPerTenantAuthentication();
-        var sp = services.BuildServiceProvider();
-
-        var ti1 = new TestTenantInfo
-        {
-            Id = "id1",
-            Identifier = "identifier1"
-        };
-
-        var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TestTenantInfo>>();
-        accessor.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
-
-        var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
-
-        Assert.Equal("name" + "__" + ti1.Identifier, options.Cookie.Name);
-    }
-
-    [Fact]
-    public void ConfigurePerTenantAuthentication_UseCookieOptionsPathReplacement()
-    {
-        var services = new ServiceCollection();
-        services.AddOptions();
-        services.AddAuthentication().AddCookie();
-        services.AddMultiTenant<TestTenantInfo>()
-                .WithPerTenantAuthentication();
-        var sp = services.BuildServiceProvider();
-
-        var ti1 = new TestTenantInfo
-        {
-            Id = "id1",
-            Identifier = "identifier1",
-            CookieLoginPath = "/__tenant__",
-            CookieLogoutPath = "/__tenant__",
-            CookieAccessDeniedPath = "/__tenant__",
-            CookiePath = "/__tenant__"
-        };
-
-        var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TestTenantInfo>>();
-        accessor.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
-
-        var options = sp.GetRequiredService<IOptions<CookieAuthenticationOptions>>();
-
-        // The string __tenant__ should be replaced with the identifier.
-        Assert.Equal(ti1.CookieLoginPath.Replace("__tenant__", ti1.Identifier), options.Value.LoginPath);
-        Assert.Equal(ti1.CookieLogoutPath.Replace("__tenant__", ti1.Identifier), options.Value.LogoutPath);
-        Assert.Equal(ti1.CookieAccessDeniedPath.Replace("__tenant__", ti1.Identifier), options.Value.AccessDeniedPath);
-        Assert.Equal(ti1.CookiePath.Replace("__tenant__", ti1.Identifier), options.Value.Cookie.Path);
     }
 
     [Fact]

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
@@ -34,6 +34,7 @@ public partial class MultiTenantBuilderExtensionsShould
     {
         var services = new ServiceCollection();
         services.AddAuthentication();
+        services.AddLogging();
         services.AddMultiTenant<TestTenantInfo>()
                 .WithPerTenantAuthentication();
 

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/RemoteAuthenticationCallbackStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/RemoteAuthenticationCallbackStrategyShould.cs
@@ -22,7 +22,7 @@ public class RemoteAuthenticationCallbackStrategyShould
     [Fact]
     public void HavePriorityNeg900()
     {
-        var strategy = new RemoteAuthenticationCallbackStrategy();
+        var strategy = new RemoteAuthenticationCallbackStrategy(null);
         Assert.Equal(-900, strategy.Priority);
     }
 }


### PR DESCRIPTION
Adjusts PerTenantAuthentication in a few ways:

- Fixes a bug in 'MultiTenantAuthenticationService' when `MultiTenantContext` is `null`.
- Removes per-tenant cookie names as a part of `WithPerTenantAuthentication`
- Adds logic to add `__tenant__` claim to cookie on signin and validation that this claim matches the current tenant on authentication.
- Adjusts `ClaimStrategy` to not rely on `HttpContext.Users`.
- Updated samples and tests.