### PR TITLE
Entity is multi-tenant if ancestor is multi-tenant

### DIFF
--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeExtensions.cs
@@ -25,7 +25,15 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
         /// <returns><see cref="true"/> if the entity type has MultiTenant configuration, <see cref="false"/> if not.</returns>
         public static bool IsMultiTenant(this IEntityType entityType)
         {
-            return (bool?)entityType.FindAnnotation(Constants.MultiTenantAnnotationName)?.Value ?? false;
+            while (entityType != null)
+            {
+                var hastMultiTenantAnnotation = (bool?) entityType.FindAnnotation(Constants.MultiTenantAnnotationName)?.Value ?? false;
+                if (hastMultiTenantAnnotation)
+                    return true;
+                entityType = entityType.BaseType;
+            }
+
+            return false;
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/EntityTypeExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/EntityTypeExtensionsShould.cs
@@ -34,6 +34,7 @@ namespace EntityTypeExtensionsShould
         protected override void OnModelCreating(ModelBuilder builder)
         {
             builder.Entity<MyMultiTenantThing>().IsMultiTenant();
+            builder.Entity<MyMultiTenantChildThing>();
         }
     }
 
@@ -45,6 +46,11 @@ namespace EntityTypeExtensionsShould
     public class MyThing
     {
         public int Id { get; set; }
+    }
+
+    public class MyMultiTenantChildThing : MyMultiTenantThing
+    {
+        
     }
 
     public class EntityTypeExtensionShould
@@ -64,6 +70,14 @@ namespace EntityTypeExtensionsShould
             var db = GetDbContext();
 
             Assert.True(db.Model.FindEntityType(typeof(MyMultiTenantThing)).IsMultiTenant());
+        }
+        
+        [Fact]
+        public void ReturnTrueOnIsMultiTenantOnIfAncestorIsMultiTenant()
+        {
+            var db = GetDbContext();
+
+            Assert.True(db.Model.FindEntityType(typeof(MyMultiTenantChildThing)).IsMultiTenant());
         }
 
         [Fact]


### PR DESCRIPTION
When using inheritance an entity in EF should be considered multi tenant if any of it's ancestors  is multi tenant.

This PR fixes this case and adds tests for it.