### PR TITLE
refactor: efcore multitenant filter improvement

### DIFF
--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -16,6 +16,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Finbuckle.MultiTenant.EntityFrameworkCore
 {
@@ -26,10 +27,25 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
         /// </summary>
         public static ModelBuilder ConfigureMultiTenant(this ModelBuilder modelBuilder)
         {
-            // Annotate the types marked with the MultiTenant Data Attribute
+            // Call IsMultiTenant() to configure the types marked with the MultiTenant Data Attribute
             foreach (var t in modelBuilder.Model.GetEntityTypes().Where(t => t.ClrType.HasMultiTenantAttribute()))
             {
-                modelBuilder.Entity(t.ClrType).IsMultiTenant();
+                var entityMi = modelBuilder.GetType()
+                                           .GetMethods()
+                                           .Where(m => m.Name == "Entity"
+                                                       && m.IsGenericMethod
+                                                       && m.ReturnType.IsGenericType
+                                                       && typeof(EntityTypeBuilder).IsAssignableFrom(m.ReturnType))
+                                           .Single()
+                                           .MakeGenericMethod(t.ClrType);
+                                                 
+                var typedBuilder = entityMi.Invoke(modelBuilder, null);
+
+                var isMultiTenantMi = typeof(FinbuckleEntityTypeBuilderExtensions).GetMethods()
+                                                                                  .Where(m => m.Name == nameof(FinbuckleEntityTypeBuilderExtensions.IsMultiTenant))
+                                                                                  .Single()
+                                                                                  .MakeGenericMethod(t.ClrType);
+                isMultiTenantMi.Invoke(null, new[] { typedBuilder } );
             }
 
             return modelBuilder;

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Finbuckle.MultiTenant
 {

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/EntityTypeBuilderExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/EntityTypeBuilderExtensionsShould.cs
@@ -39,6 +39,7 @@ namespace EntityTypeBuilderExtensionsShould
         DbSet<MyMultiTenantThing> MyMultiTenantThing { get; set; }
         DbSet<MyThingWithTenantId> MyThingWithTenantId { get; set; }
         DbSet<MyThingWithIntTenantId> MyThingWithIntTenantId { get; set; }
+        DbSet<MyMultiTenantThingWithAttribute> MyMultiTenantThingWithAttribute { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -51,10 +52,19 @@ namespace EntityTypeBuilderExtensionsShould
                 builder.Entity<MyMultiTenantThing>().IsMultiTenant();
                 builder.Entity<MyThingWithTenantId>().IsMultiTenant();
             }
+
+            // for MyMultiTenantThingWithAttribute
+            builder.ConfigureMultiTenant();
         }
     }
 
     public class MyMultiTenantThing
+    {
+        public int Id { get; set; }
+    }
+
+    [MultiTenant]
+    public class MyMultiTenantThingWithAttribute
     {
         public int Id { get; set; }
     }
@@ -86,7 +96,7 @@ namespace EntityTypeBuilderExtensionsShould
             var connection = new SqliteConnection("DataSource=:memory:");
             var options = new DbContextOptionsBuilder()
                 .UseSqlite(connection)
-                .ReplaceService<IModelCacheKeyFactory, DynamicModelCacheKeyFactory>()
+                .ReplaceService<IModelCacheKeyFactory, DynamicModelCacheKeyFactory>() // needed for testing only
                 .Options;
 
             var db = new TestDbContext(config, options);
@@ -179,7 +189,7 @@ namespace EntityTypeBuilderExtensionsShould
                     Id = "abc",
                     Identifier = "abc",
                     Name = "abc",
-                    ConnectionString = "DataSource=testdb.db"
+                    ConnectionString = "DataSource=testDb.db"
                 };
 
                 using (var db = new TestBlogDbContext(tenant1, options))
@@ -199,7 +209,7 @@ namespace EntityTypeBuilderExtensionsShould
                     Id = "123",
                     Identifier = "123",
                     Name = "123",
-                    ConnectionString = "DataSource=testdb.db"
+                    ConnectionString = "DataSource=testDb.db"
                 };
                 using (var db = new TestBlogDbContext(tenant2, options))
                 {
@@ -244,7 +254,7 @@ namespace EntityTypeBuilderExtensionsShould
                     Id = "abc",
                     Identifier = "abc",
                     Name = "abc",
-                    ConnectionString = "DataSource=testdb.db"
+                    ConnectionString = "DataSource=testDb.db"
                 };
 
                 using (var db = new TestDbContextWithExistingGlobalFilter(tenant1, options))
@@ -286,7 +296,7 @@ namespace EntityTypeBuilderExtensionsShould
                 Id = "abc",
                 Identifier = "abc",
                 Name = "abc",
-                ConnectionString = "DataSource=testdb.db"
+                ConnectionString = "DataSource=testDb.db"
             };
 
             using (var c = GetTestIdentityDbContext(tenant1))
@@ -309,7 +319,7 @@ namespace EntityTypeBuilderExtensionsShould
                 Id = "abc",
                 Identifier = "abc",
                 Name = "abc",
-                ConnectionString = "DataSource=testdb.db"
+                ConnectionString = "DataSource=testDb.db"
             };
 
             using (var c = GetTestIdentityDbContext(tenant1))
@@ -326,7 +336,7 @@ namespace EntityTypeBuilderExtensionsShould
                 Id = "abc",
                 Identifier = "abc",
                 Name = "abc",
-                ConnectionString = "DataSource=testdb.db"
+                ConnectionString = "DataSource=testDb.db"
             };
 
             using (var c = GetTestIdentityDbContext(tenant1))
@@ -350,7 +360,7 @@ namespace EntityTypeBuilderExtensionsShould
                 Id = "abc",
                 Identifier = "abc",
                 Name = "abc",
-                ConnectionString = "DataSource=testdb.db"
+                ConnectionString = "DataSource=testDb.db"
             };
 
             using (var c = GetTestIdentityDbContext(tenant1))


### PR DESCRIPTION
This change refactors how the global query filter for the `TenantId` field works on entities. In general calls to `IsMultiTenant()` in `OnModelCreating` use much less manual expression tree building. All applicable unit tests also improved to test use cases with [MultiTenant] attribute in addition to `IsMultiTenant()`.