### PR TITLE
chore: update docs for removed Index property

### DIFF
--- a/docs/CoreConcepts.md
+++ b/docs/CoreConcepts.md
@@ -18,6 +18,10 @@ Contains information about a tenant. Usually an app will get the current `Tenant
 * `Name` is a display name for the tenant.
 * `ConnectionString` is a connection string that should be used for database operations for this tenant. It might connect to a shared database or a dedicated database for the single tenant.
 
+> Note: Finbuckle.MultiTenant versions prior to v6.0.0 had an `Items` dictioanry
+> property for custom data. This was removed in favor of custom `ITenantInfo`
+> support where custom data can simply be made properties of the implementation.
+
 `TenantInfo` is a basic implementation of `ITenantInfo` with only the required properties.
 An app can define a custom `ITenantInfo` and add any other needed properties.
 When calling `AddMultiTenant<T>` the type passed into the type parameter defines the

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -118,6 +118,12 @@ services.AddMultiTenant<TenantInfo>()
 
 The configuration section should use this JSON format shown below. Any fields in the `Defaults` section will be automatically copied into each tenant unless the tenant specifies its own value. For a custom implementation of `ITenantInfo` properties are mapped from the JSON automatically.
 
+> Note: Finbuckle.MultiTenant versions prior to 6.0 had an `Index` collection
+> property to store custom data. This was removed because custom `ITenantInfo`
+> implementations can use normal properties for custom data. Older examples
+> might show an `Index` sub-object in the configuration json that may not be
+> applicable.
+
 ```json
 {
   "Finbuckle:MultiTenant:Stores:ConfigurationStore": {
@@ -128,7 +134,7 @@ The configuration section should use this JSON format shown below. Any fields in
       {
         "Id": "unique-id-0ff4adaf",
         "Identifier": "tenant-1",
-        "Name": "Tenant 1 Company Name"
+        "Name": "Tenant 1 Company Name",
         "ACustomProperty": "VIP Customer"
       },
       {


### PR DESCRIPTION
Per #362 it should be made clearer that Index
was removed from ITenantInfo.