### PR TITLE
feat: optional default tenant config

### DIFF
--- a/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
@@ -24,7 +24,7 @@ namespace Finbuckle.MultiTenant.Stores
 {
     public class ConfigurationStore<TTenantInfo> : IMultiTenantStore<TTenantInfo> where TTenantInfo : class, ITenantInfo, new()
     {
-        internal static readonly string defaultSectionName = "Finbuckle:MultiTenant:Stores:ConfigurationStore";
+        private static readonly string defaultSectionName = "Finbuckle:MultiTenant:Stores:ConfigurationStore";
         private readonly IConfigurationSection section;
         private ConcurrentDictionary<string, TTenantInfo> tenantMap;
 
@@ -61,7 +61,7 @@ namespace Finbuckle.MultiTenant.Stores
 
             foreach(var tenantSection in tenants)
             {
-                var newTenant = section.GetSection("Defaults").Get<TTenantInfo>((options => options.BindNonPublicProperties = true));
+                var newTenant = section.GetSection("Defaults").Get<TTenantInfo>((options => options.BindNonPublicProperties = true)) ?? new TTenantInfo();
                 tenantSection.Bind(newTenant, options => options.BindNonPublicProperties = true);
                 newMap.TryAdd(newTenant.Identifier, newTenant);
             }

--- a/test/Finbuckle.MultiTenant.Test/ConfigurationStoreTestSettings_NoDefaults.json
+++ b/test/Finbuckle.MultiTenant.Test/ConfigurationStoreTestSettings_NoDefaults.json
@@ -1,13 +1,11 @@
 ﻿{
   "Finbuckle:MultiTenant:Stores:ConfigurationStore": {
-    "Defaults": {
-      "ConnectionString": "Datasource=sample.db"
-    },
     "Tenants": [
       {
         "Id":  "initech-id",
         "Identifier": "initech",
-        "Name": "Initech"
+        "Name": "Initech",
+        "ConnectionString": "Datasource=sample.db"
       },
       {
         "Id": "lol-id",

--- a/test/Finbuckle.MultiTenant.Test/Stores/ConfigurationStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/ConfigurationStoreShould.cs
@@ -22,6 +22,17 @@ using Xunit;
 public class ConfigurationStoreShould : IMultiTenantStoreTestBase<ConfigurationStore<TenantInfo>>
 {
     [Fact]
+    public void NotThrowIfNoDefaultSection()
+    {
+        // See https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/426
+        var configBuilder = new ConfigurationBuilder();
+        configBuilder.AddJsonFile("ConfigurationStoreTestSettings_NoDefaults.json");
+        IConfiguration configuration = configBuilder.Build();
+        
+        var store = new ConfigurationStore<TenantInfo>(configuration);
+    }
+    
+    [Fact]
     public void ThrowIfNullConfiguration()
     {
         Assert.Throws<ArgumentNullException>(() => new ConfigurationStore<TenantInfo>(null));


### PR DESCRIPTION
ConfigurationStore does not require a defaults section.

closes #426