### PR TITLE
fix: ClaimStrategy bypass cookie validation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,6 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PackageTags>finbuckle;multitenant;multitenancy;aspnet;aspnetcore;entityframework;entityframework-core;efcore</PackageTags>
         <PackageIcon>finbuckle-128x128.png</PackageIcon>
-        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PackageTags>finbuckle;multitenant;multitenancy;aspnet;aspnetcore;entityframework;entityframework-core;efcore</PackageTags>
         <PackageIcon>finbuckle-128x128.png</PackageIcon>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/ClaimStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/ClaimStrategy.cs
@@ -9,13 +9,20 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
+// ReSharper disable once CheckNamespace
 namespace Finbuckle.MultiTenant.Strategies
 {
+	// ReSharper disable once ClassNeverInstantiated.Global
 	public class ClaimStrategy : IMultiTenantStrategy
 	{
 		private readonly string _tenantKey;
 		private readonly string _authenticationScheme;
-		public ClaimStrategy(string template, string authenticationScheme = null)
+
+		public ClaimStrategy(string template) : this(template, null)
+		{
+		}
+		
+		public ClaimStrategy(string template, string authenticationScheme)
 		{
 			if (string.IsNullOrWhiteSpace(template))
 				throw new ArgumentException(nameof(template));
@@ -26,30 +33,33 @@ namespace Finbuckle.MultiTenant.Strategies
 
 		public async Task<string> GetIdentifierAsync(object context)
 		{
-			if (!(context is HttpContext httpContext))
+			if (context is not HttpContext httpContext)
 				throw new MultiTenantException(null, new ArgumentException($@"""{nameof(context)}"" type must be of type HttpContext", nameof(context)));
 
-			if (!httpContext.User.Identity.IsAuthenticated)
+			if (httpContext.User.Identity is { IsAuthenticated: true })
+				return httpContext.User.FindFirst(_tenantKey)?.Value;
+			
+			AuthenticationScheme authScheme;
+			var schemeProvider = httpContext.RequestServices.GetRequiredService<IAuthenticationSchemeProvider>();
+			if (_authenticationScheme is null)
 			{
-				AuthenticationScheme authScheme;
-				var schemeProvider = httpContext.RequestServices.GetRequiredService<IAuthenticationSchemeProvider>();
-				if (_authenticationScheme is null)
-				{
-					authScheme = await schemeProvider.GetDefaultAuthenticateSchemeAsync();
-				}
-				else
-				{
-					authScheme = (await schemeProvider.GetAllSchemesAsync()).FirstOrDefault(x => x.Name == _authenticationScheme);
-				}
-
-				var handler = (IAuthenticationHandler)ActivatorUtilities.CreateInstance(httpContext.RequestServices, authScheme.HandlerType);
-				await handler.InitializeAsync(authScheme, httpContext);
-				httpContext.Items[$"{Constants.TenantToken}__bypass_validate_principle__"] = "true"; // Value doesn't matter.
-				var handlerResult = await handler.AuthenticateAsync();
-				httpContext.Items.Remove($"{Constants.TenantToken}__bypass_validate_principle__");
+				authScheme = await schemeProvider.GetDefaultAuthenticateSchemeAsync();
+			}
+			else
+			{
+				authScheme = (await schemeProvider.GetAllSchemesAsync()).FirstOrDefault(x => x.Name == _authenticationScheme);
 			}
 
-			var identifier = httpContext.User.FindFirst(_tenantKey)?.Value;
+			if (authScheme is null)
+				throw new NullReferenceException("No authentication scheme found.");
+			
+			var handler = (IAuthenticationHandler)ActivatorUtilities.CreateInstance(httpContext.RequestServices, authScheme.HandlerType);
+			await handler.InitializeAsync(authScheme, httpContext);
+			httpContext.Items[$"{Constants.TenantToken}__bypass_validate_principle__"] = "true"; // Value doesn't matter.
+			var handlerResult = await handler.AuthenticateAsync();
+			httpContext.Items.Remove($"{Constants.TenantToken}__bypass_validate_principle__");
+
+			var identifier = handlerResult.Principal?.FindFirst(_tenantKey)?.Value;
 			return await Task.FromResult(identifier);
 		}
 	}

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/ClaimStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/ClaimStrategy.cs
@@ -33,7 +33,7 @@ namespace Finbuckle.MultiTenant.Strategies
 
 		public async Task<string> GetIdentifierAsync(object context)
 		{
-			if (context is not HttpContext httpContext)
+			if (!(context is HttpContext httpContext))
 				throw new MultiTenantException(null, new ArgumentException($@"""{nameof(context)}"" type must be of type HttpContext", nameof(context)));
 
 			if (httpContext.User.Identity is { IsAuthenticated: true })

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/FinbuckleMultiTenantBuilderExtensionsEntityFrameworkCore.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/FinbuckleMultiTenantBuilderExtensionsEntityFrameworkCore.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds an EFCore based multitenant store to the application. Will also add the database context service unless it is already added.
         /// </summary>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
+        // ReSharper disable once InconsistentNaming
         public static FinbuckleMultiTenantBuilder<TTenantInfo> WithEFCoreStore<TEFCoreStoreDbContext, TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
             where TEFCoreStoreDbContext : EFCoreStoreDbContext<TTenantInfo>
             where TTenantInfo : class, ITenantInfo, new()


### PR DESCRIPTION
`ClaimStrategy` was only bypassing cookie authentication principal validation if `WithPerTenantAuthentication` was also used, but it should bypass regardless.