### PR TITLE
Add nullable reference types to the base project

### DIFF
--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContext.cs
@@ -6,8 +6,8 @@ namespace Finbuckle.MultiTenant
     public interface IMultiTenantContext<T>
         where T : class, ITenantInfo, new()
     {
-        T TenantInfo { get; set; }
-        StrategyInfo StrategyInfo { get; set; }
-        StoreInfo<T> StoreInfo { get; set; }
+        T? TenantInfo { get; set; }
+        StrategyInfo? StrategyInfo { get; set; }
+        StoreInfo<T>? StoreInfo { get; set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContextAccessor.cs
@@ -5,11 +5,11 @@ namespace Finbuckle.MultiTenant
 {
     public interface IMultiTenantContextAccessor
     {
-        object MultiTenantContext { get; set; }
+        object? MultiTenantContext { get; set; }
     }
 
     public interface IMultiTenantContextAccessor<T> where T : class, ITenantInfo, new()
     {
-        IMultiTenantContext<T> MultiTenantContext { get; set; }
+        IMultiTenantContext<T>? MultiTenantContext { get; set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantStore.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantStore.cs
@@ -37,14 +37,14 @@ namespace Finbuckle.MultiTenant
         /// </summary>
         /// <param name="identifier"></param>
         /// <returns></returns>
-        Task<TTenantInfo> TryGetByIdentifierAsync(string identifier);
+        Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier);
 
         /// <summary>
         /// Retrieve the TTenantInfo for a given tenant Id.
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        Task<TTenantInfo> TryGetAsync(string id);
+        Task<TTenantInfo?> TryGetAsync(string id);
 
 
         /// <summary>

--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantStrategy.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantStrategy.cs
@@ -15,7 +15,7 @@ namespace Finbuckle.MultiTenant
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        Task<string> GetIdentifierAsync(object context);
+        Task<string?> GetIdentifierAsync(object context);
         
         /// <summary>
         ///  Determines strategy execution order. Normally handled in the order registered.

--- a/src/Finbuckle.MultiTenant/Abstractions/ITenantInfo.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/ITenantInfo.cs
@@ -5,9 +5,9 @@ namespace Finbuckle.MultiTenant
 {
     public interface ITenantInfo
     {
-        string Id { get; set; }
-        string Identifier { get; set;  }
-        string Name { get; set; }
-        string ConnectionString { get; set; }
+        string? Id { get; set; }
+        string? Identifier { get; set;  }
+        string? Name { get; set; }
+        string? ConnectionString { get; set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/Abstractions/ITenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/ITenantResolver.cs
@@ -8,15 +8,17 @@ namespace Finbuckle.MultiTenant
 {
     public interface ITenantResolver
     {
-        Task<object> ResolveAsync(object context);
+        Task<object?> ResolveAsync(object context);
     }
 
     public interface ITenantResolver<T>
         where T : class, ITenantInfo, new()
     {
+        // TODO: Look into this - I think it will never be null.
         IEnumerable<IMultiTenantStrategy> Strategies { get; }
+        // TODO: Look into this - I think it will never be null.
         IEnumerable<IMultiTenantStore<T>> Stores { get; }
         
-        Task<IMultiTenantContext<T>> ResolveAsync(object context);
+        Task<IMultiTenantContext<T>?> ResolveAsync(object context);
     }
 }

--- a/src/Finbuckle.MultiTenant/Abstractions/ITenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/ITenantResolver.cs
@@ -14,11 +14,9 @@ namespace Finbuckle.MultiTenant
     public interface ITenantResolver<T>
         where T : class, ITenantInfo, new()
     {
-        // TODO: Look into this - I think it will never be null.
         IEnumerable<IMultiTenantStrategy> Strategies { get; }
-        // TODO: Look into this - I think it will never be null.
         IEnumerable<IMultiTenantStore<T>> Stores { get; }
-        
+
         Task<IMultiTenantContext<T>?> ResolveAsync(object context);
     }
 }

--- a/src/Finbuckle.MultiTenant/Events/TenantNotFoundContext.cs
+++ b/src/Finbuckle.MultiTenant/Events/TenantNotFoundContext.cs
@@ -5,7 +5,7 @@ namespace Finbuckle.MultiTenant
 {
     public class TenantNotResolvedContext
     {
-        public object Context { get; set; }
-        public string Identifier { get; set; }
+        public object? Context { get; set; }
+        public string? Identifier { get; set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/Events/TenantResolvedContext.cs
+++ b/src/Finbuckle.MultiTenant/Events/TenantResolvedContext.cs
@@ -5,7 +5,7 @@ namespace Finbuckle.MultiTenant
 {
     public class TenantResolvedContext
     {
-        public object Context { get; set; }
-        public ITenantInfo TenantInfo { get; set; }
+        public object? Context { get; set; }
+        public ITenantInfo? TenantInfo { get; set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Extensions.DependencyInjection
         public static FinbuckleMultiTenantBuilder<TTenantInfo> WithDistributedCacheStore<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder, TimeSpan? slidingExpiration)
             where TTenantInfo : class, ITenantInfo, new()
         {
-            return builder.WithStore<DistributedCacheStore<TTenantInfo>>(ServiceLifetime.Transient, Constants.TenantToken, slidingExpiration);
+            var storeParams = slidingExpiration is null ? new object[] { Constants.TenantToken } : new object[] { Constants.TenantToken, slidingExpiration };
+
+            return builder.WithStore<DistributedCacheStore<TTenantInfo>>(ServiceLifetime.Transient, storeParams);
         }
 
         /// <summary>
@@ -53,10 +55,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="clientConfig">An action to configure the underlying HttpClient.</param>
         public static FinbuckleMultiTenantBuilder<TTenantInfo> WithHttpRemoteStore<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder,
                                                                                                 string endpointTemplate,
-                                                                                                Action<IHttpClientBuilder> clientConfig) where TTenantInfo : class, ITenantInfo, new()
+                                                                                                Action<IHttpClientBuilder>? clientConfig) where TTenantInfo : class, ITenantInfo, new()
         {
-            var httpClientBuilder = builder.Services.AddHttpClient(typeof(HttpRemoteStoreClient<TTenantInfo>).FullName);
-            if (clientConfig != null)
+            var httpClientBuilder = builder.Services.AddHttpClient(typeof(HttpRemoteStoreClient<TTenantInfo>).FullName!);
+            if (clientConfig != null && httpClientBuilder != null)
                 clientConfig(httpClientBuilder);
 
             builder.Services.TryAddSingleton<HttpRemoteStoreClient<TTenantInfo>>();

--- a/src/Finbuckle.MultiTenant/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a DistributedCacheStore to the application.
         /// </summary>
         public static FinbuckleMultiTenantBuilder<TTenantInfo> WithDistributedCacheStore<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
-            where TTenantInfo : class, ITenantInfo, new()   
+            where TTenantInfo : class, ITenantInfo, new()
             => builder.WithDistributedCacheStore(TimeSpan.MaxValue);
-        
+
 
         /// <summary>
         /// Adds a DistributedCacheStore to the application.
@@ -121,10 +121,10 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (string.IsNullOrWhiteSpace(identifier))
             {
-                throw new ArgumentException("Invalid value for \"identifier\"", nameof(identifier));
+                throw new ArgumentNullException(nameof(identifier), "Invalid value for \"identifier\"");
             }
 
-            return builder.WithStrategy<StaticStrategy>(ServiceLifetime.Singleton, new object[] { identifier }); ;
+            return builder.WithStrategy<StaticStrategy>(ServiceLifetime.Singleton, new object[] { identifier });
         }
 
         /// <summary>

--- a/src/Finbuckle.MultiTenant/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Finbuckle.MultiTenant/Extensions/ServiceCollectionExtensions.cs
@@ -22,16 +22,16 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<ITenantResolver<T>, TenantResolver<T>>();
             services.AddScoped<ITenantResolver>(sp => (ITenantResolver)sp.GetRequiredService<ITenantResolver<T>>());
 
-            services.AddScoped<IMultiTenantContext<T>>(sp => sp.GetRequiredService<IMultiTenantContextAccessor<T>>().MultiTenantContext);
-            
-            services.AddScoped<T>(sp => sp.GetRequiredService<IMultiTenantContextAccessor<T>>().MultiTenantContext?.TenantInfo);
-            services.AddScoped<ITenantInfo>(sp => sp.GetService<T>());
-            
+            services.AddScoped<IMultiTenantContext<T>>(sp => sp.GetRequiredService<IMultiTenantContextAccessor<T>>().MultiTenantContext!);
+
+            services.AddScoped<T>(sp => sp.GetRequiredService<IMultiTenantContextAccessor<T>>().MultiTenantContext?.TenantInfo!);
+            services.AddScoped<ITenantInfo>(sp => sp.GetService<T>()!);
+
             services.AddSingleton<IMultiTenantContextAccessor<T>, MultiTenantContextAccessor<T>>();
             services.AddSingleton<IMultiTenantContextAccessor>(sp => (IMultiTenantContextAccessor)sp.GetRequiredService<IMultiTenantContextAccessor<T>>());
-            
+
             services.Configure<MultiTenantOptions>(config);
-            
+
             return new FinbuckleMultiTenantBuilder<T>(services);
         }
 
@@ -55,13 +55,13 @@ namespace Microsoft.Extensions.DependencyInjection
             var newService = new ServiceDescriptor(existingService.ServiceType,
                                            sp =>
                                            {
-                                               TService inner = (TService)ActivatorUtilities.CreateInstance(sp, existingService.ImplementationType);
+                                               TService inner = (TService)ActivatorUtilities.CreateInstance(sp, existingService.ImplementationType!);
 
                                                var parameters2 = new object[parameters.Length + 1];
                                                Array.Copy(parameters, 0, parameters2, 1, parameters.Length);
                                                parameters2[0] = inner;
 
-                                               return ActivatorUtilities.CreateInstance<TImpl>(sp, parameters2);
+                                               return ActivatorUtilities.CreateInstance<TImpl>(sp, parameters2)!;
                                            },
                                            existingService.Lifetime);
 
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.DependencyInjection
                                            sp =>
                                            {
                                                TService inner = (TService)existingService.ImplementationInstance;
-                                               return ActivatorUtilities.CreateInstance<TImpl>(sp, inner, parameters);
+                                               return ActivatorUtilities.CreateInstance<TImpl>(sp, inner, parameters)!;
                                            },
                                            existingService.Lifetime);
             }
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection
                                            sp =>
                                            {
                                                TService inner = (TService)existingService.ImplementationFactory(sp);
-                                               return ActivatorUtilities.CreateInstance<TImpl>(sp, inner, parameters);
+                                               return ActivatorUtilities.CreateInstance<TImpl>(sp, inner, parameters)!;
                                            },
                                            existingService.Lifetime);
             }

--- a/src/Finbuckle.MultiTenant/Extensions/TypeExtensions.cs
+++ b/src/Finbuckle.MultiTenant/Extensions/TypeExtensions.cs
@@ -16,7 +16,7 @@ namespace Finbuckle.MultiTenant
                 return source.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == unboundGeneric);
             }
 
-            Type toCheck = source;
+            Type? toCheck = source;
 
             if (unboundGeneric != toCheck)
             {

--- a/src/Finbuckle.MultiTenant/Finbuckle.MultiTenant.csproj
+++ b/src/Finbuckle.MultiTenant/Finbuckle.MultiTenant.csproj
@@ -4,6 +4,7 @@
         <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
         <Title>Finbuckle.MultiTenant</Title>
         <Description>Main library package for Finbuckle.MultiTenant.</Description>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Finbuckle.MultiTenant/Internal/MultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant/Internal/MultiTenantContextAccessor.cs
@@ -11,7 +11,7 @@ namespace Finbuckle.MultiTenant.Core
         internal static AsyncLocal<IMultiTenantContext<T>?> _asyncLocalContext = new AsyncLocal<IMultiTenantContext<T>?>();
 
         public IMultiTenantContext<T>? MultiTenantContext
-        { 
+        {
             get
             {
                 return _asyncLocalContext.Value;

--- a/src/Finbuckle.MultiTenant/Internal/MultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant/Internal/MultiTenantContextAccessor.cs
@@ -8,9 +8,9 @@ namespace Finbuckle.MultiTenant.Core
     public class MultiTenantContextAccessor<T> : IMultiTenantContextAccessor<T>, IMultiTenantContextAccessor
         where T : class, ITenantInfo, new()
     {
-        internal static AsyncLocal<IMultiTenantContext<T>> _asyncLocalContext = new AsyncLocal<IMultiTenantContext<T>>();
+        internal static AsyncLocal<IMultiTenantContext<T>?> _asyncLocalContext = new AsyncLocal<IMultiTenantContext<T>?>();
 
-        public IMultiTenantContext<T> MultiTenantContext
+        public IMultiTenantContext<T>? MultiTenantContext
         { 
             get
             {
@@ -23,7 +23,7 @@ namespace Finbuckle.MultiTenant.Core
             }
         }
 
-        object IMultiTenantContextAccessor.MultiTenantContext
+        object? IMultiTenantContextAccessor.MultiTenantContext
         {
             get => MultiTenantContext;
             set => MultiTenantContext = value as IMultiTenantContext<T> ?? MultiTenantContext;

--- a/src/Finbuckle.MultiTenant/MultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant/MultiTenantContext.cs
@@ -9,8 +9,8 @@ namespace Finbuckle.MultiTenant
     public class MultiTenantContext<T> : IMultiTenantContext<T>
         where T : class, ITenantInfo, new()
     {
-        public T TenantInfo { get; set; }
-        public StrategyInfo StrategyInfo { get; set; }
-        public StoreInfo<T> StoreInfo { get; set; }
+        public T? TenantInfo { get; set; }
+        public StrategyInfo? StrategyInfo { get; set; }
+        public StoreInfo<T>? StoreInfo { get; set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/MultiTenantException.cs
+++ b/src/Finbuckle.MultiTenant/MultiTenantException.cs
@@ -10,7 +10,12 @@ namespace Finbuckle.MultiTenant
     /// </summary>
     public class MultiTenantException : Exception
     {
-        public MultiTenantException(string message, Exception innerException = null)
-            : base(message, innerException) { }
+        public MultiTenantException(string? message) : base(message)
+        {
+        }
+
+        public MultiTenantException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
     }
 }

--- a/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsFactory.cs
+++ b/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsFactory.cs
@@ -5,7 +5,6 @@
 //    https://github.com/dotnet/runtime/blob/5aad989cebe00f0987fcb842ea5b7cbe986c67df/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
 
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.Options;
 
 namespace Finbuckle.MultiTenant.Options
@@ -34,7 +33,7 @@ namespace Finbuckle.MultiTenant.Options
             // by checking for an array and enumerate over that, so we don't need to allocate an enumerator.
             // When it isn't already an array, convert it to one, but don't use System.Linq to avoid pulling Linq in to
             // small trimmed applications.
-            
+
             _configureOptions = configureOptions as IConfigureOptions<TOptions>[] ?? new List<IConfigureOptions<TOptions>>(configureOptions).ToArray();
             _postConfigureOptions = postConfigureOptions as IPostConfigureOptions<TOptions>[] ?? new List<IPostConfigureOptions<TOptions>>(postConfigureOptions).ToArray();
             _validations = validations as IValidateOptions<TOptions>[] ?? new List<IValidateOptions<TOptions>>(validations).ToArray();
@@ -68,7 +67,7 @@ namespace Finbuckle.MultiTenant.Options
             {
                 post.PostConfigure(name, options);
             }
-            
+
             if (_validations.Length > 0)
             {
                 var failures = new List<string>();
@@ -85,7 +84,7 @@ namespace Finbuckle.MultiTenant.Options
                     throw new OptionsValidationException(name, typeof(TOptions), failures);
                 }
             }
-            
+
             return options;
         }
     }

--- a/src/Finbuckle.MultiTenant/StoreInfo.cs
+++ b/src/Finbuckle.MultiTenant/StoreInfo.cs
@@ -7,7 +7,8 @@ namespace Finbuckle.MultiTenant
 {
     public class StoreInfo<TTenantInfo> where TTenantInfo : class, ITenantInfo, new()
     {
-        public Type StoreType { get; internal set; }
-        public IMultiTenantStore<TTenantInfo> Store { get; internal set; }
+        // TODO: Should these be null?
+        public Type? StoreType { get; internal set; }
+        public IMultiTenantStore<TTenantInfo>? Store { get; internal set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/StoreInfo.cs
+++ b/src/Finbuckle.MultiTenant/StoreInfo.cs
@@ -7,7 +7,6 @@ namespace Finbuckle.MultiTenant
 {
     public class StoreInfo<TTenantInfo> where TTenantInfo : class, ITenantInfo, new()
     {
-        // TODO: Should these be null?
         public Type? StoreType { get; internal set; }
         public IMultiTenantStore<TTenantInfo>? Store { get; internal set; }
     }

--- a/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
@@ -53,10 +53,8 @@ namespace Finbuckle.MultiTenant.Stores
                 var newTenant = section.GetSection("Defaults").Get<TTenantInfo>(options => options.BindNonPublicProperties = true) ?? new TTenantInfo();
                 tenantSection.Bind(newTenant, options => options.BindNonPublicProperties = true);
 
-                if (newTenant.Identifier != null)
-                {
-                    newMap.TryAdd(newTenant.Identifier, newTenant);
-                }
+                // Throws an ArgumentNullException if the identifier is null.
+                newMap.TryAdd(newTenant.Identifier!, newTenant);
             }
 
             tenantMap = newMap;

--- a/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
@@ -13,7 +13,7 @@ namespace Finbuckle.MultiTenant.Stores
 {
     public class ConfigurationStore<TTenantInfo> : IMultiTenantStore<TTenantInfo> where TTenantInfo : class, ITenantInfo, new()
     {
-        private static readonly string defaultSectionName = "Finbuckle:MultiTenant:Stores:ConfigurationStore";
+        private const string defaultSectionName = "Finbuckle:MultiTenant:Stores:ConfigurationStore";
         private readonly IConfigurationSection section;
         private ConcurrentDictionary<string, TTenantInfo>? tenantMap;
 
@@ -97,7 +97,7 @@ namespace Finbuckle.MultiTenant.Stores
             return await Task.FromResult(tenantMap.TryGetValue(identifier, out var result) ? result : null);
         }
 
-        public Task<bool> TryRemoveAsync(string id)
+        public Task<bool> TryRemoveAsync(string identifier)
         {
             throw new NotImplementedException();
         }

--- a/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
@@ -15,7 +15,7 @@ namespace Finbuckle.MultiTenant.Stores
     {
         private static readonly string defaultSectionName = "Finbuckle:MultiTenant:Stores:ConfigurationStore";
         private readonly IConfigurationSection section;
-        private ConcurrentDictionary<string, TTenantInfo> tenantMap;
+        private ConcurrentDictionary<string, TTenantInfo>? tenantMap;
 
         public ConfigurationStore(IConfiguration configuration) : this(configuration, defaultSectionName)
         {
@@ -50,12 +50,11 @@ namespace Finbuckle.MultiTenant.Stores
 
             foreach(var tenantSection in tenants)
             {
-                var newTenant = section.GetSection("Defaults").Get<TTenantInfo>((options => options.BindNonPublicProperties = true)) ?? new TTenantInfo();
+                var newTenant = section.GetSection("Defaults").Get<TTenantInfo>(options => options.BindNonPublicProperties = true) ?? new TTenantInfo();
                 tenantSection.Bind(newTenant, options => options.BindNonPublicProperties = true);
                 newMap.TryAdd(newTenant.Identifier, newTenant);
             }
 
-            var oldMap = tenantMap;
             tenantMap = newMap;
         }
 

--- a/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/ConfigurationStore/ConfigurationStore.cs
@@ -52,7 +52,11 @@ namespace Finbuckle.MultiTenant.Stores
             {
                 var newTenant = section.GetSection("Defaults").Get<TTenantInfo>(options => options.BindNonPublicProperties = true) ?? new TTenantInfo();
                 tenantSection.Bind(newTenant, options => options.BindNonPublicProperties = true);
-                newMap.TryAdd(newTenant.Identifier, newTenant);
+
+                if (newTenant.Identifier != null)
+                {
+                    newMap.TryAdd(newTenant.Identifier, newTenant);
+                }
             }
 
             tenantMap = newMap;
@@ -63,26 +67,31 @@ namespace Finbuckle.MultiTenant.Stores
             throw new NotImplementedException();
         }
 
-        public async Task<TTenantInfo> TryGetAsync(string id)
+        public async Task<TTenantInfo?> TryGetAsync(string id)
         {
             if (id is null)
             {
                 throw new ArgumentNullException(nameof(id));
             }
 
-            return await Task.FromResult(tenantMap.Where(kv => kv.Value.Id == id).SingleOrDefault().Value);
+            return await Task.FromResult(tenantMap?.Where(kv => kv.Value.Id == id).SingleOrDefault().Value);
         }
 
         public async Task<IEnumerable<TTenantInfo>> GetAllAsync()
         {
-            return await Task.FromResult(tenantMap.Select(x => x.Value).ToList());
+            return await Task.FromResult(tenantMap?.Select(x => x.Value).ToList() ?? new List<TTenantInfo>());
         }
 
-        public async Task<TTenantInfo> TryGetByIdentifierAsync(string identifier)
+        public async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
         {
             if (identifier is null)
             {
                 throw new ArgumentNullException(nameof(identifier));
+            }
+
+            if (tenantMap is null)
+            {
+                return null;
             }
 
             return await Task.FromResult(tenantMap.TryGetValue(identifier, out var result) ? result : null);

--- a/src/Finbuckle.MultiTenant/Stores/DistributedCacheStore/DistributedCacheStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/DistributedCacheStore/DistributedCacheStore.cs
@@ -32,7 +32,7 @@ namespace Finbuckle.MultiTenant.Stores
             return true;
         }
 
-        public async Task<TTenantInfo> TryGetAsync(string id)
+        public async Task<TTenantInfo?> TryGetAsync(string id)
         {
             var bytes = await cache.GetStringAsync($"{keyPrefix}id__{id}");
             if (bytes == null)
@@ -51,7 +51,7 @@ namespace Finbuckle.MultiTenant.Stores
             throw new NotImplementedException();
         }
 
-        public async Task<TTenantInfo> TryGetByIdentifierAsync(string identifier)
+        public async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
         {
             var bytes = await cache.GetStringAsync($"{keyPrefix}identifier__{identifier}");
             if (bytes == null)

--- a/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStore.cs
@@ -41,7 +41,7 @@ namespace Finbuckle.MultiTenant.Stores
             throw new System.NotImplementedException();
         }
 
-        public Task<TTenantInfo> TryGetAsync(string id)
+        public Task<TTenantInfo?> TryGetAsync(string id)
         {
             throw new System.NotImplementedException();
         }
@@ -51,7 +51,7 @@ namespace Finbuckle.MultiTenant.Stores
 	        throw new NotImplementedException();
         }
 
-        public async Task<TTenantInfo> TryGetByIdentifierAsync(string identifier)
+        public async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
         {
             var result = await client.TryGetByIdentifierAsync(endpointTemplate, identifier);
             return result;

--- a/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStoreClient.cs
+++ b/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStoreClient.cs
@@ -19,7 +19,7 @@ namespace Finbuckle.MultiTenant.Stores
 
         public async Task<TTenantInfo?> TryGetByIdentifierAsync(string endpointTemplate, string identifier)
         {
-            var client = clientFactory.CreateClient(typeof(HttpRemoteStoreClient<TTenantInfo>).FullName);
+            var client = clientFactory.CreateClient(typeof(HttpRemoteStoreClient<TTenantInfo>).FullName!);
             var uri = endpointTemplate.Replace(HttpRemoteStore<TTenantInfo>.defaultEndpointTemplateIdentifierToken, identifier);
             var response = await client.GetAsync(uri);
 

--- a/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStoreClient.cs
+++ b/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStoreClient.cs
@@ -17,7 +17,7 @@ namespace Finbuckle.MultiTenant.Stores
             this.clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
         }
 
-        public async Task<TTenantInfo> TryGetByIdentifierAsync(string endpointTemplate, string identifier)
+        public async Task<TTenantInfo?> TryGetByIdentifierAsync(string endpointTemplate, string identifier)
         {
             var client = clientFactory.CreateClient(typeof(HttpRemoteStoreClient<TTenantInfo>).FullName);
             var uri = endpointTemplate.Replace(HttpRemoteStore<TTenantInfo>.defaultEndpointTemplateIdentifierToken, identifier);

--- a/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
@@ -59,8 +59,8 @@ namespace Finbuckle.MultiTenant.Stores
 
         public async Task<bool> TryAddAsync(TTenantInfo tenantInfo)
         {
-            var result = tenantInfo.Identifier != null
-                && tenantMap.TryAdd(tenantInfo.Identifier, tenantInfo);
+            // Throws an ArgumentNullException if the identifier is null.
+            var result = tenantMap.TryAdd(tenantInfo.Identifier!, tenantInfo);
 
             return await Task.FromResult(result);
         }

--- a/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
@@ -23,7 +23,7 @@ namespace Finbuckle.MultiTenant.Stores
             var stringComparer = StringComparer.OrdinalIgnoreCase;
             if(this.options.IsCaseSensitive)
                 stringComparer = StringComparer.Ordinal;
-            
+
             tenantMap = new ConcurrentDictionary<string, TTenantInfo>(stringComparer);
             foreach(var tenant in this.options.Tenants)
             {
@@ -41,14 +41,14 @@ namespace Finbuckle.MultiTenant.Stores
         public virtual async Task<TTenantInfo?> TryGetAsync(string id)
         {
             var result = tenantMap.Values.Where(ti => ti.Id == id).SingleOrDefault();
-            
+
             return await Task.FromResult(result);
         }
 
         public virtual async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
         {
             tenantMap.TryGetValue(identifier, out var result);
-            
+
             return await Task.FromResult(result);
         }
 

--- a/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
@@ -38,14 +38,14 @@ namespace Finbuckle.MultiTenant.Stores
             }
         }
 
-        public virtual async Task<TTenantInfo> TryGetAsync(string id)
+        public virtual async Task<TTenantInfo?> TryGetAsync(string id)
         {
             var result = tenantMap.Values.Where(ti => ti.Id == id).SingleOrDefault();
             
             return await Task.FromResult(result);
         }
 
-        public virtual async Task<TTenantInfo> TryGetByIdentifierAsync(string identifier)
+        public virtual async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
         {
             tenantMap.TryGetValue(identifier, out var result);
             
@@ -59,23 +59,24 @@ namespace Finbuckle.MultiTenant.Stores
 
         public async Task<bool> TryAddAsync(TTenantInfo tenantInfo)
         {
-            var result = tenantMap.TryAdd(tenantInfo.Identifier, tenantInfo);
+            var result = tenantInfo.Identifier != null
+                && tenantMap.TryAdd(tenantInfo.Identifier, tenantInfo);
 
             return await Task.FromResult(result);
         }
 
         public async Task<bool> TryRemoveAsync(string identifier)
         {
-            var result = tenantMap.TryRemove(identifier, out var dummy);
+            var result = tenantMap.TryRemove(identifier, out var _);
 
             return await Task.FromResult(result);
         }
 
         public async Task<bool> TryUpdateAsync(TTenantInfo tenantInfo)
         {
-            var existingTenantInfo = await TryGetAsync(tenantInfo.Id);
+            var existingTenantInfo = tenantInfo.Id != null ? await TryGetAsync(tenantInfo.Id) : null;
 
-            if(existingTenantInfo != null)
+            if (existingTenantInfo?.Identifier != null)
             {
                 var result =  tenantMap.TryUpdate(existingTenantInfo.Identifier, tenantInfo, existingTenantInfo);
                 return await Task.FromResult(result);

--- a/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
@@ -59,8 +59,7 @@ namespace Finbuckle.MultiTenant.Stores
 
         public async Task<bool> TryAddAsync(TTenantInfo tenantInfo)
         {
-            // Throws an ArgumentNullException if the identifier is null.
-            var result = tenantMap.TryAdd(tenantInfo.Identifier!, tenantInfo);
+            var result = tenantInfo.Identifier != null && tenantMap.TryAdd(tenantInfo.Identifier, tenantInfo);
 
             return await Task.FromResult(result);
         }

--- a/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
+++ b/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
@@ -164,18 +164,18 @@ namespace Finbuckle.MultiTenant.Stores
             return result;
         }
 
-        public async Task<bool> TryRemoveAsync(string id)
+        public async Task<bool> TryRemoveAsync(string identifier)
         {
-            if (id == null)
+            if (identifier == null)
             {
-                throw new ArgumentNullException(nameof(id));
+                throw new ArgumentNullException(nameof(identifier));
             }
 
             var result = false;
 
             try
             {
-                result = await Store.TryRemoveAsync(id);
+                result = await Store.TryRemoveAsync(identifier);
             }
             catch (Exception e)
             {
@@ -184,11 +184,11 @@ namespace Finbuckle.MultiTenant.Stores
 
             if (result)
             {
-                logger.LogDebug("TryRemoveAsync: Tenant Id: \"{TenantId}\" removed", id);
+                logger.LogDebug("TryRemoveAsync: Tenant Identifier: \"{TenantIdentifier}\" removed", identifier);
             }
             else
             {
-                logger.LogDebug("TryRemoveAsync: Unable to remove Tenant Id: \"{TenantId}\"", id);
+                logger.LogDebug("TryRemoveAsync: Unable to remove Tenant Identifier: \"{TenantIdentifier}\"", identifier);
             }
 
             return result;

--- a/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
+++ b/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
@@ -69,7 +69,7 @@ namespace Finbuckle.MultiTenant.Stores
                 logger.LogError(e, "Exception in GetAllAsync");
             }
 
-            return result;
+            return result != null ? result : new List<TTenantInfo>();
         }
 
         public async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)

--- a/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
+++ b/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
@@ -23,14 +23,14 @@ namespace Finbuckle.MultiTenant.Stores
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<TTenantInfo> TryGetAsync(string id)
+        public async Task<TTenantInfo?> TryGetAsync(string id)
         {
             if (id == null)
             {
                 throw new ArgumentNullException(nameof(id));
             }
 
-            TTenantInfo result = null;
+            TTenantInfo? result = null;
 
             try
             {
@@ -58,7 +58,7 @@ namespace Finbuckle.MultiTenant.Stores
 
         public async Task<IEnumerable<TTenantInfo>> GetAllAsync()
         {
-            IEnumerable<TTenantInfo> result = null;
+            IEnumerable<TTenantInfo>? result = null;
 
             try
             {
@@ -72,14 +72,14 @@ namespace Finbuckle.MultiTenant.Stores
             return result;
         }
 
-        public async Task<TTenantInfo> TryGetByIdentifierAsync(string identifier)
+        public async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
         {
             if (identifier == null)
             {
                 throw new ArgumentNullException(nameof(identifier));
             }
 
-            TTenantInfo result = null;
+            TTenantInfo? result = null;
 
             try
             {

--- a/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
+++ b/src/Finbuckle.MultiTenant/Stores/MultiTenantStoreWrapper.cs
@@ -58,7 +58,7 @@ namespace Finbuckle.MultiTenant.Stores
 
         public async Task<IEnumerable<TTenantInfo>> GetAllAsync()
         {
-            IEnumerable<TTenantInfo>? result = null;
+            IEnumerable<TTenantInfo> result = new List<TTenantInfo>();
 
             try
             {
@@ -69,7 +69,7 @@ namespace Finbuckle.MultiTenant.Stores
                 logger.LogError(e, "Exception in GetAllAsync");
             }
 
-            return result != null ? result : new List<TTenantInfo>();
+            return result;
         }
 
         public async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)

--- a/src/Finbuckle.MultiTenant/Strategies/DelegateStrategy.cs
+++ b/src/Finbuckle.MultiTenant/Strategies/DelegateStrategy.cs
@@ -15,7 +15,7 @@ namespace Finbuckle.MultiTenant.Strategies
             this.doStrategy = doStrategy ?? throw new ArgumentNullException(nameof(doStrategy));
         }
 
-        public async Task<string> GetIdentifierAsync(object context)
+        public async Task<string?> GetIdentifierAsync(object context)
         {
             var identifier = await doStrategy(context);
             return await Task.FromResult(identifier);

--- a/src/Finbuckle.MultiTenant/Strategies/MultiTenantStrategyWrapper.cs
+++ b/src/Finbuckle.MultiTenant/Strategies/MultiTenantStrategyWrapper.cs
@@ -19,14 +19,14 @@ namespace Finbuckle.MultiTenant.Strategies
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<string> GetIdentifierAsync(object context)
+        public async Task<string?> GetIdentifierAsync(object context)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            string identifier = null;
+            string? identifier = null;
 
             try
             {

--- a/src/Finbuckle.MultiTenant/Strategies/StaticStrategy.cs
+++ b/src/Finbuckle.MultiTenant/Strategies/StaticStrategy.cs
@@ -10,7 +10,7 @@ namespace Finbuckle.MultiTenant.Strategies
         internal readonly string identifier;
 
         public int Priority { get => -1000; }
-        
+
         public StaticStrategy(string identifier)
         {
             this.identifier = identifier;

--- a/src/Finbuckle.MultiTenant/Strategies/StaticStrategy.cs
+++ b/src/Finbuckle.MultiTenant/Strategies/StaticStrategy.cs
@@ -16,7 +16,7 @@ namespace Finbuckle.MultiTenant.Strategies
             this.identifier = identifier;
         }
 
-        public async Task<string> GetIdentifierAsync(object context)
+        public async Task<string?> GetIdentifierAsync(object context)
         {
             return await Task.FromResult(identifier);
         }

--- a/src/Finbuckle.MultiTenant/StrategyInfo.cs
+++ b/src/Finbuckle.MultiTenant/StrategyInfo.cs
@@ -7,7 +7,7 @@ namespace Finbuckle.MultiTenant
 {
     public class StrategyInfo
     {
-        public Type StrategyType { get; internal set; }
-        public IMultiTenantStrategy Strategy { get; internal set; }
+        public Type? StrategyType { get; internal set; }
+        public IMultiTenantStrategy? Strategy { get; internal set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/TenantInfo.cs
+++ b/src/Finbuckle.MultiTenant/TenantInfo.cs
@@ -7,13 +7,13 @@ namespace Finbuckle.MultiTenant
 {
     public class TenantInfo : ITenantInfo
     {
-        private string id;
+        private string? id;
 
         public TenantInfo()
         {
         }
 
-        public string Id
+        public string? Id
         {
             get
             {
@@ -32,8 +32,8 @@ namespace Finbuckle.MultiTenant
             }
         }
 
-        public string Identifier { get; set; }
-        public string Name { get; set; }
-        public string ConnectionString { get; set; }
+        public string? Identifier { get; set; }
+        public string? Name { get; set; }
+        public string? ConnectionString { get; set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/TenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/TenantResolver.cs
@@ -17,14 +17,14 @@ namespace Finbuckle.MultiTenant
         where T : class, ITenantInfo, new()
     {
         private readonly IOptionsMonitor<MultiTenantOptions> options;
-        private readonly ILoggerFactory loggerFactory;
+        private readonly ILoggerFactory? loggerFactory;
 
         public TenantResolver(IEnumerable<IMultiTenantStrategy> strategies, IEnumerable<IMultiTenantStore<T>> stores, IOptionsMonitor<MultiTenantOptions> options) :
             this(strategies, stores, options, null)
         {
         }
 
-        public TenantResolver(IEnumerable<IMultiTenantStrategy> strategies, IEnumerable<IMultiTenantStore<T>> stores, IOptionsMonitor<MultiTenantOptions> options, ILoggerFactory loggerFactory)
+        public TenantResolver(IEnumerable<IMultiTenantStrategy> strategies, IEnumerable<IMultiTenantStore<T>> stores, IOptionsMonitor<MultiTenantOptions> options, ILoggerFactory? loggerFactory)
         {
             Stores = stores;
             this.options = options;
@@ -36,9 +36,9 @@ namespace Finbuckle.MultiTenant
         public IEnumerable<IMultiTenantStrategy> Strategies { get; set; }
         public IEnumerable<IMultiTenantStore<T>> Stores { get; set; }
 
-        public async Task<IMultiTenantContext<T>> ResolveAsync(object context)
+        public async Task<IMultiTenantContext<T>?> ResolveAsync(object context)
         {
-            IMultiTenantContext<T> result = null;
+            IMultiTenantContext<T>? result = null;
 
             foreach (var strategy in Strategies)
             {
@@ -64,7 +64,7 @@ namespace Finbuckle.MultiTenant
                             result.StrategyInfo = new StrategyInfo { Strategy = strategy, StrategyType = strategy.GetType() };
                             result.TenantInfo = tenantInfo;
 
-                            await options.CurrentValue?.Events?.OnTenantResolved(new TenantResolvedContext { Context = context, TenantInfo = tenantInfo });
+                            await options.CurrentValue.Events.OnTenantResolved(new TenantResolvedContext { Context = context, TenantInfo = tenantInfo });
 
                             break;
                         }
@@ -73,14 +73,14 @@ namespace Finbuckle.MultiTenant
                     if (result != null)
                         break;
 
-                    await options.CurrentValue?.Events?.OnTenantNotResolved(new TenantNotResolvedContext { Context = context, Identifier = identifier });
+                    await options.CurrentValue.Events.OnTenantNotResolved(new TenantNotResolvedContext { Context = context, Identifier = identifier });
                 }
             }
 
             return result;
         }
 
-        async Task<object> ITenantResolver.ResolveAsync(object context)
+        async Task<object?> ITenantResolver.ResolveAsync(object context)
         {
             var multiTenantContext = await ResolveAsync(context);
             return multiTenantContext;

--- a/src/Finbuckle.MultiTenant/TenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/TenantResolver.cs
@@ -29,7 +29,7 @@ namespace Finbuckle.MultiTenant
             Stores = stores;
             this.options = options;
             this.loggerFactory = loggerFactory;
-            
+
             Strategies = strategies.OrderByDescending(s => s.Priority);
         }
 

--- a/test/Finbuckle.MultiTenant.Test/DependencyInjection/MultiTenantBuilderShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/DependencyInjection/MultiTenantBuilderShould.cs
@@ -83,7 +83,7 @@ namespace Finbuckle.MultiTenant.Test.DependencyInjection
                     store = scope.ServiceProvider.GetRequiredService<IMultiTenantStore<TenantInfo>>();
                     Assert.NotSame(store, store2);
                     break;
-                
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, null);
             }
@@ -128,7 +128,7 @@ namespace Finbuckle.MultiTenant.Test.DependencyInjection
         {
             var services = new ServiceCollection();
             var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
-            Assert.Throws<ArgumentNullException>(() => builder.WithStore<TestStore<TenantInfo>>(ServiceLifetime.Singleton, factory: null));
+            Assert.Throws<ArgumentNullException>(() => builder.WithStore<TestStore<TenantInfo>>(ServiceLifetime.Singleton, factory: null!));
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace Finbuckle.MultiTenant.Test.DependencyInjection
         {
             var services = new ServiceCollection();
             var accessor = new Mock<IMultiTenantContextAccessor<TenantInfo>>();
-            accessor.Setup(a => a.MultiTenantContext).Returns((IMultiTenantContext<TenantInfo>)null);
+            accessor.Setup(a => a.MultiTenantContext).Returns((IMultiTenantContext<TenantInfo>?)null);
             services.AddSingleton(accessor.Object);
             var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
             // Note: using MultiTenantBuilderShould as our test options class.
@@ -151,7 +151,7 @@ namespace Finbuckle.MultiTenant.Test.DependencyInjection
         {
             var services = new ServiceCollection();
             var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
-            Assert.Throws<ArgumentNullException>(() => builder.WithPerTenantOptions<MultiTenantBuilderShould>(null));
+            Assert.Throws<ArgumentNullException>(() => builder.WithPerTenantOptions<MultiTenantBuilderShould>(null!));
         }
 
         [Theory]
@@ -261,7 +261,7 @@ namespace Finbuckle.MultiTenant.Test.DependencyInjection
         {
             var services = new ServiceCollection();
             var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
-            Assert.Throws<ArgumentNullException>(() => builder.WithStrategy<StaticStrategy>(ServiceLifetime.Singleton, factory: null));
+            Assert.Throws<ArgumentNullException>(() => builder.WithStrategy<StaticStrategy>(ServiceLifetime.Singleton, factory: null!));
         }
 
         private class TestStore<TTenant> : IMultiTenantStore<TTenant>
@@ -286,7 +286,7 @@ namespace Finbuckle.MultiTenant.Test.DependencyInjection
                 throw new NotImplementedException();
             }
 
-            public Task<TTenant> TryGetAsync(string id)
+            public Task<TTenant?> TryGetAsync(string id)
             {
                 throw new NotImplementedException();
             }
@@ -296,12 +296,12 @@ namespace Finbuckle.MultiTenant.Test.DependencyInjection
                 throw new NotImplementedException();
             }
 
-            public Task<TTenant> TryGetByIdentifierAsync(string identifier)
+            public Task<TTenant?> TryGetByIdentifierAsync(string identifier)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<bool> TryRemoveAsync(string id)
+            public Task<bool> TryRemoveAsync(string identifier)
             {
                 throw new NotImplementedException();
             }

--- a/test/Finbuckle.MultiTenant.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
@@ -44,7 +44,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
             var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
             builder.WithHttpRemoteStore("http://example.com");
             var sp = services.BuildServiceProvider();
-        
+
             sp.GetRequiredService<HttpRemoteStoreClient<TenantInfo>>();
             var store = sp.GetRequiredService<IMultiTenantStore<TenantInfo>>();
             Assert.IsType<HttpRemoteStore<TenantInfo>>(store);
@@ -58,7 +58,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
             var flag = false;
             builder.WithHttpRemoteStore("http://example.com", _ => flag = true);
             var sp = services.BuildServiceProvider();
-        
+
             sp.GetRequiredService<HttpRemoteStoreClient<TenantInfo>>();
             var store = sp.GetRequiredService<IMultiTenantStore<TenantInfo>>();
             Assert.IsType<HttpRemoteStore<TenantInfo>>(store);
@@ -82,14 +82,14 @@ namespace Finbuckle.MultiTenant.Test.Extensions
             Assert.IsType<ConfigurationStore<TenantInfo>>(store);
 
             var tc = store.TryGetByIdentifierAsync("initech").Result;
-            Assert.Equal("initech-id", tc.Id);
+            Assert.Equal("initech-id", tc!.Id);
             Assert.Equal("initech", tc.Identifier);
             Assert.Equal("Initech", tc.Name);
             // Note: connection string below loading from default in json.
             Assert.Equal("Datasource=sample.db", tc.ConnectionString);
 
             tc = store.TryGetByIdentifierAsync("lol").Result;
-            Assert.Equal("lol-id", tc.Id);
+            Assert.Equal("lol-id", tc!.Id);
             Assert.Equal("lol", tc.Identifier);
             Assert.Equal("LOL", tc.Name);
             Assert.Equal("Datasource=lol.db", tc.ConnectionString);
@@ -114,14 +114,14 @@ namespace Finbuckle.MultiTenant.Test.Extensions
             Assert.IsType<ConfigurationStore<TenantInfo>>(store);
 
             var tc = store.TryGetByIdentifierAsync("initech").Result;
-            Assert.Equal("initech-id", tc.Id);
+            Assert.Equal("initech-id", tc!.Id);
             Assert.Equal("initech", tc.Identifier);
             Assert.Equal("Initech", tc.Name);
             // Note: connection string below loading from default in json.
             Assert.Equal("Datasource=sample.db", tc.ConnectionString);
 
             tc = store.TryGetByIdentifierAsync("lol").Result;
-            Assert.Equal("lol-id", tc.Id);
+            Assert.Equal("lol-id", tc!.Id);
             Assert.Equal("lol", tc.Identifier);
             Assert.Equal("LOL", tc.Name);
             Assert.Equal("Datasource=lol.db", tc.ConnectionString);
@@ -133,7 +133,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
             var services = new ServiceCollection();
             var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
             Assert.Throws<ArgumentNullException>(()
-                => builder.WithInMemoryStore(null));
+                => builder.WithInMemoryStore(null!));
         }
 
         [Fact]
@@ -152,7 +152,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
             Assert.IsType<InMemoryStore<TenantInfo>>(store);
 
             var tc = store.TryGetByIdentifierAsync("lol").Result;
-            Assert.Equal("lol", tc.Id);
+            Assert.Equal("lol", tc!.Id);
             Assert.Equal("lol", tc.Identifier);
             Assert.Equal("LOL", tc.Name);
             Assert.Equal("Datasource=lol.db", tc.ConnectionString);
@@ -191,8 +191,8 @@ namespace Finbuckle.MultiTenant.Test.Extensions
         {
             var services = new ServiceCollection();
             var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
-            Assert.Throws<ArgumentException>(()
-                => builder.WithStaticStrategy(null));
+            Assert.Throws<ArgumentNullException>(()
+                => builder.WithStaticStrategy(null!));
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.Test/Extensions/ServiceCollectionExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Extensions/ServiceCollectionExtensionsShould.cs
@@ -19,7 +19,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
             var service = services.SingleOrDefault(s => s.ServiceType == typeof(ITenantResolver));
 
             Assert.NotNull(service);
-            Assert.Equal(ServiceLifetime.Scoped, service.Lifetime);
+            Assert.Equal(ServiceLifetime.Scoped, service!.Lifetime);
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
             var service = services.SingleOrDefault(s => s.ServiceType == typeof(ITenantResolver<TenantInfo>));
 
             Assert.NotNull(service);
-            Assert.Equal(ServiceLifetime.Scoped, service.Lifetime);
+            Assert.Equal(ServiceLifetime.Scoped, service!.Lifetime);
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
                                                         s.ServiceType == typeof(IMultiTenantContext<TenantInfo>));
 
             Assert.NotNull(service);
-            Assert.Equal(ServiceLifetime.Scoped, service.Lifetime);
+            Assert.Equal(ServiceLifetime.Scoped, service!.Lifetime);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
                                                         s.ServiceType == typeof(TenantInfo));
 
             Assert.NotNull(service);
-            Assert.Equal(ServiceLifetime.Scoped, service.Lifetime);
+            Assert.Equal(ServiceLifetime.Scoped, service!.Lifetime);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
                                                         s.ServiceType == typeof(ITenantInfo));
 
             Assert.NotNull(service);
-            Assert.Equal(ServiceLifetime.Scoped, service.Lifetime);
+            Assert.Equal(ServiceLifetime.Scoped, service!.Lifetime);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
                                                         s.ServiceType == typeof(IMultiTenantContextAccessor));
 
             Assert.NotNull(service);
-            Assert.Equal(ServiceLifetime.Singleton, service.Lifetime);
+            Assert.Equal(ServiceLifetime.Singleton, service!.Lifetime);
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
                                                         s.ServiceType == typeof(IMultiTenantContextAccessor<TenantInfo>));
 
             Assert.NotNull(service);
-            Assert.Equal(ServiceLifetime.Singleton, service.Lifetime);
+            Assert.Equal(ServiceLifetime.Singleton, service!.Lifetime);
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace Finbuckle.MultiTenant.Test.Extensions
                                                         s.ServiceType == typeof(IConfigureOptions<MultiTenantOptions>));
 
             Assert.NotNull(service);
-            Assert.Equal(ServiceLifetime.Singleton, service.Lifetime);
+            Assert.Equal(ServiceLifetime.Singleton, service!.Lifetime);
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj
+++ b/test/Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,7 +39,7 @@
   <ItemGroup>
     <ProjectReference Include="../../src/Finbuckle.MultiTenant/Finbuckle.MultiTenant.csproj" />
   </ItemGroup>
-    
+
   <ItemGroup>
     <None Include="*TestSettings*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsCacheShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsCacheShould.cs
@@ -106,7 +106,7 @@ namespace Finbuckle.MultiTenant.Test.Options
             tca.MultiTenantContext = tc;
             var cache = new MultiTenantOptionsCache<TestOptions, TenantInfo>(tca);
 
-            Assert.Throws<ArgumentNullException>(() => cache.GetOrAdd("", null));
+            Assert.Throws<ArgumentNullException>(() => cache.GetOrAdd("", null!));
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace Finbuckle.MultiTenant.Test.Options
             var tca = new MultiTenantContextAccessor<TenantInfo>();
             tca.MultiTenantContext = tc;
 
-            Assert.Throws<ArgumentNullException>(() => new MultiTenantOptionsCache<TestOptions, TenantInfo>(null));
+            Assert.Throws<ArgumentNullException>(() => new MultiTenantOptionsCache<TestOptions, TenantInfo>(null!));
         }
 
         [Theory]
@@ -148,22 +148,22 @@ namespace Finbuckle.MultiTenant.Test.Options
             // Remove named options for current tenant.
             result = cache.TryRemove(name);
             Assert.True(result);
-            var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>)cache.GetType().
-                GetField("map", BindingFlags.NonPublic | BindingFlags.Instance).
+            var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType().
+                GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.
                 GetValue(cache);
 
-            dynamic tenantInternalCache = tenantCache[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)
+            dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .GetValue(tenantCache[ti.Id]);
 
             // Assert named options removed and other options on tenant left as-is.
-            Assert.False(tenantInternalCache.Keys.Contains(name ?? ""));
+            Assert.False(tenantInternalCache!.Keys.Contains(name ?? ""));
             Assert.True(tenantInternalCache.Keys.Contains("diffname"));
 
             // Assert other tenant not affected.
             ti.Id = "test-id-123";
-            tenantInternalCache = tenantCache[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)
+            tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .GetValue(tenantCache[ti.Id]);
-            Assert.True(tenantInternalCache.ContainsKey(name ?? ""));
+            Assert.True(tenantInternalCache!.ContainsKey(name ?? ""));
         }
 
         [Fact]
@@ -192,19 +192,19 @@ namespace Finbuckle.MultiTenant.Test.Options
             cache.Clear();
 
             // Assert options cleared on this tenant.
-            var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>)cache.GetType().
-                GetField("map", BindingFlags.NonPublic | BindingFlags.Instance).
+            var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType().
+                GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.
                 GetValue(cache);
 
-            dynamic tenantInternalCache = tenantCache[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)
+            dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .GetValue(tenantCache[ti.Id]);
-            Assert.True(tenantInternalCache.IsEmpty);
+            Assert.True(tenantInternalCache!.IsEmpty);
 
             // Assert options still exist on other tenant.
             ti.Id = "diff_id";
-            tenantInternalCache = tenantCache[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)
+            tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .GetValue(tenantCache[ti.Id]);
-            Assert.False(tenantInternalCache.IsEmpty);
+            Assert.False(tenantInternalCache!.IsEmpty);
         }
 
         [Fact]
@@ -232,18 +232,18 @@ namespace Finbuckle.MultiTenant.Test.Options
             cache.Clear("test-id-123");
 
             // Assert options cleared on this tenant.
-            var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>)cache.GetType().
-                GetField("map", BindingFlags.NonPublic | BindingFlags.Instance).
+            var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType().
+                GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.
                 GetValue(cache);
 
-            dynamic tenantInternalCache = tenantCache[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)
+            dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .GetValue(tenantCache["test-id-123"]);
-            Assert.True(tenantInternalCache.IsEmpty);
+            Assert.True(tenantInternalCache!.IsEmpty);
 
             // Assert options still exist on other tenant.
-            tenantInternalCache = tenantCache["diff_id"].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)
+            tenantInternalCache = tenantCache?["diff_id"].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .GetValue(tenantCache["diff_id"]);
-            Assert.False(tenantInternalCache.IsEmpty);
+            Assert.False(tenantInternalCache!.IsEmpty);
         }
 
         [Fact]
@@ -271,19 +271,19 @@ namespace Finbuckle.MultiTenant.Test.Options
             cache.ClearAll();
 
             // Assert options cleared on this tenant.
-            var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>)cache.GetType().
-                GetField("map", BindingFlags.NonPublic | BindingFlags.Instance).
+            var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType().
+                GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.
                 GetValue(cache);
 
-            dynamic tenantInternalCache = tenantCache[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)
+            dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .GetValue(tenantCache[ti.Id]);
-            Assert.True(tenantInternalCache.IsEmpty);
+            Assert.True(tenantInternalCache!.IsEmpty);
 
             // Assert options cleared on other tenant.
             ti.Id = "diff_id";
-            tenantInternalCache = tenantCache[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)
+            tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .GetValue(tenantCache[ti.Id]);
-            Assert.True(tenantInternalCache.IsEmpty);
+            Assert.True(tenantInternalCache!.IsEmpty);
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsFactoryShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsFactoryShould.cs
@@ -25,7 +25,7 @@ namespace Finbuckle.MultiTenant.Test.Options
             accessor.MultiTenantContext = new MultiTenantContext<TenantInfo> { TenantInfo = new TenantInfo { Id = "test-id-123" } };
 
             var options = sp.GetRequiredService<IOptionsSnapshot<TestOptions>>().Get(name);
-            Assert.Equal($"{name}_begin_{accessor.MultiTenantContext.TenantInfo.Id}_end", options.DefaultConnectionString);
+            Assert.Equal($"{name}_begin_{accessor.MultiTenantContext.TenantInfo!.Id}_end", options.DefaultConnectionString);
         }
 
         [Theory]
@@ -46,7 +46,7 @@ namespace Finbuckle.MultiTenant.Test.Options
             accessor.MultiTenantContext = new MultiTenantContext<TenantInfo> { TenantInfo = new TenantInfo { Id = "id", Identifier = "identifier" } };
 
             var options = sp.GetRequiredService<IOptionsSnapshot<TestOptions>>().Get(name);
-            Assert.Equal($"{name}_begin_{accessor.MultiTenantContext.TenantInfo.Id}_{accessor.MultiTenantContext.TenantInfo.Identifier}_end", options.DefaultConnectionString);
+            Assert.Equal($"{name}_begin_{accessor.MultiTenantContext.TenantInfo!.Id}_{accessor.MultiTenantContext.TenantInfo.Identifier}_end", options.DefaultConnectionString);
         }
 
         [Fact]

--- a/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsManagerShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsManagerShould.cs
@@ -19,7 +19,7 @@ namespace Finbuckle.MultiTenant.Test.Options
             var mock = new Mock<IOptionsMonitorCache<Object>>();
             mock.Setup(c => c.GetOrAdd(It.IsAny<string>(), It.IsAny<Func<Object>>())).Returns(new Object());
 
-            var manager = new MultiTenantOptionsManager<Object>(null, mock.Object);
+            var manager = new MultiTenantOptionsManager<Object>(null!, mock.Object);
 
             manager.Get(optionName);
 
@@ -32,9 +32,9 @@ namespace Finbuckle.MultiTenant.Test.Options
             var mock = new Mock<IOptionsMonitorCache<Object>>();
             mock.Setup(c => c.GetOrAdd(It.IsAny<string>(), It.IsAny<Func<Object>>())).Returns(new Object());
 
-            var manager = new MultiTenantOptionsManager<Object>(null, mock.Object);
+            var manager = new MultiTenantOptionsManager<Object>(null!, mock.Object);
 
-            manager.Get(null);
+            manager.Get(null!);
 
             mock.Verify(c => c.GetOrAdd(It.Is<String>(p => p == Microsoft.Extensions.Options.Options.DefaultName), It.IsAny<Func<Object>>()), Times.Once);
         }
@@ -45,7 +45,7 @@ namespace Finbuckle.MultiTenant.Test.Options
             var mock = new Mock<IOptionsMonitorCache<Object>>();
             mock.Setup(c => c.GetOrAdd(It.IsAny<string>(), It.IsAny<Func<Object>>())).Returns(new Object());
 
-            var manager = new MultiTenantOptionsManager<Object>(null, mock.Object);
+            var manager = new MultiTenantOptionsManager<Object>(null!, mock.Object);
 
             var dummy = manager.Value;
 
@@ -58,7 +58,7 @@ namespace Finbuckle.MultiTenant.Test.Options
             var mock = new Mock<TestOptionsCache<Object>>();
             mock.Setup(i => i.Clear());
 
-            var manager = new MultiTenantOptionsManager<Object>(null, mock.Object);
+            var manager = new MultiTenantOptionsManager<Object>(null!, mock.Object);
             manager.Reset();
 
             mock.Verify(i => i.Clear(), Times.Once);

--- a/test/Finbuckle.MultiTenant.Test/Options/TestOptions.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/TestOptions.cs
@@ -8,6 +8,6 @@ namespace Finbuckle.MultiTenant.Test.Options
     internal class TestOptions
     {
         [Required]
-        public string DefaultConnectionString { get; set; }
+        public string? DefaultConnectionString { get; set; }
     }
 }

--- a/test/Finbuckle.MultiTenant.Test/Stores/ConfigurationStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/ConfigurationStoreShould.cs
@@ -2,6 +2,7 @@
 // Refer to the solution LICENSE file for more inforation.
 
 using System;
+using System.Threading.Tasks;
 using Finbuckle.MultiTenant.Stores;
 using Microsoft.Extensions.Configuration;
 using Xunit;
@@ -17,16 +18,16 @@ namespace Finbuckle.MultiTenant.Test.Stores
             var configBuilder = new ConfigurationBuilder();
             configBuilder.AddJsonFile("ConfigurationStoreTestSettings_NoDefaults.json");
             IConfiguration configuration = configBuilder.Build();
-        
+
             // ReSharper disable once ObjectCreationAsStatement
             // Will throw if fail
             new ConfigurationStore<TenantInfo>(configuration);
         }
-    
+
         [Fact]
         public void ThrowIfNullConfiguration()
         {
-            Assert.Throws<ArgumentNullException>(() => new ConfigurationStore<TenantInfo>(null));
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationStore<TenantInfo>(null!));
         }
 
         [Fact]
@@ -37,7 +38,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
             IConfiguration configuration = configBuilder.Build();
 
             Assert.Throws<ArgumentException>(() => new ConfigurationStore<TenantInfo>(configuration, ""));
-            Assert.Throws<ArgumentException>(() => new ConfigurationStore<TenantInfo>(configuration, null));
+            Assert.Throws<ArgumentException>(() => new ConfigurationStore<TenantInfo>(configuration, null!));
         }
 
         [Fact]
@@ -55,7 +56,15 @@ namespace Finbuckle.MultiTenant.Test.Stores
         {
             var store = CreateTestStore();
 
-            Assert.Equal("initech", store.TryGetByIdentifierAsync("INITECH").Result.Identifier);
+            Assert.Equal("initech", store.TryGetByIdentifierAsync("INITECH").Result!.Identifier);
+        }
+
+        [Fact]
+        public void ThrowWhenTryingToGetIdentifierGivenNullIdentifier()
+        {
+            var store = CreateTestStore();
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await store.TryGetByIdentifierAsync(null!));
         }
 
         // Basic store functionality tested in MultiTenantStoresShould.cs

--- a/test/Finbuckle.MultiTenant.Test/Stores/DistributedCacheStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/DistributedCacheStoreShould.cs
@@ -36,6 +36,16 @@ namespace Finbuckle.MultiTenant.Test.Stores
         }
 
         [Fact]
+        public void RemoveReturnsFalseWhenNoMatchingIdentifierFound()
+        {
+            var store = CreateTestStore();
+
+            var r = store.TryRemoveAsync("DOESNOTEXIST").Result;
+
+            Assert.False(r);
+        }
+
+        [Fact]
         public void AddDualEntriesOnAddOrUpdate()
         {
             var store = CreateTestStore();
@@ -45,8 +55,8 @@ namespace Finbuckle.MultiTenant.Test.Stores
 
             Assert.NotNull(t1);
             Assert.NotNull(t2);
-            Assert.Equal("lol-id", t1.Id);
-            Assert.Equal("lol-id", t2.Id);
+            Assert.Equal("lol-id", t1!.Id);
+            Assert.Equal("lol-id", t2!.Id);
             Assert.Equal("lol", t1.Identifier);
             Assert.Equal("lol", t2.Identifier);
         }
@@ -62,8 +72,8 @@ namespace Finbuckle.MultiTenant.Test.Stores
 
             Assert.NotNull(t1);
             Assert.NotNull(t2);
-            Assert.Equal("lol-id", t1.Id);
-            Assert.Equal("lol-id", t2.Id);
+            Assert.Equal("lol-id", t1!.Id);
+            Assert.Equal("lol-id", t2!.Id);
             Assert.Equal("lol", t1.Identifier);
             Assert.Equal("lol", t2.Identifier);
         }
@@ -81,7 +91,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         }
 
         // Basic store functionality tested in MultiTenantStoresShould.cs
-    
+
         protected override IMultiTenantStore<TenantInfo> CreateTestStore()
         {
             var services = new ServiceCollection();
@@ -89,7 +99,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
             var sp = services.BuildServiceProvider();
 
             var store = new DistributedCacheStore<TenantInfo>(sp.GetRequiredService<IDistributedCache>(), Constants.TenantToken, TimeSpan.FromSeconds(3));
-    
+
             return PopulateTestStore(store);
         }
 
@@ -128,7 +138,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         {
             base.RemoveTenantInfoFromStore();
         }
-    
+
         [Fact]
         public override void UpdateTenantInfoInStore()
         {

--- a/test/Finbuckle.MultiTenant.Test/Stores/HttpRemoteStoreClientShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/HttpRemoteStoreClientShould.cs
@@ -12,7 +12,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         [Fact]
         public void ThrowIfHttpClientFactoryIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new HttpRemoteStoreClient<TenantInfo>(null));
-        }   
+            Assert.Throws<ArgumentNullException>(() => new HttpRemoteStoreClient<TenantInfo>(null!));
+        }
     }
 }

--- a/test/Finbuckle.MultiTenant.Test/Stores/HttpRemoteStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/HttpRemoteStoreShould.cs
@@ -22,7 +22,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
             {
                 var result = new HttpResponseMessage();
 
-                var numSegments = request.RequestUri.Segments.Length;
+                var numSegments = request.RequestUri!.Segments.Length;
                 if (string.Equals(request.RequestUri.Segments[numSegments - 1], "initech", StringComparison.OrdinalIgnoreCase))
                 {
 
@@ -41,7 +41,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         [Fact]
         public void ThrowIfTypedClientParamIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new HttpRemoteStore<TenantInfo>(null, "http://example.com"));
+            Assert.Throws<ArgumentNullException>(() => new HttpRemoteStore<TenantInfo>(null!, "http://example.com"));
         }
 
         [Theory]
@@ -77,7 +77,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
             var store = new HttpRemoteStore<TenantInfo>(client, "http://example.com");
 
             var field = store.GetType().GetField("endpointTemplate", BindingFlags.NonPublic | BindingFlags.Instance);
-            var endpointTemplate = field.GetValue(store);
+            var endpointTemplate = field?.GetValue(store);
 
             Assert.Equal($"http://example.com/{HttpRemoteStore<TenantInfo>.defaultEndpointTemplateIdentifierToken}", endpointTemplate);
         }

--- a/test/Finbuckle.MultiTenant.Test/Stores/IMultiTenantStoreTestBase.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/IMultiTenantStoreTestBase.cs
@@ -25,7 +25,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         {
             var store = CreateTestStore();
 
-            Assert.Equal("initech", store.TryGetAsync("initech-id").Result.Identifier);
+            Assert.Equal("initech", store.TryGetAsync("initech-id").Result!.Identifier);
         }
 
         //[Fact]
@@ -41,7 +41,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         {
             var store = CreateTestStore();
 
-            Assert.Equal("initech", store.TryGetByIdentifierAsync("initech").Result.Identifier);
+            Assert.Equal("initech", store.TryGetByIdentifierAsync("initech").Result!.Identifier);
         }
 
         //[Fact]

--- a/test/Finbuckle.MultiTenant.Test/Stores/InMemoryStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/InMemoryStoreShould.cs
@@ -72,6 +72,19 @@ namespace Finbuckle.MultiTenant.Test.Stores
         }
 
         [Fact]
+        public void FailIfAddingWithoutTenantIdentifier()
+        {
+            var store = CreateCaseSensitiveTestStore();
+            var ti = new TenantInfo
+            {
+                Id = "NullTenant",
+                Name = "NullTenant"
+            };
+
+            Assert.False(store.TryAddAsync(ti).Result);
+        }
+
+        [Fact]
         public void ThrowIfDuplicateIdentifierInOptionsTenants()
         {
             var services = new ServiceCollection();

--- a/test/Finbuckle.MultiTenant.Test/Stores/InMemoryStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/InMemoryStoreShould.cs
@@ -40,14 +40,14 @@ namespace Finbuckle.MultiTenant.Test.Stores
         public void GetTenantInfoFromStoreCaseInsensitiveByDefault()
         {
             var store = CreateTestStore();
-            Assert.Equal("initech", store.TryGetByIdentifierAsync("iNitEch").Result.Identifier);
+            Assert.Equal("initech", store.TryGetByIdentifierAsync("iNitEch").Result!.Identifier);
         }
 
         [Fact]
         public void GetTenantInfoFromStoreCaseSensitive()
         {
             var store = CreateCaseSensitiveTestStore();
-            Assert.Equal("initech", store.TryGetByIdentifierAsync("initech").Result.Identifier);
+            Assert.Equal("initech", store.TryGetByIdentifierAsync("initech").Result!.Identifier);
             Assert.Null(store.TryGetByIdentifierAsync("iNitEch").Result);
         }
 
@@ -109,7 +109,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
 
         protected override IMultiTenantStore<TenantInfo> CreateTestStore()
         {
-            var store = new InMemoryStore<TenantInfo>(null);
+            var store = new InMemoryStore<TenantInfo>(null!);
 
             return PopulateTestStore(store);
         }

--- a/test/Finbuckle.MultiTenant.Test/Stores/MultiTenantStoreWrapperShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/MultiTenantStoreWrapperShould.cs
@@ -14,7 +14,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
 
         protected override IMultiTenantStore<TenantInfo> CreateTestStore()
         {
-            var store = new MultiTenantStoreWrapper<TenantInfo>(new InMemoryStore<TenantInfo>(null), NullLogger.Instance);
+            var store = new MultiTenantStoreWrapper<TenantInfo>(new InMemoryStore<TenantInfo>(null!), NullLogger.Instance);
 
             return PopulateTestStore(store);
         }
@@ -36,7 +36,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         {
             var store = CreateTestStore();
 
-            var e = Assert.Throws<AggregateException>(() => store.TryGetAsync(null).Result);
+            var e = Assert.Throws<AggregateException>(() => store.TryGetAsync(null!).Result);
             Assert.IsType<ArgumentNullException>(e.InnerException);
         }
 
@@ -57,7 +57,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         {
             var store = CreateTestStore();
 
-            var e = Assert.Throws<AggregateException>(() => store.TryGetByIdentifierAsync(null).Result);
+            var e = Assert.Throws<AggregateException>(() => store.TryGetByIdentifierAsync(null!).Result);
             Assert.IsType<ArgumentNullException>(e.InnerException);
         }
 
@@ -71,7 +71,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         public void ThrowWhenAddingIfTenantInfoIsNull()
         {
             var store = CreateTestStore();
-            var e = Assert.Throws<AggregateException>(() => store.TryAddAsync(null).Result);
+            var e = Assert.Throws<AggregateException>(() => store.TryAddAsync(null!).Result);
             Assert.IsType<ArgumentNullException>(e.InnerException);
         }
 
@@ -80,6 +80,14 @@ namespace Finbuckle.MultiTenant.Test.Stores
         {
             var store = CreateTestStore();
             var e = Assert.Throws<AggregateException>(() => store.TryAddAsync(new TenantInfo()).Result);
+            Assert.IsType<ArgumentNullException>(e.InnerException);
+        }
+
+        [Fact]
+        public void ThrowWhenAddingIfTenantInfoIdentifierIsNull()
+        {
+            var store = CreateTestStore();
+            var e = Assert.Throws<AggregateException>(() => store.TryAddAsync(new TenantInfo() { Id = "inittech-id" }).Result);
             Assert.IsType<ArgumentNullException>(e.InnerException);
         }
 
@@ -104,7 +112,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         {
             var store = CreateTestStore();
 
-            var e = Assert.Throws<AggregateException>(() => store.TryUpdateAsync(null).Result);
+            var e = Assert.Throws<AggregateException>(() => store.TryUpdateAsync(null!).Result);
             Assert.IsType<ArgumentNullException>(e.InnerException);
         }
 
@@ -136,7 +144,7 @@ namespace Finbuckle.MultiTenant.Test.Stores
         public void ThrowWhenRemovingIfTenantIdentifierIsNull()
         {
             var store = CreateTestStore();
-            var e = Assert.Throws<AggregateException>(() => store.TryRemoveAsync(null).Result);
+            var e = Assert.Throws<AggregateException>(() => store.TryRemoveAsync(null!).Result);
             Assert.IsType<ArgumentNullException>(e.InnerException);
         }
 

--- a/test/Finbuckle.MultiTenant.Test/Strategies/DelegateStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Strategies/DelegateStrategyShould.cs
@@ -31,11 +31,11 @@ namespace Finbuckle.MultiTenant.Test.Strategies
 
             Assert.Equal(identifier, result);
         }
-    
+
         [Fact]
         public void ThrowIfNullDelegate()
         {
-            Assert.Throws<ArgumentNullException>(() => new DelegateStrategy(null));
+            Assert.Throws<ArgumentNullException>(() => new DelegateStrategy(null!));
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.Test/Strategies/StaticStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Strategies/StaticStrategyShould.cs
@@ -2,6 +2,7 @@
 // Refer to the solution LICENSE file for more inforation.
 
 using System;
+using System.Threading.Tasks;
 using Finbuckle.MultiTenant.Strategies;
 using Xunit;
 
@@ -15,7 +16,7 @@ namespace Finbuckle.MultiTenant.Test.Strategies
         [InlineData("")] // empty string
         [InlineData("    ")] // whitespace
         [InlineData(null)] // null
-        public async void ReturnExpectedIdentifier(string staticIdentifier)
+        public async Task ReturnExpectedIdentifier(string staticIdentifier)
         {
             var strategy = new StaticStrategy(staticIdentifier);
 

--- a/test/Finbuckle.MultiTenant.Test/TenantResolverShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/TenantResolverShould.cs
@@ -1,6 +1,7 @@
 // Copyright Finbuckle LLC, Andrew White, and Contributors.
 // Refer to the solution LICENSE file for more inforation.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Finbuckle.MultiTenant.Stores;
@@ -81,10 +82,60 @@ namespace Finbuckle.MultiTenant.Test
 
             var resolver = sp.GetRequiredService<ITenantResolver<TenantInfo>>();
             var result = resolver.ResolveAsync(new object()).Result;
-        
-            Assert.Equal("initech", result.TenantInfo.Identifier);
-            Assert.IsType<StaticStrategy>(result.StrategyInfo.Strategy);
-            Assert.IsType<ConfigurationStore<TenantInfo>>(result.StoreInfo.Store);
+
+            Assert.Equal("initech", result!.TenantInfo!.Identifier);
+            Assert.IsType<StaticStrategy>(result!.StrategyInfo!.Strategy);
+            Assert.IsType<ConfigurationStore<TenantInfo>>(result!.StoreInfo!.Store);
+        }
+
+        [Fact]
+        void ReturnNullMultiTenantContextGivenNoStrategies()
+        {
+            var configBuilder = new ConfigurationBuilder();
+            configBuilder.AddJsonFile("ConfigurationStoreTestSettings.json");
+            var configuration = configBuilder.Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            services.
+                AddMultiTenant<TenantInfo>().
+                WithInMemoryStore().
+                WithConfigurationStore();
+
+            var sp = services.BuildServiceProvider();
+            var resolver = sp.GetRequiredService<ITenantResolver<TenantInfo>>();
+            var result = resolver.ResolveAsync(new object()).Result;
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        void ThrowGivenStaticStrategyWithNullIdentifierArgument()
+        {
+            var services = new ServiceCollection();
+
+            Action action = () => services.
+                AddMultiTenant<TenantInfo>().
+                WithStaticStrategy(null!).
+                WithInMemoryStore().
+                WithConfigurationStore();
+
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        void ThrowGivenDelegateStrategyWithNullArgument()
+        {
+            var services = new ServiceCollection();
+
+            Action action = () => services.
+                AddMultiTenant<TenantInfo>().
+                WithDelegateStrategy(null!).
+                WithInMemoryStore().
+                WithConfigurationStore();
+
+            Assert.Throws<ArgumentNullException>(action);
         }
 
         [Fact]
@@ -109,10 +160,10 @@ namespace Finbuckle.MultiTenant.Test
 
             var resolver = sp.GetRequiredService<ITenantResolver<TenantInfo>>();
             var result = resolver.ResolveAsync(new object()).Result;
-        
-            Assert.Equal("initech", result.TenantInfo.Identifier);
-            Assert.IsType<StaticStrategy>(result.StrategyInfo.Strategy);
-            Assert.IsType<ConfigurationStore<TenantInfo>>(result.StoreInfo.Store);
+
+            Assert.Equal("initech", result!.TenantInfo!.Identifier);
+            Assert.IsType<StaticStrategy>(result!.StrategyInfo!.Strategy);
+            Assert.IsType<ConfigurationStore<TenantInfo>>(result!.StoreInfo!.Store);
         }
 
         [Fact]
@@ -127,7 +178,7 @@ namespace Finbuckle.MultiTenant.Test
 
             services.
                 AddMultiTenant<TenantInfo>().
-                WithDelegateStrategy(_ => Task.FromResult<string>(null)).
+                WithDelegateStrategy(_ => Task.FromResult<string>(null!)).
                 WithInMemoryStore().
                 WithConfigurationStore();
             var sp = services.BuildServiceProvider();


### PR DESCRIPTION
Partially closes #487 

- Enables NRTs in the `Finbuckle.MultiTenant` and `Finbuckle.MultiTenant.Test` projects
- Updates the projects to handle the new warnings
- The code should maintain existing functionality
    - Where larger changes are required, I used the null-forgiveness operator to avoid breaking changes (These can be improved later on when other breaking changes are considered)
    - Please take a careful look to make sure I didn't break anything with my changes