### PR TITLE
feat: add BasePathStrategy option to rebase the AspNetCore Request.PathBase

### DIFF
--- a/docs/Strategies.md
+++ b/docs/Strategies.md
@@ -1,17 +1,28 @@
 # MultiTenant Strategies
 
-A multitenant strategy is responsible for defining how the tenant is determined. It ultimately produces an identifier string which is used to create a `TenantInfo` object with information from the [MultiTenant store](Stores).
+A multitenant strategy is responsible for defining how the tenant is determined. It ultimately produces an identifier
+string which is used to create a `TenantInfo` object with information from the [MultiTenant store](Stores).
 
-Finbuckle.MultiTenant supports several "out-of-the-box" strategies for resolving the tenant. Custom strategies can be created by implementing `IMultiTenantStrategy` or using `DelegateStrategy`.
+Finbuckle.MultiTenant supports several "out-of-the-box" strategies for resolving the tenant. Custom strategies can be
+created by implementing `IMultiTenantStrategy` or using `DelegateStrategy`.
 
-The `Strategy` property on the `StrategyInfo` member of `MultiTenantContext` instance returned by `HttpContext.GetMultiTenantContext()` returns the actual strategy used to resolve the tenant information for the current context.
+The `Strategy` property on the `StrategyInfo` member of `MultiTenantContext` instance returned
+by `HttpContext.GetMultiTenantContext()` returns the actual strategy used to resolve the tenant information for the
+current context.
 
 ## IMultiTenantStrategy and Custom Strategies
-All multitenant strategies derive from `IMultiTenantStrategy` and must implement the `GetIdentifierAsync` method. 
 
-If an identifier can't be determined, `GetIdentifierAsync` should return null which will ultimately result in a null `TenantInfo`.
+All multitenant strategies derive from `IMultiTenantStrategy` and must implement the `GetIdentifierAsync` method.
 
-Configure a custom implementation of `IMultiTenantStrategy` by calling `WithStrategy<TStrategy>` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup` class. There are several available overrides for configuring the strategy. The first override uses dependency injection along with any passed parameters to construct the implementation instance. The second override accepts a `Func<IServiceProvider, TStrategy>` factory method for even more customization. The library internally decorates any `IMultiTenantStrategy` with a wrapper providing basic logging and exception handling.
+If an identifier can't be determined, `GetIdentifierAsync` should return null which will ultimately result in a
+null `TenantInfo`.
+
+Configure a custom implementation of `IMultiTenantStrategy` by calling `WithStrategy<TStrategy>`
+after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup` class. There are several available
+overrides for configuring the strategy. The first override uses dependency injection along with any passed parameters to
+construct the implementation instance. The second override accepts a `Func<IServiceProvider, TStrategy>` factory method
+for even more customization. The library internally decorates any `IMultiTenantStrategy` with a wrapper providing basic
+logging and exception handling.
 
 ```cs
 // Register a custom strategy with the templated method.
@@ -25,12 +36,12 @@ services.AddMultiTenant<TenantInfo>()
 ```
 
 ## Accessing the Strategies at Runtime
+
 MultiTenant strategies are registered in the dependency injection system under the
 `IMultiTenantStrategy` service type.
 
 If multiple strategies are registered a specific one can be retrieving an
-`IEnumerable<IMultiTenantStrategy>` and filtering to the specific implementation
-type:
+`IEnumerable<IMultiTenantStrategy>` and filtering to the specific implementation type:
 
 ```cs
 // Assume we have a service provider. The IEnumerable could be injected via
@@ -41,16 +52,23 @@ var strategy = serviceProvider.GetService<IEnumerable<IMultiTenantStrategy>>
 ```
 
 ## Using Multiple Strategies
-Multiple strategies can be registered after `AddMultiTenant<T>` and each strategy will be tried in the order configured until a non-null identifier is returned. The remaining strategies are skipped for that request.
 
-Note that some strategies are registered as singleton service so registering them multiple times after `AddMultiTenant<T>` is not recommended. The main use for registering multiple strategies of the same type is using several instances of the `DelegateStrategy` utilizing distinct logic.
+Multiple strategies can be registered after `AddMultiTenant<T>` and each strategy will be tried in the order configured
+until a non-null identifier is returned. The remaining strategies are skipped for that request.
+
+Note that some strategies are registered as singleton service so registering them multiple times
+after `AddMultiTenant<T>` is not recommended. The main use for registering multiple strategies of the same type is using
+several instances of the `DelegateStrategy` utilizing distinct logic.
 
 ## Static Strategy
+
 > NuGet package: Finbuckle.MultiTenant
 
-Always uses the same identifier to resolve the tenant. Often useful in testing or to resolve to a fallback or default tenant by registering the strategy last. This strategy is configured as a singleton.
+Always uses the same identifier to resolve the tenant. Often useful in testing or to resolve to a fallback or default
+tenant by registering the strategy last. This strategy is configured as a singleton.
 
-Configure by calling `WithStaticStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup` class and passing in the identifier to use for tenant resolution:
+Configure by calling `WithStaticStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup`
+class and passing in the identifier to use for tenant resolution:
 
 ```cs
 services.AddMultiTenant<TenantInfo>()
@@ -58,11 +76,17 @@ services.AddMultiTenant<TenantInfo>()
 ```
 
 ## Delegate Strategy
+
 > NuGet package: Finbuckle.MultiTenant
 
-Uses a provided `Func<object, Task<string>>` to determine the tenant. For example the lambda function `async context => "initech"` would use "initech" as the identifier when resolving the tenant for every request. This strategy is good to use for testing or simple logic. This strategy is configured as transient and multiple instances can be registered.
+Uses a provided `Func<object, Task<string>>` to determine the tenant. For example the lambda
+function `async context => "initech"` would use "initech" as the identifier when resolving the tenant for every request.
+This strategy is good to use for testing or simple logic. This strategy is configured as transient and multiple
+instances can be registered.
 
-Configure by calling `WithDelegateStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup` class. A `Func<object, Task<string>>`is passed in which will be used with each request to resolve the tenant. A lambda or async lambda can be used as the parameter:
+Configure by calling `WithDelegateStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup`
+class. A `Func<object, Task<string>>`is passed in which will be used with each request to resolve the tenant. A lambda
+or async lambda can be used as the parameter:
 
 ```cs
 // Use the request query parameter "tenant" to get the tenantId:
@@ -79,35 +103,55 @@ services.AddMultiTenant<TenantInfo>()
 ```
 
 ## Base Path Strategy
+
 > NuGet package: Finbuckle.MultiTenant.AspNetCore
 
-Uses the base (i.e. first) path segment to determine the tenant. For example, a request to "https://www.example.com/initech" would use "initech" as the identifier when resolving the tenant. This strategy is configured as a singleton.
+Uses the base (i.e. first) path segment to determine the tenant. For example, a request
+to "https://www.example.com/initech" would use "initech" as the identifier when resolving the tenant. This strategy is
+configured as a singleton.
 
-Configure by calling `WithBasePathStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup` class:
+Configure by calling `WithBasePathStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup`
+class:
 
 ```cs
 services.AddMultiTenant<TenantInfo>()
         .WithBasePathStrategy()...
 ```
 
+This strategy can also adjust the ASP.NET Core `Request.PathBase` and `Request.Path` variables so that subsequent
+middleware checking `Request.Path` do not see the tenant identifier segment but generated URLs are still valid. This can
+be useful in some scenarios where an application makes certain assumptions about paths that you otherwise cannot work
+around.
+
+For example, a request to `https://mydomain.com/mytenant/mypath` by default has a `Request.PathBase` of `/` and
+a `Request.Path` of `/mytenant/mypath`. Setting this option will adjust these values to `/mytenant` and `/mypath`
+respectively when a tenant is successfully resolved with the `BasePathStrategy`.
+
+```cs
+services.AddMultiTenant<TenantInfo>()
+        .WithBasePathStrategy(options =>
+        {
+          // defaults to false for compatibility
+          options.RebaseAspNetCorePathBase = true;
+        })...
+```
+
 ## Claim Strategy
+
 > NuGet package: Finbuckle.MultiTenant.AspNetCore
 
-Uses a claim to determine the tenant identifier. By default the first claim
-value with type `__tenant__` is used, but a custom type name can also be used.
-This strategy uses the default authentication scheme, which is usually cookie
-based, but does not go so far as to set `HttpContext.User`. Thus the ASP.NET
-Core authentication middleware should still be used as normal, and in most use
-cases should come after `UseMultiTenant` when using `ClaimsStrategy`. Due to how
-the authentication middleware is implemented there is practically no performance
-penalty when used in conjunction with the `ClaimStrategy`.
+Uses a claim to determine the tenant identifier. By default the first claim value with type `__tenant__` is used, but a
+custom type name can also be used. This strategy uses the default authentication scheme, which is usually cookie based,
+but does not go so far as to set `HttpContext.User`. Thus the ASP.NET Core authentication middleware should still be
+used as normal, and in most use cases should come after `UseMultiTenant` when using `ClaimsStrategy`. Due to how the
+authentication middleware is implemented there is practically no performance penalty when used in conjunction with
+the `ClaimStrategy`.
 
-Note that this strategy is does not work well with per-tenant cookie names since
-it must know the cookie name before the tenant is resolved.
+Note that this strategy is does not work well with per-tenant cookie names since it must know the cookie name before the
+tenant is resolved.
 
 Configure by calling `WithClaimStrategy` after `AddMultiTenant<T>` in the
-`ConfigureServices` method of the `Startup` class. An overload to accept a
-custom claim type is also available:
+`ConfigureServices` method of the `Startup` class. An overload to accept a custom claim type is also available:
 
 ```cs
 // This will check for a claim type __tenant__
@@ -118,12 +162,16 @@ services.AddMultiTenant<TenantInfo>()
 services.AddMultiTenant<TenantInfo>()
         .WithClaimStrategy("MyClaimType")...
 ```
+
 ## Session Strategy
+
 > NuGet package: Finbuckle.MultiTenant.AspNetCore
 
 Uses the ASP.NET Core session to retrieve the tenant identifier. This strategy is configured as a singleton.
 
-Configure by calling `WithSessionStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup` class. This will use a default session key named `__tenant__`. An overload of `WithSessionStrategy can be used to specify a different key name:
+Configure by calling `WithSessionStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup`
+class. This will use a default session key named `__tenant__`. An overload of `WithSessionStrategy can be used to
+specify a different key name:
 
 ```cs
 // Configure to use "__tenant__" as the session key,
@@ -135,12 +183,20 @@ services.AddMultiTenant<TenantInfo>()
         .WithSessionStrategy("my-tenant-session-key")...
 ```
 
-Note that an app will have to [configure session state](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/app-state?view=aspnetcore-3.1#session-state) accordingly and then actually set the session variable. A typical use case is to register the session strategy before a more expensive strategy. The expensive strategy can set the session value so that for subsequent requests resolve the tenant without invoking the expensive strategy.
+Note that an app will have
+to [configure session state](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/app-state?view=aspnetcore-3.1#session-state)
+accordingly and then actually set the session variable. A typical use case is to register the session strategy before a
+more expensive strategy. The expensive strategy can set the session value so that for subsequent requests resolve the
+tenant without invoking the expensive strategy.
 
 ## Route Strategy
+
 > NuGet package: Finbuckle.MultiTenant.AspNetCore
 
-Uses the `__tenant__` route parameter (or a specified route parameter) to determine the tenant. For example, a request to "https://www.example.com/initech/home/" and a route configuration of `{__tenant__}/{controller=Home}/{action=Index}` would use "initech" as the identifier when resolving the tenant. The `__tenant__` parameter can be placed anywhere in the route path configuration. This strategy is configured as a singleton.
+Uses the `__tenant__` route parameter (or a specified route parameter) to determine the tenant. For example, a request
+to "https://www.example.com/initech/home/" and a route configuration of `{__tenant__}/{controller=Home}/{action=Index}`
+would use "initech" as the identifier when resolving the tenant. The `__tenant__` parameter can be placed anywhere in
+the route path configuration. This strategy is configured as a singleton.
 
 ```cs
 public class Startup
@@ -185,18 +241,30 @@ public class Startup
 ```
 
 ## Host Strategy
+
 > NuGet package: Finbuckle.MultiTenant.AspNetCore
 
-Uses request's host value to determine the tenant. By default the first host segment is used. For example, a request to "https://initech.example.com/abc123" would use "initech" as the identifier when resolving the tenant. This strategy can be difficult to use in a development environment. Make sure the development system is configured properly to allow subdomains on `localhost`. This strategy is configured as a singleton.
+Uses request's host value to determine the tenant. By default the first host segment is used. For example, a request
+to "https://initech.example.com/abc123" would use "initech" as the identifier when resolving the tenant. This strategy
+can be difficult to use in a development environment. Make sure the development system is configured properly to allow
+subdomains on `localhost`. This strategy is configured as a singleton.
 
-The host strategy uses a template string which defines how the strategy will find the tenant identifier. The pattern specifies the location for the tenant identifier using "\_\_tenant\_\_" and can contain other valid domain characters. It can also use '?' and '\*' characters to represent one or "zero or more" segments. For example:
-  - `__tenant__.*` is the default if no pattern is provided and selects the first (or only) domain segment as the tenant identifier.
-  - `*.__tenant__.?` selects the main domain (or second to last) as the tenant identifier.
-  - `__tenant__.example.com` will always use the subdomain for the tenant identifier, but only if there are no prior subdomains and the overall host ends with "example.com".
-  - `*.__tenant__.?.?` is similar to the above example except it will select the first subdomain even if others exist and doesn't require ".com".
-  - As a special case, a pattern string of just `__tenant__` will use the entire host as the tenant identifier, as opposed to a single segment.
+The host strategy uses a template string which defines how the strategy will find the tenant identifier. The pattern
+specifies the location for the tenant identifier using "\_\_tenant\_\_" and can contain other valid domain characters.
+It can also use '?' and '\*' characters to represent one or "zero or more" segments. For example:
 
-Configure by calling `WithHostStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup` class. A template pattern can be specified with the overloaded version:
+- `__tenant__.*` is the default if no pattern is provided and selects the first (or only) domain segment as the tenant
+  identifier.
+- `*.__tenant__.?` selects the main domain (or second to last) as the tenant identifier.
+- `__tenant__.example.com` will always use the subdomain for the tenant identifier, but only if there are no prior
+  subdomains and the overall host ends with "example.com".
+- `*.__tenant__.?.?` is similar to the above example except it will select the first subdomain even if others exist and
+  doesn't require ".com".
+- As a special case, a pattern string of just `__tenant__` will use the entire host as the tenant identifier, as opposed
+  to a single segment.
+
+Configure by calling `WithHostStrategy` after `AddMultiTenant<T>` in the `ConfigureServices` method of the `Startup`
+class. A template pattern can be specified with the overloaded version:
 
 ```cs
 // Use the default template "__tenant__.*":
@@ -209,14 +277,14 @@ services.AddMultiTenant<TenantInfo>()
 ```
 
 ## Header Strategy
+
 > NuGet package: Finbuckle.MultiTenant.AspNetCore
 
-Uses an HTTP request header to determine the tenant identifier. By default the header
-with key `__tenant__` is used, but a custom key can also be used.
+Uses an HTTP request header to determine the tenant identifier. By default the header with key `__tenant__` is used, but
+a custom key can also be used.
 
 Configure by calling `WithHeaderStrategy` after `AddMultiTenant<T>` in the
-`ConfigureServices` method of the `Startup` class. An overload to accept a
-custom claim type is also available:
+`ConfigureServices` method of the `Startup` class. An overload to accept a custom claim type is also available:
 
 ```cs
 // This will check for a claim type __tenant__
@@ -229,9 +297,11 @@ services.AddMultiTenant<TenantInfo>()
 ```
 
 ## Remote Authentication Callback Strategy
+
 > NuGet package: Finbuckle.MultiTenant.AspNetCore
 
-This is a special strategy used for per-tenant authentication when remote authentication such as OpenID Connect or OAuth (e.g. Log in via Facebook) are used. This strategy is configured as a singleton.
+This is a special strategy used for per-tenant authentication when remote authentication such as OpenID Connect or
+OAuth (e.g. Log in via Facebook) are used. This strategy is configured as a singleton.
 
-The strategy is configured internally when `WithPerTenantAuthentication` is called
-to configure [per-tenant authentication](Authentication).
+The strategy is configured internally when `WithPerTenantAuthentication` is called to
+configure [per-tenant authentication](Authentication).

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -3,16 +3,21 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Finbuckle.MultiTenant;
 using Finbuckle.MultiTenant.AspNetCore;
+using Finbuckle.MultiTenant.AspNetCore.Options;
 using Finbuckle.MultiTenant.Internal;
 using Finbuckle.MultiTenant.Strategies;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -26,7 +31,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Configures authentication options to enable per-tenant behavior.
         /// </summary>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithPerTenantAuthentication<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithPerTenantAuthentication<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
             where TTenantInfo : class, ITenantInfo, new()
         {
             return WithPerTenantAuthentication(builder, _ => { });
@@ -39,8 +45,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="config">Authentication options config.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
         // ReSharper disable once MemberCanBePrivate.Global
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithPerTenantAuthentication<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder, Action<MultiTenantAuthenticationOptions> config)
-             where TTenantInfo : class, ITenantInfo, new()
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithPerTenantAuthentication<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder, Action<MultiTenantAuthenticationOptions> config)
+            where TTenantInfo : class, ITenantInfo, new()
         {
             builder.WithPerTenantAuthenticationCore(config);
             builder.WithPerTenantAuthenticationConventions();
@@ -55,7 +62,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
         [SuppressMessage("ReSharper", "EmptyGeneralCatchClause")]
         public static FinbuckleMultiTenantBuilder<TTenantInfo> WithPerTenantAuthenticationConventions<TTenantInfo>(
-            this FinbuckleMultiTenantBuilder<TTenantInfo> builder, Action<MultiTenantAuthenticationOptions>? config = null)
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder,
+            Action<MultiTenantAuthenticationOptions>? config = null)
             where TTenantInfo : class, ITenantInfo, new()
         {
             // Set events to set and validate tenant for each cookie based authentication principal.
@@ -66,10 +74,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.Events.OnValidatePrincipal = async context =>
                 {
                     // Skip if bypass set (e.g. ClaimsStrategy in effect)
-                    if(context.HttpContext.Items.Keys.Contains($"{Constants.TenantToken}__bypass_validate_principal__"))
+                    if (context.HttpContext.Items.Keys.Contains(
+                            $"{Constants.TenantToken}__bypass_validate_principal__"))
                         return;
 
-                    var currentTenant = context.HttpContext.GetMultiTenantContext<TTenantInfo>()?.TenantInfo?.Identifier;
+                    var currentTenant = context.HttpContext.GetMultiTenantContext<TTenantInfo>()?.TenantInfo
+                        ?.Identifier;
                     string? authTenant = null;
                     if (context.Properties.Items.ContainsKey(Constants.TenantToken))
                     {
@@ -78,11 +88,12 @@ namespace Microsoft.Extensions.DependencyInjection
                     else
                     {
                         var loggerFactory = context.HttpContext.RequestServices.GetService<ILoggerFactory>();
-                        loggerFactory?.CreateLogger<FinbuckleMultiTenantBuilder<TTenantInfo>>().LogWarning("No tenant found in authentication properties.");
+                        loggerFactory?.CreateLogger<FinbuckleMultiTenantBuilder<TTenantInfo>>()
+                            .LogWarning("No tenant found in authentication properties.");
                     }
 
                     // Does the current tenant match the auth property tenant?
-                    if(!string.Equals(currentTenant, authTenant, StringComparison.OrdinalIgnoreCase))
+                    if (!string.Equals(currentTenant, authTenant, StringComparison.OrdinalIgnoreCase))
                         context.RejectPrincipal();
 
                     await origOnValidatePrincipal(context);
@@ -93,25 +104,69 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.WithPerTenantOptions<CookieAuthenticationOptions>((options, tc) =>
             {
                 var d = (dynamic)tc;
-                try { options.LoginPath = ((string)d.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier); } catch { }
-                try { options.LogoutPath = ((string)d.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier); } catch { }
-                try { options.AccessDeniedPath = ((string)d.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier); } catch { }
+                try
+                {
+                    options.LoginPath = ((string)d.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier);
+                }
+                catch
+                {
+                }
+
+                try
+                {
+                    options.LogoutPath = ((string)d.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier);
+                }
+                catch
+                {
+                }
+
+                try
+                {
+                    options.AccessDeniedPath =
+                        ((string)d.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier);
+                }
+                catch
+                {
+                }
             });
 
             // Set per-tenant OpenIdConnect options by convention.
             builder.WithPerTenantOptions<OpenIdConnectOptions>((options, tc) =>
             {
                 var d = (dynamic)tc;
-                try { options.Authority = ((string)d.OpenIdConnectAuthority).Replace(Constants.TenantToken, tc.Identifier); } catch { }
-                try { options.ClientId = ((string)d.OpenIdConnectClientId).Replace(Constants.TenantToken, tc.Identifier); } catch { }
-                try { options.ClientSecret = ((string)d.OpenIdConnectClientSecret).Replace(Constants.TenantToken, tc.Identifier); } catch { }
+                try
+                {
+                    options.Authority =
+                        ((string)d.OpenIdConnectAuthority).Replace(Constants.TenantToken, tc.Identifier);
+                }
+                catch
+                {
+                }
+
+                try
+                {
+                    options.ClientId = ((string)d.OpenIdConnectClientId).Replace(Constants.TenantToken, tc.Identifier);
+                }
+                catch
+                {
+                }
+
+                try
+                {
+                    options.ClientSecret =
+                        ((string)d.OpenIdConnectClientSecret).Replace(Constants.TenantToken, tc.Identifier);
+                }
+                catch
+                {
+                }
             });
 
             var challengeSchemeProp = typeof(TTenantInfo).GetProperty("ChallengeScheme");
             if (challengeSchemeProp != null && challengeSchemeProp.PropertyType == typeof(string))
             {
                 builder.WithPerTenantOptions<AuthenticationOptions>((options, tc)
-                    => options.DefaultChallengeScheme = (string?)challengeSchemeProp.GetValue(tc) ?? options.DefaultChallengeScheme);
+                    => options.DefaultChallengeScheme =
+                        (string?)challengeSchemeProp.GetValue(tc) ?? options.DefaultChallengeScheme);
             }
 
             return builder;
@@ -128,7 +183,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 null)
             where TTenantInfo : class, ITenantInfo, new()
         {
-
             config ??= _ => { };
             builder.Services.Configure(config);
 
@@ -136,12 +190,14 @@ namespace Microsoft.Extensions.DependencyInjection
             // remote authentication can get the tenant from the authentication
             // properties in the state parameter.
             if (builder.Services.All(s => s.ServiceType != typeof(IAuthenticationService)))
-                throw new MultiTenantException("WithPerTenantAuthenticationCore() must be called after AddAuthentication() in ConfigureServices.");
+                throw new MultiTenantException(
+                    "WithPerTenantAuthenticationCore() must be called after AddAuthentication() in ConfigureServices.");
             builder.Services.DecorateService<IAuthenticationService, MultiTenantAuthenticationService<TTenantInfo>>();
 
             // Replace IAuthenticationSchemeProvider so that the options aren't
             // cached and can be used per-tenant.
-            builder.Services.Replace(ServiceDescriptor.Singleton<IAuthenticationSchemeProvider, MultiTenantAuthenticationSchemeProvider>());
+            builder.Services.Replace(ServiceDescriptor
+                .Singleton<IAuthenticationSchemeProvider, MultiTenantAuthenticationSchemeProvider>());
 
             return builder;
         }
@@ -151,7 +207,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="builder">MultiTenantBuilder instance.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithSessionStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithSessionStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
             where TTenantInfo : class, ITenantInfo, new()
             => builder.WithStrategy<SessionStrategy>(ServiceLifetime.Singleton, Constants.TenantToken);
 
@@ -161,7 +218,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">MultiTenantBuilder instance.</param>
         /// <param name="tenantKey">The session key to use.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithSessionStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantKey)
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithSessionStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantKey)
             where TTenantInfo : class, ITenantInfo, new()
             => builder.WithStrategy<SessionStrategy>(ServiceLifetime.Singleton, tenantKey);
 
@@ -169,7 +227,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds and configures a RemoteAuthenticationCallbackStrategy to the application.
         /// </summary>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithRemoteAuthenticationCallbackStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithRemoteAuthenticationCallbackStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
             where TTenantInfo : class, ITenantInfo, new()
         {
             return builder.WithStrategy<RemoteAuthenticationCallbackStrategy>(ServiceLifetime.Singleton);
@@ -179,15 +238,42 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds and configures a BasePathStrategy to the application.
         /// </summary>
         /// <returns>The same MultiTenantBuilder passed into the method.></returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithBasePathStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithBasePathStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
             where TTenantInfo : class, ITenantInfo, new()
-            => builder.WithStrategy<BasePathStrategy>(ServiceLifetime.Singleton);
+        {
+            builder.Services.Configure<MultiTenantOptions>(options =>
+            {
+                var origOnTenantResolved = options.Events.OnTenantResolved;
+                options.Events.OnTenantResolved = tenantResolvedContext =>
+                {
+                    var httpContext = tenantResolvedContext.Context as HttpContext ??
+                                      throw new MultiTenantException("BasePathStrategy expects HttpContext.");
+
+                    if (tenantResolvedContext.StrategyType == typeof(BasePathStrategy) &&
+                        httpContext.RequestServices.GetRequiredService<IOptions<BasePathStrategyOptions>>().Value
+                            .RebaseAspNetCorePathBase)
+                    {
+                        httpContext.Request.Path.StartsWithSegments($"/{tenantResolvedContext.TenantInfo.Identifier}",
+                            out var matched, out var
+                                newPath);
+                        httpContext.Request.PathBase = Path.Combine(httpContext.Request.PathBase, matched);
+                        httpContext.Request.Path = newPath;
+                    }
+
+                    return origOnTenantResolved(tenantResolvedContext);
+                };
+            });
+
+            return builder.WithStrategy<BasePathStrategy>(ServiceLifetime.Singleton);
+        }
 
         /// <summary>
         /// Adds and configures a RouteStrategy with a route parameter Constants.TenantToken to the application.
         /// </summary>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithRouteStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithRouteStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
             where TTenantInfo : class, ITenantInfo, new()
             => builder.WithRouteStrategy(Constants.TenantToken);
 
@@ -197,7 +283,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">MultiTenantBuilder instance.</param>
         /// <param name="tenantParam">The name of the route parameter used to determine the tenant identifier.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithRouteStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantParam)
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithRouteStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantParam)
             where TTenantInfo : class, ITenantInfo, new()
         {
             if (string.IsNullOrWhiteSpace(tenantParam))
@@ -213,7 +300,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds and configures a HostStrategy with template "__tenant__.*" to the application.
         /// </summary>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithHostStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithHostStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
             where TTenantInfo : class, ITenantInfo, new()
             => builder.WithHostStrategy($"{Constants.TenantToken}.*");
 
@@ -223,7 +311,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">MultiTenantBuilder instance.</param>
         /// <param name="template">The template for determining the tenant identifier in the host.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithHostStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string template)
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithHostStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string template)
             where TTenantInfo : class, ITenantInfo, new()
         {
             if (string.IsNullOrWhiteSpace(template))
@@ -238,7 +327,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds and configures a ClaimStrategy for claim name "__tenant__" to the application. Uses the default authentication handler scheme.
         /// </summary>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithClaimStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder) where TTenantInfo : class, ITenantInfo, new()
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithClaimStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder) where TTenantInfo : class, ITenantInfo, new()
         {
             return builder.WithClaimStrategy(Constants.TenantToken);
         }
@@ -249,7 +339,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">MultiTenantBuilder instance.</param>
         /// <param name="tenantKey">Claim name for determining the tenant identifier.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithClaimStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantKey) where TTenantInfo : class, ITenantInfo, new()
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithClaimStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantKey)
+            where TTenantInfo : class, ITenantInfo, new()
         {
             BypassSessionPrincipalValidation(builder);
             return builder.WithStrategy<ClaimStrategy>(ServiceLifetime.Singleton, tenantKey);
@@ -262,13 +354,16 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="tenantKey">Claim name for determining the tenant identifier.</param>
         /// <param name="authenticationScheme">The authentication scheme to check for claims.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithClaimStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantKey, string authenticationScheme) where TTenantInfo : class, ITenantInfo, new()
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithClaimStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantKey, string authenticationScheme)
+            where TTenantInfo : class, ITenantInfo, new()
         {
             BypassSessionPrincipalValidation(builder);
             return builder.WithStrategy<ClaimStrategy>(ServiceLifetime.Singleton, tenantKey, authenticationScheme);
         }
 
-        private static void BypassSessionPrincipalValidation<TTenantInfo>(FinbuckleMultiTenantBuilder<TTenantInfo> builder)
+        private static void BypassSessionPrincipalValidation<TTenantInfo>(
+            FinbuckleMultiTenantBuilder<TTenantInfo> builder)
             where TTenantInfo : class, ITenantInfo, new()
         {
             builder.Services.ConfigureAll<CookieAuthenticationOptions>(options =>
@@ -277,7 +372,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.Events.OnValidatePrincipal = async context =>
                 {
                     // Skip if bypass set (e.g. ClaimStrategy in effect)
-                    if (context.HttpContext.Items.Keys.Contains($"{Constants.TenantToken}__bypass_validate_principal__"))
+                    if (context.HttpContext.Items.Keys.Contains(
+                            $"{Constants.TenantToken}__bypass_validate_principal__"))
                         return;
 
                     if (origOnValidatePrincipal != null)
@@ -290,7 +386,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds and configures a HeaderStrategy with tenantKey "__tenant__" to the application.
         /// </summary>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithHeaderStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder) where TTenantInfo : class, ITenantInfo, new()
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithHeaderStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder) where TTenantInfo : class, ITenantInfo, new()
         {
             return builder.WithStrategy<HeaderStrategy>(ServiceLifetime.Singleton, Constants.TenantToken);
         }
@@ -301,7 +398,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">MultiTenantBuilder instance.</param>
         /// <param name="tenantKey">The template for determining the tenant identifier in the host.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithHeaderStrategy<TTenantInfo>(this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantKey) where TTenantInfo : class, ITenantInfo, new()
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithHeaderStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantKey)
+            where TTenantInfo : class, ITenantInfo, new()
         {
             return builder.WithStrategy<HeaderStrategy>(ServiceLifetime.Singleton, tenantKey);
         }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -240,8 +240,20 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The same MultiTenantBuilder passed into the method.></returns>
         public static FinbuckleMultiTenantBuilder<TTenantInfo> WithBasePathStrategy<TTenantInfo>(
             this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
+            where TTenantInfo : class, ITenantInfo, new() => WithBasePathStrategy(builder, configureOptions =>
+        {
+            configureOptions.RebaseAspNetCorePathBase = false;
+        });
+
+        /// <summary>
+        /// Adds and configures a BasePathStrategy to the application.
+        /// </summary>
+        /// <returns>The same MultiTenantBuilder passed into the method.></returns>
+        public static FinbuckleMultiTenantBuilder<TTenantInfo> WithBasePathStrategy<TTenantInfo>(
+            this FinbuckleMultiTenantBuilder<TTenantInfo> builder, Action<BasePathStrategyOptions> configureOptions)
             where TTenantInfo : class, ITenantInfo, new()
         {
+            builder.Services.Configure(configureOptions);
             builder.Services.Configure<MultiTenantOptions>(options =>
             {
                 var origOnTenantResolved = options.Events.OnTenantResolved;

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -18,7 +18,9 @@ namespace Finbuckle.MultiTenant
         public static IMultiTenantContext<T>? GetMultiTenantContext<T>(this HttpContext httpContext)
         where T : class, ITenantInfo, new()
         {
-            return httpContext.RequestServices.GetRequiredService<IMultiTenantContextAccessor<T>>().MultiTenantContext;
+            var services = httpContext.RequestServices;
+            var context = services.GetRequiredService<IMultiTenantContextAccessor<T>>();
+            return context?.MultiTenantContext;
         }
 
         /// <summary>

--- a/src/Finbuckle.MultiTenant.AspNetCore/Options/BasePathStrategyOptions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Options/BasePathStrategyOptions.cs
@@ -1,0 +1,11 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more inforation.
+
+namespace Finbuckle.MultiTenant.AspNetCore.Options
+{
+    public class BasePathStrategyOptions
+    {
+        // TODO make this default to true in next major release
+        public bool RebaseAspNetCorePathBase { get; set; } = false;
+    }
+}

--- a/src/Finbuckle.MultiTenant/MultiTenantOptions.cs
+++ b/src/Finbuckle.MultiTenant/MultiTenantOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 
+// TODO move to options folder/namespace on future major release
 namespace Finbuckle.MultiTenant
 {
     public class MultiTenantOptions

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using Finbuckle.MultiTenant.AspNetCore.Options;
 using Finbuckle.MultiTenant.Strategies;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -496,6 +497,36 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
 
             var strategy = sp.GetRequiredService<IMultiTenantStrategy>();
             Assert.IsType<BasePathStrategy>(strategy);
+        }
+        
+        [Fact]
+        public void AddBasePathStrategyDefaultRebaseFalse()
+        {
+            var services = new ServiceCollection();
+            var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
+            builder.WithBasePathStrategy();
+            var sp = services.BuildServiceProvider();
+
+            var strategy = sp.GetRequiredService<IMultiTenantStrategy>();
+            Assert.IsType<BasePathStrategy>(strategy);
+
+            var options = sp.GetRequiredService<IOptions<BasePathStrategyOptions>>();
+            Assert.False(options.Value.RebaseAspNetCorePathBase);
+        }
+        
+        [Fact]
+        public void AddBasePathStrategyWithOptions()
+        {
+            var services = new ServiceCollection();
+            var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
+            builder.WithBasePathStrategy(configureOptions => configureOptions.RebaseAspNetCorePathBase = true);
+            var sp = services.BuildServiceProvider();
+
+            var strategy = sp.GetRequiredService<IMultiTenantStrategy>();
+            Assert.IsType<BasePathStrategy>(strategy);
+
+            var options = sp.GetRequiredService<IOptions<BasePathStrategyOptions>>();
+            Assert.True(options.Value.RebaseAspNetCorePathBase);
         }
 
         [Fact]

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
@@ -519,7 +519,7 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
         {
             var services = new ServiceCollection();
             var builder = new FinbuckleMultiTenantBuilder<TenantInfo>(services);
-            builder.WithBasePathStrategy(configureOptions => configureOptions.RebaseAspNetCorePathBase = true);
+            builder.WithBasePathStrategy(options => options.RebaseAspNetCorePathBase = true);
             var sp = services.BuildServiceProvider();
 
             var strategy = sp.GetRequiredService<IMultiTenantStrategy>();

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Finbuckle.MultiTenant.AspNetCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Finbuckle.MultiTenant.AspNetCore.Test.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
-    <PackageReference Include="Moq" Version="4.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Moq" Version="4.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/BasePathStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/BasePathStrategyShould.cs
@@ -2,8 +2,10 @@
 // Refer to the solution LICENSE file for more inforation.
 
 using System;
+using Finbuckle.MultiTenant.AspNetCore.Options;
 using Finbuckle.MultiTenant.Strategies;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -14,9 +16,68 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Strategies
         private HttpContext CreateHttpContextMock(string path)
         {
             var mock = new Mock<HttpContext>();
-            mock.Setup(c => c.Request.Path).Returns(path);
-
+            mock.SetupProperty<PathString>(c => c.Request.Path, path);
+            mock.SetupProperty<PathString>(c => c.Request.PathBase, "/");
+            mock.SetupProperty(c => c.RequestServices);
             return mock.Object;
+        }
+
+        [Fact]
+        public async void RebaseAspNetCoreBasePathIfOptionTrue()
+        {
+
+            var services = new ServiceCollection();
+            services.AddOptions().AddMultiTenant<TenantInfo>().WithBasePathStrategy().WithInMemoryStore(options =>
+            {
+                options.Tenants.Add(new TenantInfo
+                {
+                    Id = "base123",
+                    Identifier = "base",
+                    Name = "base tenant"
+                });
+            });
+            services.Configure<BasePathStrategyOptions>(options => options.RebaseAspNetCorePathBase = true);
+            var serviceProvider = services.BuildServiceProvider();
+            var httpContext = CreateHttpContextMock("/base/notbase");
+            httpContext.RequestServices = serviceProvider;
+
+            Assert.Equal("/", httpContext.Request.PathBase);
+            Assert.Equal("/base/notbase", httpContext.Request.Path);
+            
+            // will trigger OnTenantFound event...
+            var resolver = await serviceProvider.GetRequiredService<ITenantResolver>().ResolveAsync(httpContext);
+
+            Assert.Equal("/base", httpContext.Request.PathBase);
+            Assert.Equal("/notbase", httpContext.Request.Path);
+        }
+        
+        [Fact]
+        public async void NotRebaseAspNetCoreBasePathIfOptionFalse()
+        {
+
+            var services = new ServiceCollection();
+            services.AddOptions().AddMultiTenant<TenantInfo>().WithBasePathStrategy().WithInMemoryStore(options =>
+            {
+                options.Tenants.Add(new TenantInfo
+                {
+                    Id = "base123",
+                    Identifier = "base",
+                    Name = "base tenant"
+                });
+            });
+            services.Configure<BasePathStrategyOptions>(options => options.RebaseAspNetCorePathBase = false);
+            var serviceProvider = services.BuildServiceProvider();
+            var httpContext = CreateHttpContextMock("/base/notbase");
+            httpContext.RequestServices = serviceProvider;
+
+            Assert.Equal("/", httpContext.Request.PathBase);
+            Assert.Equal("/base/notbase", httpContext.Request.Path);
+            
+            // will trigger OnTenantFound event...
+            var resolver = await serviceProvider.GetRequiredService<ITenantResolver>().ResolveAsync(httpContext);
+
+            Assert.Equal("/", httpContext.Request.PathBase);
+            Assert.Equal("/base/notbase", httpContext.Request.Path);
         }
 
         [Theory]


### PR DESCRIPTION
This feature provides an option for `BasePathStrategy` to adjust the `Request.PathBase` and `Request.Path` properties to move the tenant path over to the `Request.PathBase`. This allows any logic after the middleware to see the path without and concern for the tenant in the base path -- i.e. it will look like the path on a regular non-multitenant app which can be useful in certain situations.

- [x] implementation
- [x] tests
- [ ] docs