### PR TITLE
chore: update cicd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           npm install -D @semantic-release/git
           npm install -D @semantic-release/changelog
           npm install -D @semantic-release/exec
+          npm install -D conventional-changelog-conventionalcommits
       - name: run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,16 +1,19 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/github",
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits"
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits"
+    }],"@semantic-release/github",
     "@semantic-release/changelog",
     ["@semantic-release/exec", {
-      "prepareCmd": "sed -E -i 's/<(Version|span class=\"_version\")>.*<\\/(Version|span)>/<\\1>${nextRelease.version}<\\/\\2>/' Directory.Build.props *.md docs/*.md"
+      "prepareCmd": "./release.sh -f private -v ${nextRelease.version} -r \"${nextRelease.notes}\""
     }],
     ["@semantic-release/git", {
       "assets": ["Directory.Build.props", "*.md", "docs"],
-      "message": "chore(release-prep): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      "message": "chore: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }]
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,32 @@
-## [6.5.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.5.0...v6.5.1) (2021-11-17)
+### [6.5.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.5.0...v6.5.1) (2021-11-17)
 
 
 ### Bug Fixes
 
 * ClaimStrategy validation bypass type principle changed to principal ([#493](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/493)) ([fbfd022](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/fbfd0228c8b30a5f663fd2dfade0ae1b5bda09da))
 
-# [6.5.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.4.2...v6.5.0) (2021-11-08)
+## [6.5.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.4.2...v6.5.0) (2021-11-08)
 
 
 ### Features
 
 * add .NET 6 support ([#489](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/489)) ([a2d0416](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/a2d041670bf7efb198b06a864bad0a4cfc490a0c))
 
-## [6.4.2](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.4.1...v6.4.2) (2021-10-25)
+### [6.4.2](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.4.1...v6.4.2) (2021-10-25)
 
 
 ### Bug Fixes
 
 * change Options types from internal to public ([#483](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/483)) ([af9521d](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/af9521d993ce1c0369662c8db26d790c06c521f3))
 
-## [6.4.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.4.0...v6.4.1) (2021-10-11)
+### [6.4.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.4.0...v6.4.1) (2021-10-11)
 
 
 ### Bug Fixes
 
 * options not validating ([d4c6f30](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/d4c6f30d8d78b9e1c42a627f426a8ca867bc860f))
 
-# [6.4.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.3.1...v6.4.0) (2021-10-07)
+## [6.4.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.3.1...v6.4.0) (2021-10-07)
 
 
 ### Bug Fixes
@@ -38,7 +38,7 @@
 
 * add optional parameter to specify the ClaimStrategy authentication scheme. ([#398](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/398)) thanks @Valks! ([d74ae41](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/d74ae41a71b9df6a95a711ef3bad6d4ebc9f73f7))
 
-## [6.3.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.3.0...v6.3.1) (2021-09-30)
+### [6.3.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.3.0...v6.3.1) (2021-09-30)
 
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![Finbuckle Logo](https://www.finbuckle.com/images/finbuckle-32x32-gh.png) Finbuckle.MultiTenant <span class="_version"></span>
+# ![Finbuckle Logo](https://www.finbuckle.com/images/finbuckle-32x32-gh.png) Finbuckle.MultiTenant <span class="_version">6.5.1</span>
 
 ## About Finbuckle.MultiTenant
 
@@ -8,7 +8,7 @@ See [https://www.finbuckle.com/multitenant](https://www.finbuckle.com/multitenan
 
 Tablef of Contents
 
-1. [What's New in Finbuckle.MultiTenant <span class="_version"></span>](#whats-new)
+1. [What's New in Finbuckle.MultiTenant <span class="_version">6.5.1</span>](#whats-new)
 2. [Quick Start](#quick-start)
 3. [Documentation](#documentation)
 4. [Sample Projects](#samples)
@@ -20,9 +20,12 @@ Tablef of Contents
 10. [Building from Source](#building-from-source)
 11. [Running Unit Tests](#running-unit-tests)
 
-## <a name="whats-new"></a> What's New in Finbuckle.MultiTenant <span class="_version"></span>
+## <a name="whats-new"></a> What's New in Finbuckle.MultiTenant <span class="_version">6.5.1</span>
 
 <!--_release-notes-->
+### Bug Fixes
+
+* ClaimStrategy validation bypass type principle changed to principal ([#493](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/493)) ([fbfd022](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/fbfd0228c8b30a5f663fd2dfade0ae1b5bda09da))
 <!--_release-notes-->
 
 See the [changelog file](CHANGELOG.md) for a full history of changes.

--- a/README.md
+++ b/README.md
@@ -1,116 +1,108 @@
-# ![Finbuckle Logo](https://www.finbuckle.com/images/finbuckle-32x32-gh.png) Finbuckle.MultiTenant <span class="_version">6.5.1</span>
+# ![Finbuckle Logo](https://www.finbuckle.com/images/finbuckle-32x32-gh.png) Finbuckle.MultiTenant <span class="_version"></span>
 
 ## About Finbuckle.MultiTenant
 
-Finbuckle.MultiTenant is open source multitenancy middleware library for .NET. It enables tenant resolution, per-tenant app behavior, and per-tenant data isolation. See [https://www.finbuckle.com/multitenant](https://www.finbuckle.com/multitenant) for more details and documentation.
+Finbuckle.MultiTenant is an open-source multitenancy middleware library for .NET. It enables tenant resolution,
+per-tenant app behavior, and per-tenant data isolation.
+See [https://www.finbuckle.com/multitenant](https://www.finbuckle.com/multitenant) for more details and documentation.
 
-## Main Build and Test Status
+Tablef of Contents
 
-![Build Status Linux 6.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/linux-6.0.yml/badge.svg)  
-![Build Status MacOS 6.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/macos-6.0.yml/badge.svg)  
-![Build Status Windows 6.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/windows-6.0.yml/badge.svg)
+1. [What's New in Finbuckle.MultiTenant <span class="_version"></span>](#whats-new)
+2. [Quick Start](#quick-start)
+3. [Documentation](#documentation)
+4. [Sample Projects](#samples)
+5. [Build and Test Status](#build-and-test-status)
+6. [License](#license)
+7. [.NET Foundation](#net-foundation)
+8. [Code of Conduct](#code-of-conduct)
+9. [Community](#community)
+10. [Building from Source](#building-from-source)
+11. [Running Unit Tests](#running-unit-tests)
 
-![Build Status Linux 5.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/linux-5.0.yml/badge.svg)  
-![Build Status MacOS 5.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/macos-5.0.yml/badge.svg)  
-![Build Status Windows 5.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/windows-5.0.yml/badge.svg)
+## <a name="whats-new"></a> What's New in Finbuckle.MultiTenant <span class="_version"></span>
 
-![Build Status Linux 3.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/linux-3.1.yml/badge.svg)  
-![Build Status MacOS 3.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/macos-3.1.yml/badge.svg?)  
-![Build Status Windows 3.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/windows-3.1.yml/badge.svg)
+<!--_release-notes-->
+<!--_release-notes-->
 
-## License
-
-This project uses the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0). See [LICENSE](LICENSE) file for license information.
-
-## .NET Foundation
-
-This project is supported by the [.NET Foundation](https://dotnetfoundation.org).
-
-## Code of Conduct
-
-This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community.
-For more information see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct) or the [CONTRIBUTING.md](CONTRIBUTING.md) file.
-
-## Community
-
-Check out the [GitHub repository](https://github.com/Finbuckle/Finbuckle.MultiTenant) to ask a question, make a request, or check out the code!
-
-## Sample Projects
-
-In addition to this documentation a variety of sample projects are available in the 'samples' directory. Be sure to read the information on the index page of each sample and the code comments in the `Startup` class.
+See the [changelog file](CHANGELOG.md) for a full history of changes.
 
 ## Quick Start
 
-Finbuckle.MultiTenant is designed to be easy to use and follows standard .NET conventions as much as possible. This introduction assumes a standard ASP.NET Core
-use case, but any application using .NET dependency injection can work with the library.
+Finbuckle.MultiTenant is designed to be easy to use and follows standard .NET conventions as much as possible. This
+introduction assumes a standard ASP.NET Core use case, but any application using .NET dependency injection can work with
+the library.
 
 ### Installation
 
 First, install the Finbuckle.MultiTenant.AspNetCore NuGet package:
 
 .NET Core CLI
+
 ```bash
 $ dotnet add package Finbuckle.MultiTenant.AspNetCore
 ```
 
 ### Basic Configuration
 
-Next, in the app's startup `ConfigureServices` method call `AddMultiTenant<T>` and its various builder methods:
+Next, in the app's service configuration call `AddMultiTenant<T>` and its various builder methods:
 
 ```cs
-public void ConfigureServices(IServiceCollection services)
-{
-    ...
-    services.AddMultiTenant<TenantInfo>()
-            .WithHostStrategy()
-            .WithConfigurationStore()
-    ...
-}
+builder.Services.AddMultiTenant<TenantInfo>()
+                .WithHostStrategy()
+                .WithConfigurationStore();
 ```
 
-Finally, in the `Configure` method call `UseMultiTenant()` to register the middleware:
+Finally, in the app pipeline configuration call `UseMultiTenant()` before `UseEndpoints(...)` to register the
+middleware:
 
 ```cs
-public void Configure(IApplicationBuilder app)
-{
-    ...
-    app.UseMultiTenant(); // Before UseEndpoints!
-    ...
-    app.UseEndpoints(...);
-}
+app.UseMultiTenant();
+...
+app.UseEndpoints(...);
 ```
 
 That's all that is needed to get going. Let's breakdown each line:
 
-`services.AddMultiTenant<TenantInfo>()`
+`builder.Services.AddMultiTenant<TenantInfo>()`
 
-This line registers the base services and designates `TenantInfo` as the class that will hold tenant information at runtime.
+This line registers the base services and designates `TenantInfo` as the class that will hold tenant information at
+runtime.
 
-The type parameter for `AddMultiTenant<T>` must be an implementation of `ITenantInfo` and holds basic information about the tenant such as its name and an identifier. `TenantInfo` is provided as a basic implementation, but a custom implementation can be used if more properties are needed.
+The type parameter for `AddMultiTenant<T>` must be an implementation of `ITenantInfo` and holds basic information about
+the tenant such as its name and an identifier. `TenantInfo` is provided as a basic implementation, but a custom
+implementation can be used if more properties are needed.
 
 See [Core Concepts](https://www.finbuckle.com/MultiTenant/Docs/CoreConcepts) for more information on `ITenantInfo`.
 
 `.WithHostStrategy()`
 
-The line tells the app that our "strategy" to determine the request tenant will be to look at the request host, which defaults to the extracting the subdomain as a tenant identifier.
+The line tells the app that our "strategy" to determine the request tenant will be to look at the request host, which
+defaults to the extracting the subdomain as a tenant identifier.
 
 See [Strategies](https://www.finbuckle.com/MultiTenant/Docs/Strategies) for more information.
 
 `.WithConfigurationStore()`
 
-This line tells the app that information for all tenants are in the `appsettings.json` file used for app configuration. If a tenant in the store has the identifier found by the strategy, the tenant will be successfully resolved for the current request.
+This line tells the app that information for all tenants are in the `appsettings.json` file used for app configuration.
+If a tenant in the store has the identifier found by the strategy, the tenant will be successfully resolved for the
+current request.
 
 See [Stores](https://www.finbuckle.com/MultiTenant/Docs/Stores) for more information.
 
-Finbuckle.MultiTenant comes with a collection of strategies and store types that can be mixed and matched in various ways.
+Finbuckle.MultiTenant comes with a collection of strategies and store types that can be mixed and matched in various
+ways.
 
-`app.MultiTenant()`
+`app.UseMultiTenant()`
 
-This line configures the middleware which resolves the tenant using the registered strategies, stores, and other settings. Be sure to call it before calling `UseEndpoints()` and other middleware which will use per-tenant functionality, e.g. `UseAuthentication()`.
+This line configures the middleware which resolves the tenant using the registered strategies, stores, and other
+settings. Be sure to call it before calling `UseEndpoints()` and other middleware which will use per-tenant
+functionality, e.g. `UseAuthentication()`.
 
 ### Basic Usage
 
-With the services and middleware configured, access information for the current tenant from the `TenantInfo` property on the `MultiTenantContext<T>` object accessed from the `GetMultiTenantContext<T>` extension method:
+With the services and middleware configured, access information for the current tenant from the `TenantInfo` property on
+the `MultiTenantContext<T>` object accessed from the `GetMultiTenantContext<T>` extension method:
 
 ```cs
 var tenantInfo = HttpContext.GetMultiTenantContext<TenantInfo>().TenantInfo;
@@ -123,26 +115,56 @@ if(tenantInfo != null)
 }
 ```
 
-The type of the `TenantInfo` property depends on the type passed when calling `AddMultiTenant<T>` during configuration. If the current tenant could not be determined then `TenantInfo` will be null.
+The type of the `TenantInfo` property depends on the type passed when calling `AddMultiTenant<T>` during configuration.
+If the current tenant could not be determined then `TenantInfo` will be null.
 
 The `ITenantInfo` instance and/or the typed instance are also available directly through dependency injection.
 
 See [Configuration and Usage](https://www.finbuckle.com/MultiTenant/Docs/ConfigurationAndUsage) for more information.
 
-## Advanced Usage
+## Documentation
 
-The library builds on this basic functionality to provide a variety of higher level features. See the documentation for more details:
+The library builds on this basic functionality to provide a variety of higher level features. See the [documentation](https://www.finbuckle.com/multitenant/docs) for
+more details:
 
 * [Per-tenant Options](https://www.finbuckle.com/MultiTenant/Docs/Options)
 * [Per-tenant Authentication](https://www.finbuckle.com/MultiTenant/Docs/Authentication)
 * [Entity Framework Core Data Isolation](https://www.finbuckle.com/MultiTenant/Docs/EFCore)
 * [ASP.NET Core Identity Data Isolation](https://www.finbuckle.com/MultiTenant/Docs/Identity)
 
-## Samples
+## Samples Projects
 
-A variety of sample projects are available in the `samples` directory. Be sure to read the information on the index page of each sample and the code comments in the `Startup` class.
+A variety of [sample projects](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/main/samples) are available in the repository.
 
-## Compiling from Source
+## Build and Test Status
+
+| Windows                                                                                                                     | Linux                                                                                                                   | macOS                                                                                                                     |
+|-----------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| ![Build Status Windows 6.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/windows-6.0.yml/badge.svg) | ![Build Status Linux 6.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/linux-6.0.yml/badge.svg) | ![Build Status MacOS 6.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/macos-6.0.yml/badge.svg)   |
+| ![Build Status Windows 5.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/windows-5.0.yml/badge.svg) | ![Build Status Linux 5.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/linux-5.0.yml/badge.svg) | ![Build Status MacOS 5.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/macos-5.0.yml/badge.svg)   |
+| ![Build Status Windows 3.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/windows-3.1.yml/badge.svg) | ![Build Status Linux 3.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/linux-3.1.yml/badge.svg) | ![Build Status MacOS 3.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/actions/workflows/macos-3.1.yml/badge.svg?)  |
+
+## License
+
+This project uses the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0). See [LICENSE](LICENSE) file for
+license information.
+
+## .NET Foundation
+
+This project is supported by the [.NET Foundation](https://dotnetfoundation.org).
+
+## Code of Conduct
+
+This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our
+community. For more information see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct)
+or the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+
+## Community
+
+Check out the [GitHub repository](https://github.com/Finbuckle/Finbuckle.MultiTenant) to ask a question, make a request,
+or peruse the code!
+
+## Building from Source
 
 From the command line clone the git repository, `cd` into the new directory, and compile with `dotnet build`.
 

--- a/docs/History.md
+++ b/docs/History.md
@@ -1,0 +1,4 @@
+# Version History
+
+<!--_history-->
+<!--_history-->

--- a/docs/History.md
+++ b/docs/History.md
@@ -1,4 +1,217 @@
 # Version History
 
 <!--_history-->
+### [6.5.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.5.0...v6.5.1) (2021-11-17)
+
+
+### Bug Fixes
+
+* ClaimStrategy validation bypass type principle changed to principal ([#493](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/493)) ([fbfd022](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/fbfd0228c8b30a5f663fd2dfade0ae1b5bda09da))
+
+## [6.5.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.4.2...v6.5.0) (2021-11-08)
+
+
+### Features
+
+* add .NET 6 support ([#489](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/489)) ([a2d0416](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/a2d041670bf7efb198b06a864bad0a4cfc490a0c))
+
+### [6.4.2](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.4.1...v6.4.2) (2021-10-25)
+
+
+### Bug Fixes
+
+* change Options types from internal to public ([#483](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/483)) ([af9521d](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/af9521d993ce1c0369662c8db26d790c06c521f3))
+
+### [6.4.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.4.0...v6.4.1) (2021-10-11)
+
+
+### Bug Fixes
+
+* options not validating ([d4c6f30](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/d4c6f30d8d78b9e1c42a627f426a8ca867bc860f))
+
+## [6.4.0](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.3.1...v6.4.0) (2021-10-07)
+
+
+### Bug Fixes
+
+* ClaimStrategy bypass cookie principal validation ([#475](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/475)) ([cd38a7f](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/cd38a7f25f3eb4ccbf3fcc546cf93f2d2463df39))
+
+
+### Features
+
+* add optional parameter to specify the ClaimStrategy authentication scheme. ([#398](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/398)) thanks @Valks! ([d74ae41](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/d74ae41a71b9df6a95a711ef3bad6d4ebc9f73f7))
+
+### [6.3.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.3.0...v6.3.1) (2021-09-30)
+
+
+### Bug Fixes
+
+* revert some platform targets to netstandard ([#469](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/469)) ([aceff1d](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/aceff1d73540b22ef64c6cec0fd50e43eff5387b))
+
+**6.3.0**
+* Removed support for .NET Core 2.1 which ended Microsoft support in August 2020.
+* Retargeted specifically to .netcoreapp3.1 and .net5.0 across all packages.
+* Added `AdjustKey`, `AdjustIndex`, `AdjustAlIndexes`, `AdjustUniqueIndexes` methods to be chained off `IsMultiTenant` in EFCore functionality. They add the implicit `TenantId` to the respective key/indexes.
+* Reverted generic version of `IsMultiTenant` back to non-generic version for more flexibility.
+* Improved tenant resolution logging functionality and performance. Thanks to **@lahma**!
+* Fixed a bug with `InMemoryStore` implementation of `TryUpdate`. Thanks to **@mphill**!
+* Fixed a bug where `ConfigurationStore` would throw an exception if there was no default section in the config.
+* Fixed a bug where ASP.NET Core Identity security stamp validation would force user logout and raise exceptions. Thanks to **@Nivalux** for finding the root cause of this bug.
+* Fixed a bug where `MultiTenantOptionsManager<TOptions>` was internal instead of public.
+* Fixed problematic references in sample projects.
+* Updated and improved documentation.
+* Updated and improved tests.
+* Added various project files for .NET Foundation on-boarding.
+
+**6.2.0**
+* Added a new events system. See PR #359 Thanks to **@natelaff**!
+* Some internal refactoring.
+* Various documentation fixes.
+* Added sourcelink to allow debugging into remote source code.
+* Added a security policy.
+
+**6.1.0**
+* .NET 5.0 support.
+* New `DistributedCacheStore` uses the ASP.NET Core distributed cache for tenant resolution.
+* New `HeaderStrategy` uses HTTP headers for tenant resolution. Thanks to **@natelaff**!
+* Support for inheritance in multitenant Entity Framework Core entity. Thanks to **@rchamorro**!
+* Fixed a conflict between ClaimStrategy and per-tenant authentication.
+* Updated docs, samples, and unit tests.
+
+**6.0.0**
+* Customizable `TenantInfo`. Implement `ITenantInfo` as needed or use the basic `TenantInfo` implementation. Should work with most strategies and stores. This was a major overhaul to the library. See docs for more information.
+* Changed NuGet structure: use `Finbuckle.MultiTenant.AspNetCore` for web apps and if needed add `Finbuckle.MultiTenant.EntityFrameworkCore`.
+* `WithPerTenantAuthentication` - Adds support for common per-tenant authentication scenarios. See docs for full details.
+* Multiple strategies and stores can be registe red. They will run in the order registered and the first tenant returned by a strategy/store combination is used.
+* New `ClaimStrategy` checks for a tenant claim to resolve the tenant.
+* New `SessionStrategy` uses a session variable to resolve the tenant.
+* Refactored `InMemoryStore`, removed deprecated configuration functionality.
+* Improved Blazor support.
+* Improved support for non ASP.NET Core use cases.
+* Removed support for ASP.NET 3.0.
+* Removed `FallbackStrategy`, `StaticStrategy` is a better alternative.
+* Bug fixes, refactors, and tweaks.
+* Improved unit tests.
+* Updated and improved documentation.
+* Updated sample. Removed some older ASP.NET Core 2.1 samples.
+
+**5.0.4**
+* Fixed a conflicting assembly and NuGet versions.
+* Minor documentation fix.
+
+**5.0.3**
+* Fixed a bug where documented static methods were internal rather than public.
+* Minor documentation fix.
+
+**5.0.1**
+* Updated for [.NET Core January 2020 Updates](https://devblogs.microsoft.com/dotnet/net-core-january-2020/) adding support for .NET Core 2.1.15, 3.0.2, and 3.1.1.
+* Updated dependencies as recommended in security notices for [.NET Core January 2020 Updates](https://devblogs.microsoft.com/dotnet/net-core-january-2020/).
+* *Finbuckle.MultiTenant.AspNetCore* targets `netcoreapp3.1`, `netcoreapp3.0`, and `netcoreapp2.1`.
+* *Finbuckle.MultiTenant.Core* targets `netstandard2.1` and `netstandard2.0`.
+* *Finbuckle.MultiTenant.EntityFrameworkCore* targets `netstandard2.1` and `netstandard2.0`.
+
+**5.0.0**
+* Added support for ASP.NET Core 3.1.
+* Major refactor of how Entity Framework multitenant data isolation works. No longer need to derive from `MultiTenantDbContext` greatly improving flexibility. `IdentityMultiTenantDbContext` reworked under this new model and no longer requires or recommends use of multitenant support classes, e.g. `MultiTenantIdentityUser`. Attempted to minimize impact, but if using `IdentityMultiTenantDbContext` **this may be a breaking change!** Thanks **@GordonBlahut**!
+* Simplified `EFCoreStore` to use `TenantInfo` directly. **This is a breaking change!**
+* Fixed a bug with user id not being set correctly in legacy 'IdentityMultiTenantDbContext'.
+* Added `ConfigurationStore` to load tenant information from app configuration. The store is read-only in code, but changes in configuration (e.g. appsettings.json) are picked up at runtime. Updated most sample projects to use this store.
+* Deprecated `InMemoryStore` functionality that reads from configuration.
+* Added `HttpRemoteStore` which will make an http request to get a `TenantInfo` object. It can be extended with `DelegatingHandler`s (i.e. to add authentication headers). Added sample projects for this store. Thanks to **@colindekker**!
+* Fixed an exception with OpenIdConnect remote authentication if "state" is not returned from the identity provider. The new behavior will result in no tenant found for the request.
+* Updated samples.
+* Updated documentation.
+* Updated unit tests.
+
+**4.0.0**
+* Added support for ASP.NET Core 3! Valid project targets are `netcoreapp3.0`, `netcoreapp2.0`, and `netcoreapp2.1`.
+* Added a sample app for ASP.NET 3 highlighting the route strategy improvements due to the endpoint routing mechanism.
+* Fixed a bug where route strategy could throw an exception when used with Razor Pages. Thanks @stardocs-services!
+* Support for configuring multiple multitenant strategies. Each will be tried in the order configured until a non-null tenant identifier is returned. The exception is the fallback strategy which always goes last.
+* Refactored component assemblies for better dependency control. EFCore can be excluded by referencing `Finbuckle.MultiTenant.AspNetCore` instead of `Finbuckle.MultiTenant`.
+* Updated documentation.
+* Updated unit tests to check against all valid project targets.
+* Symbols package included for debugging.
+
+**3.2.0**
+* Added support for any preexisting global query filters in `MultiTenantDbContext` and `MultiTenantIdentityDbContext`. Thanks @nbarbettini!
+* Exposed the inner stores and strategies as a property on the respective `StoreInfo` and `StrategyInfo` properties of `MultiTenantContext`. Previously you could only access the wrapper object for each. Thanks @WalternativE!
+* Fixed certain methods on `MultiTenantOptionsCache` to be external as originally intended. Thanks @chernihiv!
+* Fix a bug with `TryUpdateAsync` in the wrapper store. Thanks @steebwba!
+* Updated documentation and fixed typos. Thanks @MesfinMo!
+
+**3.1.0**
+* Added a strategy wrapper that handles validation and logging for the active strategy. When implementing `IMultiTenantStrategy` basic validation and logging are automatically provided.
+* Added the delegate strategy that accepts a lambda to return the tenant identifier. Configure by calling `WithDelegateStrategy(...)`.
+* Added the fallback strategy that provides a tenant identifier if the normal strategy (or remote authentication, if applicable) fails to resolve a tenant. Configure by calling `WithFallbackStrategy(...)`.
+* Added `TrySetTenantInfo` as an extension method to `HttpContext`. This will set the `TenantInfo` provided as the current tenant for the request and can optionally reset the service providers so that scoped services are regenerated under the new tenant.
+* Updated and improved documentation and sample projects.
+* Miscellaneous bug fixes, code improvement, and unit tests.
+* Thanks to @nbarbettini for contributing to this release.
+
+**3.0.1**
+* Refactored  the global query filter used in `MultiTenantDbContext` and `MultiTenantIdentityDbContext` (Thanks @GordonBlahut!) for better performance and code quality.
+* Removed custom `IModelCacheKeyFactory` as it is no longer needed due to the global query filter changes.
+* Updated documentation and samples.
+
+**3.0.0**
+* Allow resetting option cache per-tenant. This is a breaking change.
+* Host strategy can match entire domain as a special case (prior it only matched a single host segment).
+* Added a sample project demonstrating a common login page shared by all tenants.
+* Overhauled documentation.
+* Updated unit and integration tests.
+
+**2.0.2**
+* Fixed bug in Identity where `UserLogins` primary key was not adjusted for multitenant usage.
+* Updated and Fixed the IdentityDataIsolation sample project.
+* General code and test cleanup.
+
+**2.0.1**
+* Fixed bug where the `TenantInfo` constructor did not save the passed `Items` collection.
+* Tested for compatibility with ASP.NET Core 2.2.
+* Updated samples for ASP.NET Core 2.2.
+* Cleaned up library dependencies to target ASP.NET Core 2.1 or greater.
+
+**2.0.0 General Changes**
+* Changed `TenantContext` to `MultiTenantContext` which includes `TenantInfo`, `StrategyInfo`, and `StoreInfo` properties.
+* Namespace changes (e.g. use of `Microsoft.Extensions.DependencyInjection` namespace for `Configure` and `ConfigureServices` methods).
+* Additional and improved unit tests.
+* Updated sample project dependencies.
+* Various other internal improvements to code and bug fixes.
+
+**2.0.0 MultiTenant Store Enhancements**
+* `TryUpdate` method added to `IMultiTenantStore` interface.
+* Added `EFCoreStore` which allows an Entity Framework Core database context as the tenant store.
+* Added sample project demonstrating use of `EFCoreStore`.
+* Custom can be configured with custom dependency injection lifetime (single, scoped, or transient) via `WithStore` method overloads.
+* Custom stores automatically receive logging and error support via internal use of `MultiTenantStoreWrapper`.
+
+**2.0.0 MultiTenant Strategy Enhancements**
+* Use of async/await for strategy execution for improved performance.
+* Custom strategies can be configured with custom dependency injection lifetime (single, scoped, or transient) via `WithStrategy` method overloads.
+* Moved route configuration for RouteStrategy from `UseMultiTenant` to `WithRouteStrategy`.
+
+**1.2.0**
+* Added variants of `MultiTenantIdentityDbContext` which allows more flexible integration with Identity (Thanks @Cpcrook!)
+* Added sample project for data isolation with Identity
+* Minor refactoring and more unit tests
+* Various bug fixes
+
+**1.1.1**
+* Fixed bug affecting per-tenant data isolation using a shared database
+* Added sample project for data isolation
+* Added new constructors for `MultiTenantDbContext` and `MultiTenantIdentityDbContext`
+
+**1.1.0**
+* Remote authentication support
+* Strategy improvements
+* Store improvements
+* Per-tenant options improvements
+* Logging support
+* Updated samples
+* Improved unit and integration tests
+* Switch to Apache 2.0 license
+
+**1.0.0**
+* Initial release
 <!--_history-->

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -1,6 +1,6 @@
 [Introduction](Introduction)
 
-[What's New in Finbuckle.MultiTenant <span class="_version"></span>](WhatsNew)
+[What's New in Finbuckle.MultiTenant <span class="_version">6.5.1</span>](WhatsNew)
 
 [Version History](History)
 

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -1,5 +1,9 @@
 [Introduction](Introduction)
 
+[What's New in Finbuckle.MultiTenant <span class="_version"></span>](WhatsNew)
+
+[Version History](History)
+
 [Getting Started](GettingStarted)
 
 [Core Concepts](CoreConcepts)

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -1,4 +1,4 @@
-# ![Finbuckle Logo](https://www.finbuckle.com/images/finbuckle-32x32-gh.png) Finbuckle.MultiTenant <span class="_version">6.5.1</span>
+# ![Finbuckle Logo](https://www.finbuckle.com/images/finbuckle-32x32-gh.png) Finbuckle.MultiTenant <span class="_version"></span>
 
 ## About Finbuckle.MultiTenant
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -1,4 +1,4 @@
-# ![Finbuckle Logo](https://www.finbuckle.com/images/finbuckle-32x32-gh.png) Finbuckle.MultiTenant <span class="_version"></span>
+# ![Finbuckle Logo](https://www.finbuckle.com/images/finbuckle-32x32-gh.png) Finbuckle.MultiTenant <span class="_version">6.5.1</span>
 
 ## About Finbuckle.MultiTenant
 

--- a/docs/WhatsNew.md
+++ b/docs/WhatsNew.md
@@ -1,0 +1,4 @@
+# What's New in Finbuckle.MultiTenant <span class="_version></span>
+
+<!--_release-notes-->
+<!--_release-notes-->

--- a/docs/WhatsNew.md
+++ b/docs/WhatsNew.md
@@ -1,4 +1,10 @@
-# What's New in Finbuckle.MultiTenant <span class="_version></span>
+# What's New in Finbuckle.MultiTenant <span class="_version>6.5.1</span>
 
 <!--_release-notes-->
+### [6.5.1](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v6.5.0...v6.5.1) (2021-11-17)
+
+
+### Bug Fixes
+
+* ClaimStrategy validation bypass type principle changed to principal ([#493](https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/493)) ([fbfd022](https://github.com/Finbuckle/Finbuckle.MultiTenant/commit/fbfd0228c8b30a5f663fd2dfade0ae1b5bda09da))
 <!--_release-notes-->

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This script is intended for use with semantic-release prepare step with
+# the exec plugin.
+
+while getopts v:r:f: flag
+do
+    case "${flag}" in
+        v) version=${OPTARG};;
+        r) release_notes=${OPTARG};;
+        f) feed_type=${OPTARG};;
+    esac
+done
+
+# Update the Version property in Directory.Build.props:
+sed -E -i 's|<Version>.*</Version>|<Version>'"${version}"'</Version>|g' Directory.Build.props
+
+# Update the version in readme and docs files with <span class="_version"> elements:
+sed -E -i 's|<span class="_version">.*</span>|<span class="_version">'"${version}"'</span>|g' README.md docs/*.md
+
+# Set text to display whether the release is public feed or private feed:
+sed -E -i 's|<span class="_release-feed-type">.*</span>|<span class="_release-feed-type">'"${feed_type}"'</span>|g' README.md docs/*.md
+
+# Set text wherever release notes are needed in docs:
+perl -i -0777 -pe 's|<!--_release-notes-->.*<!--_release-notes-->|<!--_release-notes-->\n'"${release_notes}"'\n<!--_release-notes-->|s' docs/*.md
+
+# Set text for release notes in readme (header line stripped):
+release_notes_no_header=$(echo -e "${release_notes}" | tail -n +2)
+perl -i -0777 -pe 's|<!--_release-notes-->.*<!--_release-notes-->|<!--_release-notes-->\n'"${release_notes_no_header}"'\n<!--_release-notes-->|s' README.md
+
+# Copy the new changelog file to the Version History docs page:
+history=$(<CHANGELOG.md)
+perl -i -0777 -pe 's|<!--_history-->.*<!--_history-->|<!--_history-->\n'"${history}"'\n<!--_history-->|s' docs/History.md


### PR DESCRIPTION
This PR updates the cicd to be able to plug in the release version and release notes as needed into various files, e.g. documentation.