### PR TITLE
fix: remove tenant id value generator

### DIFF
--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
@@ -12,15 +12,15 @@ using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Finbuckle.MultiTenant.EntityFrameworkCore
 {
-    public class TenantIdGenerator : ValueGenerator<string?>
-    {
-        public override string? Next(EntityEntry entry)
-        {
-            return ((IMultiTenantDbContext)entry.Context).TenantInfo.Id;
-        }
-
-        public override bool GeneratesTemporaryValues => false;
-    }
+    // public class TenantIdGenerator : ValueGenerator<string?>
+    // {
+    //     public override string? Next(EntityEntry entry)
+    //     {
+    //         return ((IMultiTenantDbContext)entry.Context).TenantInfo.Id;
+    //     }
+    //
+    //     public override bool GeneratesTemporaryValues => false;
+    // }
 
     public static class FinbuckleEntityTypeBuilderExtensions
     {
@@ -52,8 +52,8 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore
             {
                 builder.Property<string>("TenantId")
                        .IsRequired()
-                       .HasMaxLength(Finbuckle.MultiTenant.Internal.Constants.TenantIdMaxLength)
-                       .HasValueGenerator<TenantIdGenerator>();
+                       .HasMaxLength(Finbuckle.MultiTenant.Internal.Constants.TenantIdMaxLength);
+//                       .HasValueGenerator<TenantIdGenerator>();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The generator was running into potential EFCore bugs and conflicted with the design intent of `TenantNotSetMode`.