### PR TITLE
fix: Update scheme provider to support decorator pattern

### DIFF
--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -194,10 +194,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     "WithPerTenantAuthenticationCore() must be called after AddAuthentication() in ConfigureServices.");
             builder.Services.DecorateService<IAuthenticationService, MultiTenantAuthenticationService<TTenantInfo>>();
 
-            // Replace IAuthenticationSchemeProvider so that the options aren't
-            // cached and can be used per-tenant.
-            builder.Services.Replace(ServiceDescriptor
-                .Singleton<IAuthenticationSchemeProvider, MultiTenantAuthenticationSchemeProvider>());
+            // We need to "decorate" IAuthenticationScheme provider.
+            builder.Services.DecorateService<IAuthenticationSchemeProvider, MultiTenantAuthenticationSchemeProvider>();
 
             return builder;
         }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantAuthenticationSchemeProvider.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantAuthenticationSchemeProvider.cs
@@ -23,7 +23,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
 
         /// <summary>
         /// Creates an instance of <see cref="MultiTenantAuthenticationSchemeProvider"/>
-        /// using the specified <paramref name="options"/>,
+        /// using the specified <paramref name="options"/> and decorates the existing <paramref name="inner"/>.
         /// </summary>
         /// <param name="inner">The <see cref="IAuthenticationSchemeProvider"/> to decorate.</param>
         /// <param name="options">The <see cref="AuthenticationOptions"/> options.</param>
@@ -34,7 +34,7 @@ namespace Finbuckle.MultiTenant.AspNetCore
 
         /// <summary>
         /// Creates an instance of <see cref="MultiTenantAuthenticationSchemeProvider"/>
-        /// using the specified <paramref name="options"/> and <paramref name="schemes"/>.
+        /// using the specified <paramref name="options"/> and <paramref name="schemes"/>. This instance decorates the existing <paramref name="inner"/>.
         /// </summary>
         /// <param name="inner">The <see cref="IAuthenticationSchemeProvider"/> to decorate.</param>
         /// <param name="options">The <see cref="AuthenticationOptions"/> options.</param>

--- a/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantAuthenticationSchemeProvider.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Internal/MultiTenantAuthenticationSchemeProvider.cs
@@ -19,13 +19,16 @@ namespace Finbuckle.MultiTenant.AspNetCore
     /// </summary>
     internal class MultiTenantAuthenticationSchemeProvider : IAuthenticationSchemeProvider
     {
+        private readonly IAuthenticationSchemeProvider _inner;
+
         /// <summary>
         /// Creates an instance of <see cref="MultiTenantAuthenticationSchemeProvider"/>
         /// using the specified <paramref name="options"/>,
         /// </summary>
+        /// <param name="inner">The <see cref="IAuthenticationSchemeProvider"/> to decorate.</param>
         /// <param name="options">The <see cref="AuthenticationOptions"/> options.</param>
-        public MultiTenantAuthenticationSchemeProvider(IOptions<AuthenticationOptions> options)
-            : this(options, new Dictionary<string, AuthenticationScheme>(StringComparer.Ordinal))
+        public MultiTenantAuthenticationSchemeProvider(IAuthenticationSchemeProvider inner, IOptions<AuthenticationOptions> options)
+            : this(inner, options, new Dictionary<string, AuthenticationScheme>(StringComparer.Ordinal))
         {
         }
 
@@ -33,10 +36,12 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// Creates an instance of <see cref="MultiTenantAuthenticationSchemeProvider"/>
         /// using the specified <paramref name="options"/> and <paramref name="schemes"/>.
         /// </summary>
+        /// <param name="inner">The <see cref="IAuthenticationSchemeProvider"/> to decorate.</param>
         /// <param name="options">The <see cref="AuthenticationOptions"/> options.</param>
         /// <param name="schemes">The dictionary used to store authentication schemes.</param>
-        public MultiTenantAuthenticationSchemeProvider(IOptions<AuthenticationOptions> options, IDictionary<string, AuthenticationScheme> schemes)
+        public MultiTenantAuthenticationSchemeProvider(IAuthenticationSchemeProvider inner, IOptions<AuthenticationOptions> options, IDictionary<string, AuthenticationScheme> schemes)
         {
+            _inner = inner;
             _optionsProvider = options;
 
             _schemes = schemes ?? throw new ArgumentNullException(nameof(schemes));
@@ -122,8 +127,22 @@ namespace Finbuckle.MultiTenant.AspNetCore
         /// </summary>
         /// <param name="name">The name of the authenticationScheme.</param>
         /// <returns>The scheme or null if not found.</returns>
-        public virtual Task<AuthenticationScheme?> GetSchemeAsync(string name)
-            => Task.FromResult(_schemes.ContainsKey(name) ? _schemes[name] : null);
+        public virtual async Task<AuthenticationScheme?> GetSchemeAsync(string name)
+        {
+            AuthenticationScheme? scheme = null;
+
+            if (_inner != null)
+            {
+                scheme = await _inner.GetSchemeAsync(name);
+            }
+
+            if (scheme == null)
+            {
+                scheme = _schemes.ContainsKey(name) ? _schemes[name] : null;
+            }
+
+            return scheme;
+        }
 
         /// <summary>
         /// Returns the scheme for this tenants in priority order for request handling.


### PR DESCRIPTION
This change addresses: #548 

This allows the existing Duende Identity Server dynamic identity providers to be used when Finbuckle is running by decorating Duende's `IAuthenticationSchemeProvider`.