### PR TITLE
Corrected various async/await code issues 

### DIFF
--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/BasePathStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/BasePathStrategy.cs
@@ -9,7 +9,7 @@ namespace Finbuckle.MultiTenant.Strategies
 {
     public class BasePathStrategy : IMultiTenantStrategy
     {
-        public async Task<string?> GetIdentifierAsync(object context)
+        public Task<string?> GetIdentifierAsync(object context)
         {
             if(!(context is HttpContext httpContext))
                 throw new MultiTenantException(null,
@@ -21,11 +21,11 @@ namespace Finbuckle.MultiTenant.Strategies
                 path.Value?.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
             if (pathSegments is null || pathSegments.Length == 0)
-                return null;
+                return Task.FromResult<string?>(null);
 
             string identifier = pathSegments[0];
 
-            return await Task.FromResult(identifier); // Prevent the compliler warning that no await exists.
+            return Task.FromResult<string?>(identifier);
         }
     }
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/ClaimStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/ClaimStrategy.cs
@@ -62,7 +62,7 @@ namespace Finbuckle.MultiTenant.Strategies
 			httpContext.Items.Remove($"{Constants.TenantToken}__bypass_validate_principal__");
 
 			var identifier = handlerResult.Principal?.FindFirst(_tenantKey)?.Value;
-			return await Task.FromResult(identifier);
+			return identifier;
 		}
 	}
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/HeaderStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/HeaderStrategy.cs
@@ -2,6 +2,7 @@
 // Refer to the solution LICENSE file for more inforation.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
@@ -15,13 +16,13 @@ namespace Finbuckle.MultiTenant.Strategies
             _headerKey = headerKey;
         }
 
-        public async Task<string?> GetIdentifierAsync(object context)
+        public Task<string?> GetIdentifierAsync(object context)
         {
             if (!(context is HttpContext httpContext))
                 throw new MultiTenantException(null,
                     new ArgumentException($"\"{nameof(context)}\" type must be of type HttpContext", nameof(context)));
 
-            return await Task.FromResult(httpContext?.Request.Headers[_headerKey]);
+            return Task.FromResult(httpContext?.Request.Headers[_headerKey].FirstOrDefault());
         }
     }
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/HostStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/HostStrategy.cs
@@ -61,7 +61,7 @@ namespace Finbuckle.MultiTenant.Strategies
             this.regex = $"^{template}$";
         }
 
-        public async Task<string?> GetIdentifierAsync(object context)
+        public Task<string?> GetIdentifierAsync(object context)
         {
             if (!(context is HttpContext httpContext))
                 throw new MultiTenantException(null,
@@ -70,7 +70,7 @@ namespace Finbuckle.MultiTenant.Strategies
             var host = httpContext.Request.Host;
 
             if (host.HasValue == false)
-                return null;
+                return Task.FromResult<string?>(null);
 
             string? identifier = null;
 
@@ -83,7 +83,7 @@ namespace Finbuckle.MultiTenant.Strategies
                 identifier = match.Groups["identifier"].Value;
             }
 
-            return await Task.FromResult(identifier);
+            return Task.FromResult(identifier);
         }
     }
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RouteStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RouteStrategy.cs
@@ -21,7 +21,7 @@ namespace Finbuckle.MultiTenant.Strategies
             this.tenantParam = tenantParam;
         }
 
-        public async Task<string?> GetIdentifierAsync(object context)
+        public Task<string?> GetIdentifierAsync(object context)
         {
 
             if (!(context is HttpContext httpContext))
@@ -31,7 +31,7 @@ namespace Finbuckle.MultiTenant.Strategies
             object? identifier;
             httpContext.Request.RouteValues.TryGetValue(tenantParam, out identifier);
 
-            return await Task.FromResult(identifier as string);
+            return Task.FromResult(identifier as string);
         }
     }
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/SessionStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/SessionStrategy.cs
@@ -21,14 +21,14 @@ namespace Finbuckle.MultiTenant.Strategies
             this.tenantKey = tenantKey;
         }
 
-        public async Task<string?> GetIdentifierAsync(object context)
+        public Task<string?> GetIdentifierAsync(object context)
         {
             if(!(context is HttpContext httpContext))
                 throw new MultiTenantException(null,
                     new ArgumentException($"\"{nameof(context)}\" type must be of type HttpContext", nameof(context)));
 
             var identifier = httpContext.Session.GetString(tenantKey);
-            return await Task.FromResult(identifier); // Prevent the compliler warning that no await exists.
+            return Task.FromResult(identifier); // Prevent the compliler warning that no await exists.
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/BasePathStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/BasePathStrategyShould.cs
@@ -97,12 +97,12 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Strategies
         }
 
         [Fact]
-        public void ThrowIfContextIsNotHttpContext()
+        public async void ThrowIfContextIsNotHttpContext()
         {
             var context = new Object();
             var strategy = new BasePathStrategy();
 
-            Assert.Throws<AggregateException>(() => strategy.GetIdentifierAsync(context).Result);
+            await Assert.ThrowsAsync<MultiTenantException>(() => strategy.GetIdentifierAsync(context));
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/HostStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/HostStrategyShould.cs
@@ -70,12 +70,12 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Strategies
         }
 
         [Fact]
-        public void ThrowIfContextIsNotHttpContext()
+        public async void ThrowIfContextIsNotHttpContext()
         {
             var context = new Object();
             var strategy = new HostStrategy("__tenant__.*");
 
-            Assert.Throws<AggregateException>(() => strategy.GetIdentifierAsync(context).Result);
+            await Assert.ThrowsAsync<MultiTenantException>(() => strategy.GetIdentifierAsync(context));
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/RouteStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/RouteStrategyShould.cs
@@ -31,12 +31,12 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Strategies
         }
 
         [Fact]
-        public void ThrowIfContextIsNotHttpContext()
+        public async void ThrowIfContextIsNotHttpContext()
         {
             var context = new Object();
             var strategy = new RouteStrategy("__tenant__");
 
-            Assert.Throws<AggregateException>(() => strategy.GetIdentifierAsync(context).Result);
+            await Assert.ThrowsAsync<MultiTenantException>(() => strategy.GetIdentifierAsync(context));
         }
 
         [Fact]

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/SessionStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/SessionStrategyShould.cs
@@ -52,12 +52,12 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Strategies
         }
 
         [Fact]
-        public void ThrowIfContextIsNotHttpContext()
+        public async void ThrowIfContextIsNotHttpContext()
         {
             var context = new Object();
             var strategy = new SessionStrategy("__tenant__");
 
-            Assert.Throws<AggregateException>(() => strategy.GetIdentifierAsync(context).Result);
+            await Assert.ThrowsAsync<MultiTenantException>(() => strategy.GetIdentifierAsync(context));
         }
 
         [Fact]


### PR DESCRIPTION
This PR removes various async/await keywords in places where they are not needed and unnecessary. This also fixes the exception propagation in those methods. 

Tests are fixed to capture the proper exception types, instead of "aggregate" exceptions.

This code path is quite hot, therefore it is beneficial to fix these.