### PR TITLE
Improved WithPerTenantAuthenticationConventions code to not throw

### DIFF
--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -106,7 +106,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 var dynamicTenantInfo = (dynamic)tc;
                 if (dynamicTenantInfo != null)
                 {
-                    ;
                     options.LoginPath = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.LoginPath)) ? ((string)dynamicTenantInfo.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
                     options.LogoutPath = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.LogoutPath)) ? ((string)dynamicTenantInfo.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
                     options.AccessDeniedPath = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.AccessDeniedPath)) != null ? ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -103,61 +103,24 @@ namespace Microsoft.Extensions.DependencyInjection
             // Set per-tenant cookie options by convention.
             builder.WithPerTenantOptions<CookieAuthenticationOptions>((options, tc) =>
             {
-                var d = (dynamic)tc;
-                try
+                var dynamicTenantInfo = (dynamic)tc;
+                if (dynamicTenantInfo != null)
                 {
-                    options.LoginPath = ((string)d.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier);
-                }
-                catch
-                {
-                }
-
-                try
-                {
-                    options.LogoutPath = ((string)d.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier);
-                }
-                catch
-                {
-                }
-
-                try
-                {
-                    options.AccessDeniedPath =
-                        ((string)d.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier);
-                }
-                catch
-                {
+                    options.LoginPath = dynamicTenantInfo.LoginPath != null ? ((string)dynamicTenantInfo.CookieLoginPath).Replace(TenantToken, tc.Identifier) : string.Empty;
+                    options.LogoutPath = dynamicTenantInfo.LogoutPath != null ? ((string)dynamicTenantInfo.CookieLogoutPath).Replace(TenantToken, tc.Identifier) : string.Empty;
+                    options.AccessDeniedPath = dynamicTenantInfo.AccessDeniedPath != null ? ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(TenantToken, tc.Identifier) : string.Empty;
                 }
             });
 
             // Set per-tenant OpenIdConnect options by convention.
             builder.WithPerTenantOptions<OpenIdConnectOptions>((options, tc) =>
             {
-                var d = (dynamic)tc;
-                try
+                var dynamicTenantInfo = (dynamic)tc;
+                if (dynamicTenantInfo != null)
                 {
-                    options.Authority =
-                        ((string)d.OpenIdConnectAuthority).Replace(Constants.TenantToken, tc.Identifier);
-                }
-                catch
-                {
-                }
-
-                try
-                {
-                    options.ClientId = ((string)d.OpenIdConnectClientId).Replace(Constants.TenantToken, tc.Identifier);
-                }
-                catch
-                {
-                }
-
-                try
-                {
-                    options.ClientSecret =
-                        ((string)d.OpenIdConnectClientSecret).Replace(Constants.TenantToken, tc.Identifier);
-                }
-                catch
-                {
+                    options.Authority = dynamicTenantInfo.OpenIdConnectAuthority != null ? ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(TenantToken, tc.Identifier) : string.Empty;
+                    options.ClientId = dynamicTenantInfo.OpenIdConnectClientId != null ? ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(TenantToken, tc.Identifier) : string.Empty;
+                    options.ClientSecret = dynamicTenantInfo.OpenIdConnectClientSecret != null ? ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(TenantToken, tc.Identifier) : string.Empty;
                 }
             });
 

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Security.Principal;
 using System.Threading.Tasks;
 using Finbuckle.MultiTenant;
 using Finbuckle.MultiTenant.AspNetCore;
@@ -106,9 +107,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 var dynamicTenantInfo = (dynamic)tc;
                 if (dynamicTenantInfo != null)
                 {
-                    options.LoginPath = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.LoginPath)) ? ((string)dynamicTenantInfo.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.LogoutPath = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.LogoutPath)) ? ((string)dynamicTenantInfo.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.AccessDeniedPath = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.AccessDeniedPath)) != null ? ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.LoginPath = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.CookieLoginPath)) ? ((string)dynamicTenantInfo.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.LogoutPath = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.CookieLogoutPath)) ? ((string)dynamicTenantInfo.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.AccessDeniedPath = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.CookieAccessDeniedPath)) ? ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
                 }
             });
 
@@ -118,9 +119,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 var dynamicTenantInfo = (dynamic)tc;
                 if (dynamicTenantInfo != null)
                 {
-                    options.Authority = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.OpenIdConnectAuthority)) ? ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.ClientId = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.OpenIdConnectClientId)) ? ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.ClientSecret = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.OpenIdConnectClientSecret)) ? ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.Authority = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectAuthority)) ? ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.ClientId = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectClientId)) ? ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.ClientSecret = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectClientSecret)) ? ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
                 }
             });
 
@@ -133,6 +134,22 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             return builder;
+
+            bool HasPropertyWithValidValue(dynamic entity, string propertyName)
+            {
+                var property = entity.GetType().GetProperty(propertyName);
+                if (property != null)
+                {
+                    if (string.IsNullOrWhiteSpace(property.GetValue(entity, null)))
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -106,9 +106,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 var dynamicTenantInfo = (dynamic)tc;
                 if (dynamicTenantInfo != null)
                 {
-                    options.LoginPath = dynamicTenantInfo.LoginPath != null ? ((string)dynamicTenantInfo.CookieLoginPath).Replace(TenantToken, tc.Identifier) : string.Empty;
-                    options.LogoutPath = dynamicTenantInfo.LogoutPath != null ? ((string)dynamicTenantInfo.CookieLogoutPath).Replace(TenantToken, tc.Identifier) : string.Empty;
-                    options.AccessDeniedPath = dynamicTenantInfo.AccessDeniedPath != null ? ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(TenantToken, tc.Identifier) : string.Empty;
+                    options.LoginPath = dynamicTenantInfo.LoginPath != null ? ((string)dynamicTenantInfo.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.LogoutPath = dynamicTenantInfo.LogoutPath != null ? ((string)dynamicTenantInfo.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.AccessDeniedPath = dynamicTenantInfo.AccessDeniedPath != null ? ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
                 }
             });
 
@@ -118,9 +118,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 var dynamicTenantInfo = (dynamic)tc;
                 if (dynamicTenantInfo != null)
                 {
-                    options.Authority = dynamicTenantInfo.OpenIdConnectAuthority != null ? ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(TenantToken, tc.Identifier) : string.Empty;
-                    options.ClientId = dynamicTenantInfo.OpenIdConnectClientId != null ? ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(TenantToken, tc.Identifier) : string.Empty;
-                    options.ClientSecret = dynamicTenantInfo.OpenIdConnectClientSecret != null ? ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(TenantToken, tc.Identifier) : string.Empty;
+                    options.Authority = dynamicTenantInfo.OpenIdConnectAuthority != null ? ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.ClientId = dynamicTenantInfo.OpenIdConnectClientId != null ? ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.ClientSecret = dynamicTenantInfo.OpenIdConnectClientSecret != null ? ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
                 }
             });
 

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -106,9 +106,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 var dynamicTenantInfo = (dynamic)tc;
                 if (dynamicTenantInfo != null)
                 {
-                    options.LoginPath = dynamicTenantInfo.LoginPath != null ? ((string)dynamicTenantInfo.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.LogoutPath = dynamicTenantInfo.LogoutPath != null ? ((string)dynamicTenantInfo.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.AccessDeniedPath = dynamicTenantInfo.AccessDeniedPath != null ? ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    ;
+                    options.LoginPath = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.LoginPath)) ? ((string)dynamicTenantInfo.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.LogoutPath = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.LogoutPath)) ? ((string)dynamicTenantInfo.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.AccessDeniedPath = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.AccessDeniedPath)) != null ? ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
                 }
             });
 
@@ -118,9 +119,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 var dynamicTenantInfo = (dynamic)tc;
                 if (dynamicTenantInfo != null)
                 {
-                    options.Authority = dynamicTenantInfo.OpenIdConnectAuthority != null ? ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.ClientId = dynamicTenantInfo.OpenIdConnectClientId != null ? ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.ClientSecret = dynamicTenantInfo.OpenIdConnectClientSecret != null ? ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.Authority = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.OpenIdConnectAuthority)) ? ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.ClientId = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.OpenIdConnectClientId)) ? ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    options.ClientSecret = !string.IsNullOrEmpty(Convert.ToString(dynamicTenantInfo.OpenIdConnectClientSecret)) ? ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
                 }
             });
 


### PR DESCRIPTION
This code is bugging me because it constantly throws exceptions, then swallows them. They are still registered in the runtime as exceptions.

Code should not throw and catch (yet alone swallow) when a simple if null check could save throwing.

This PR just improves the code in this place and removes unnecessary exceptions.