### PR TITLE
Fix/pertenantoptions convention default

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -11,7 +11,8 @@ Common authentication options are supported per-tenant as discussed below, but
 additional authentication options can be configured per-tenant using
 [per-tenant options](Options) as needed.
 
-See the [Per-Tenant Authentication Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/PerTenantAuthenticationSample)
+See
+the [Per-Tenant Authentication Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/PerTenantAuthenticationSample)
 for a demonstration of the features discussed in this topic.
 
 The sections below assume Finbuckle.MultiTenant is installed and configured. See
@@ -24,6 +25,7 @@ The `WithPerTenantAuthentication()` method can be called after
 options based on public properties of the `ITenantInfo` type parameter.
 
 The following happens when `WithPerTenantAuthentication()` is called:
+
 - Cookie sign-in events are modified to add a tenant claim during sign-in. Existing
   sign-in events are preserved.
 - Cookie validation events are modified to validate that a tenant claim exists
@@ -31,6 +33,7 @@ The following happens when `WithPerTenantAuthentication()` is called:
   preserved.
 
 The following also happens if the `ItenantInfo` implementation has the appropriate property:
+
 - The default challenge scheme is set to the `ChallengeScheme` property
   of the `ITenantInfo` implementation.
 - 'LoginPath' for cookie authentication is set to the `CookieLoginPath` property
@@ -64,8 +67,8 @@ By changing the default challenge per-tenant, the user can be redirected to a
 different scheme as needed. Combined with a per-tenant OpenID Connect authority,
 this can route to shared or tenant specific authentication infrastructure.
 
-The `CookieLoginPath`, `CookieLogoutPath`, and
-`CookieAccessDeniedPath` properties can use a template format where `__tenant__`
+The `CookieLoginPath`, `CookieLogoutPath`, `CookieAccessDeniedPath`, `OpenIdConnectAuthority`, `OpenIdConnectClientId`
+, `OpenIdConnectClientSecret` properties can use a template format where `__tenant__`
 will be replaced with the identifier for each specific tenant. For example, a
 `CookieLoginPath` of "/\_\_tenant\_\_/Identity/Account/Login" will result in
 "/initech/Identity/Account/Login" for the Initech tenant.
@@ -113,37 +116,37 @@ work.
 
 ```json
 "Finbuckle:MultiTenant:Stores:ConfigurationStore": {
-    "Defaults": {
-        "ConnectionString": "",
-        "CookieLoginPath": "/__tenant__/home/login",
-        "CookieLogoutPath": "/__tenant__/home/logout"
-    },
-    "Tenants": [
-        {
-            "Id": "93f330717e5d4f039cd05da312d559cc",
-            "Identifier": "megacorp",
-            "Name": "MegaCorp",
-            "ChallengeScheme": "Cookies"
-        },
-        {
-            "Id": "505c5c97f4e2442394610c673ac91f61",
-            "Identifier": "acme",
-            "Name": "ACME",
-            "ChallengeScheme": "OpenIdConnect",
-            "OpenIdConnectAuthority": "https://finbuckle-acme.us.auth0.com",
-            "OpenIdConnectClientId": "2lGONpJBwIqWuN2QDAmBbYGt0k0khwQB",
-            "OpenIdConnectClientSecret": "HWxQfz6U8GvPCSsvfH5U3uv6CzAeQSt8qHrc19_qEvUQhdsaJX9Dp-t9W-5SAj0m"
-        },
-        {
-            "Id": "4ee609d6da0342e682012232566cff0e",
-            "Identifier": "initech",
-            "Name": "Initech",
-            "ChallengeScheme": "OpenIdConnect",
-            "OpenIdConnectAuthority": "https://finbuckle-initech.us.auth0.com",
-            "OpenIdConnectClientId": "nmPF6VABNmzTISvtYLPenf08ARveQifZ",
-            "OpenIdConnectClientSecret": "WINWtT2WAhWYUOgGHsAPIUV-dAHs1X4qcU6Pv98HBrorlOB5OMKetnsR0Ov0LuVm"
-        }
-    ]
+"Defaults": {
+"ConnectionString": "",
+"CookieLoginPath": "/__tenant__/home/login",
+"CookieLogoutPath": "/__tenant__/home/logout"
+},
+"Tenants": [
+{
+"Id": "93f330717e5d4f039cd05da312d559cc",
+"Identifier": "megacorp",
+"Name": "MegaCorp",
+"ChallengeScheme": "Cookies"
+},
+{
+"Id": "505c5c97f4e2442394610c673ac91f61",
+"Identifier": "acme",
+"Name": "ACME",
+"ChallengeScheme": "OpenIdConnect",
+"OpenIdConnectAuthority": "https://finbuckle-acme.us.auth0.com",
+"OpenIdConnectClientId": "2lGONpJBwIqWuN2QDAmBbYGt0k0khwQB",
+"OpenIdConnectClientSecret": "HWxQfz6U8GvPCSsvfH5U3uv6CzAeQSt8qHrc19_qEvUQhdsaJX9Dp-t9W-5SAj0m"
+},
+{
+"Id": "4ee609d6da0342e682012232566cff0e",
+"Identifier": "initech",
+"Name": "Initech",
+"ChallengeScheme": "OpenIdConnect",
+"OpenIdConnectAuthority": "https://finbuckle-initech.us.auth0.com",
+"OpenIdConnectClientId": "nmPF6VABNmzTISvtYLPenf08ARveQifZ",
+"OpenIdConnectClientSecret": "WINWtT2WAhWYUOgGHsAPIUV-dAHs1X4qcU6Pv98HBrorlOB5OMKetnsR0Ov0LuVm"
+}
+]
 }
 ```
 

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -2,11 +2,8 @@
 // Refer to the solution LICENSE file for more inforation.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Security.Principal;
-using System.Threading.Tasks;
 using Finbuckle.MultiTenant;
 using Finbuckle.MultiTenant.AspNetCore;
 using Finbuckle.MultiTenant.AspNetCore.Options;
@@ -16,7 +13,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -103,70 +99,41 @@ namespace Microsoft.Extensions.DependencyInjection
             // Set per-tenant cookie options by convention.
             builder.WithPerTenantOptions<CookieAuthenticationOptions>((options, tc) =>
             {
-                var dynamicTenantInfo = (dynamic)tc;
-                if (dynamicTenantInfo != null)
-                {
-                    if (HasPropertyWithValidValue(dynamicTenantInfo, "CookieLoginPath"))
-                        options.LoginPath =
-                            ((string)dynamicTenantInfo.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier);
-                    if (HasPropertyWithValidValue(dynamicTenantInfo, "CookieLogoutPath"))
-                        options.LogoutPath =
-                            ((string)dynamicTenantInfo.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier);
-                    if (HasPropertyWithValidValue(dynamicTenantInfo, "CookieAccessDeniedPath"))
-                        options.AccessDeniedPath = ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(
-                            Constants.TenantToken,
-                            tc.Identifier);
-                }
+                if (GetPropertyWithValidValue(tc, "CookieLoginPath") is string loginPath)
+                    options.LoginPath = loginPath.Replace(Constants.TenantToken, tc.Identifier);
+
+                if (GetPropertyWithValidValue(tc, "CookieLogoutPath") is string logoutPath)
+                    options.LogoutPath = logoutPath.Replace(Constants.TenantToken, tc.Identifier);
+
+                if (GetPropertyWithValidValue(tc, "CookieAccessDeniedPath") is string accessDeniedPath)
+                    options.AccessDeniedPath = accessDeniedPath.Replace(Constants.TenantToken, tc.Identifier);
             });
 
             // Set per-tenant OpenIdConnect options by convention.
             builder.WithPerTenantOptions<OpenIdConnectOptions>((options, tc) =>
             {
-                var dynamicTenantInfo = (dynamic)tc;
-                if (dynamicTenantInfo != null)
-                {
-                    if (HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectAuthority)))
-                        options.Authority = ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(
-                            Constants.TenantToken,
-                            tc.Identifier);
+                if (GetPropertyWithValidValue(tc, "OpenIdConnectAuthority") is string authority)
+                    options.Authority = authority.Replace(Constants.TenantToken, tc.Identifier);
 
-                    if (HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectClientId)))
-                        options.ClientId = ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(
-                            Constants.TenantToken,
-                            tc.Identifier);
+                if (GetPropertyWithValidValue(tc, "OpenIdConnectClientId") is string clientId)
+                    options.ClientId = clientId.Replace(Constants.TenantToken, tc.Identifier);
 
-                    if (HasPropertyWithValidValue(dynamicTenantInfo,
-                            nameof(dynamicTenantInfo.OpenIdConnectClientSecret)))
-                        options.ClientSecret = ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(
-                            Constants.TenantToken,
-                            tc.Identifier);
-                }
+                if (GetPropertyWithValidValue(tc, "OpenIdConnectClientSecret") is string clientSecret)
+                    options.ClientSecret = clientSecret.Replace(Constants.TenantToken, tc.Identifier);
             });
 
-            var challengeSchemeProp = typeof(TTenantInfo).GetProperty("ChallengeScheme");
-            if (challengeSchemeProp != null && challengeSchemeProp.PropertyType == typeof(string))
+            builder.WithPerTenantOptions<AuthenticationOptions>((options, tc) =>
             {
-                builder.WithPerTenantOptions<AuthenticationOptions>((options, tc)
-                    => options.DefaultChallengeScheme =
-                        (string?)challengeSchemeProp.GetValue(tc) ?? options.DefaultChallengeScheme);
-            }
+                if (GetPropertyWithValidValue(tc, "ChallengeScheme") is string challengeScheme)
+                    options.DefaultChallengeScheme = challengeScheme;
+            });
 
             return builder;
 
-            bool HasPropertyWithValidValue(dynamic entity, string propertyName)
+            object? GetPropertyWithValidValue(TTenantInfo entity, string propertyName)
             {
                 var property = entity.GetType().GetProperty(propertyName);
-                if (property != null)
-                {
-                    if (string.IsNullOrWhiteSpace(property.GetValue(entity, null)))
-                    {
-                        return false;
-                    }
-
-                    return true;
-                }
-
-                return false;
+                return property?.GetValue(entity);
             }
         }
 
@@ -345,6 +312,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">MultiTenantBuilder instance.</param>
         /// <param name="tenantKey">Claim name for determining the tenant identifier.</param>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
+        // ReSharper disable once MemberCanBePrivate.Global
         public static FinbuckleMultiTenantBuilder<TTenantInfo> WithClaimStrategy<TTenantInfo>(
             this FinbuckleMultiTenantBuilder<TTenantInfo> builder, string tenantKey)
             where TTenantInfo : class, ITenantInfo, new()
@@ -382,6 +350,7 @@ namespace Microsoft.Extensions.DependencyInjection
                             $"{Constants.TenantToken}__bypass_validate_principal__"))
                         return;
 
+                    // TODO test removing this check since the event property is non-nullable
                     if (origOnValidatePrincipal != null)
                         await origOnValidatePrincipal(context);
                 };

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/FinbuckleMultiTenantBuilderExtensions.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Configures conventional functionality for per-tenant authentication.
         /// </summary>
         /// <returns>The same MultiTenantBuilder passed into the method.</returns>
-        [SuppressMessage("ReSharper", "EmptyGeneralCatchClause")]
         public static FinbuckleMultiTenantBuilder<TTenantInfo> WithPerTenantAuthenticationConventions<TTenantInfo>(
             this FinbuckleMultiTenantBuilder<TTenantInfo> builder,
             Action<MultiTenantAuthenticationOptions>? config = null)
@@ -107,9 +106,16 @@ namespace Microsoft.Extensions.DependencyInjection
                 var dynamicTenantInfo = (dynamic)tc;
                 if (dynamicTenantInfo != null)
                 {
-                    options.LoginPath = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.CookieLoginPath)) ? ((string)dynamicTenantInfo.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.LogoutPath = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.CookieLogoutPath)) ? ((string)dynamicTenantInfo.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.AccessDeniedPath = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.CookieAccessDeniedPath)) ? ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    if (HasPropertyWithValidValue(dynamicTenantInfo, "CookieLoginPath"))
+                        options.LoginPath =
+                            ((string)dynamicTenantInfo.CookieLoginPath).Replace(Constants.TenantToken, tc.Identifier);
+                    if (HasPropertyWithValidValue(dynamicTenantInfo, "CookieLogoutPath"))
+                        options.LogoutPath =
+                            ((string)dynamicTenantInfo.CookieLogoutPath).Replace(Constants.TenantToken, tc.Identifier);
+                    if (HasPropertyWithValidValue(dynamicTenantInfo, "CookieAccessDeniedPath"))
+                        options.AccessDeniedPath = ((string)dynamicTenantInfo.CookieAccessDeniedPath).Replace(
+                            Constants.TenantToken,
+                            tc.Identifier);
                 }
             });
 
@@ -119,9 +125,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 var dynamicTenantInfo = (dynamic)tc;
                 if (dynamicTenantInfo != null)
                 {
-                    options.Authority = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectAuthority)) ? ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.ClientId = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectClientId)) ? ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
-                    options.ClientSecret = HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectClientSecret)) ? ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(Constants.TenantToken, tc.Identifier) : string.Empty;
+                    if (HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectAuthority)))
+                        options.Authority = ((string)dynamicTenantInfo.OpenIdConnectAuthority).Replace(
+                            Constants.TenantToken,
+                            tc.Identifier);
+
+                    if (HasPropertyWithValidValue(dynamicTenantInfo, nameof(dynamicTenantInfo.OpenIdConnectClientId)))
+                        options.ClientId = ((string)dynamicTenantInfo.OpenIdConnectClientId).Replace(
+                            Constants.TenantToken,
+                            tc.Identifier);
+
+                    if (HasPropertyWithValidValue(dynamicTenantInfo,
+                            nameof(dynamicTenantInfo.OpenIdConnectClientSecret)))
+                        options.ClientSecret = ((string)dynamicTenantInfo.OpenIdConnectClientSecret).Replace(
+                            Constants.TenantToken,
+                            tc.Identifier);
                 }
             });
 
@@ -218,10 +236,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The same MultiTenantBuilder passed into the method.></returns>
         public static FinbuckleMultiTenantBuilder<TTenantInfo> WithBasePathStrategy<TTenantInfo>(
             this FinbuckleMultiTenantBuilder<TTenantInfo> builder)
-            where TTenantInfo : class, ITenantInfo, new() => WithBasePathStrategy(builder, configureOptions =>
-        {
-            configureOptions.RebaseAspNetCorePathBase = false;
-        });
+            where TTenantInfo : class, ITenantInfo, new() => WithBasePathStrategy(builder,
+            configureOptions => { configureOptions.RebaseAspNetCorePathBase = false; });
 
         /// <summary>
         /// Adds and configures a BasePathStrategy to the application.

--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/SessionStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/SessionStrategy.cs
@@ -28,7 +28,7 @@ namespace Finbuckle.MultiTenant.Strategies
                     new ArgumentException($"\"{nameof(context)}\" type must be of type HttpContext", nameof(context)));
 
             var identifier = httpContext.Session.GetString(tenantKey);
-            return Task.FromResult(identifier); // Prevent the compliler warning that no await exists.
+            return Task.FromResult<string?>(identifier); // Prevent the compiler warning that no await exists.
         }
     }
 }

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
@@ -21,14 +21,16 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
 {
     public class MultiTenantBuilderExtensionsShould
     {
-        public class TestTenantInfo : ITenantInfo
+        private class TestTenantInfo : ITenantInfo
         {
             public string? Id { get; set; }
             public string? Identifier { get; set; }
             public string? Name { get; set; }
             public string? ConnectionString { get; set; }
+
             public string? ChallengeScheme { get; set; }
-            public string? CookiePath { get; set; }
+
+            // public string? CookiePath { get; set; }
             public string? CookieLoginPath { get; set; }
             public string? CookieLogoutPath { get; set; }
             public string? CookieAccessDeniedPath { get; set; }
@@ -48,8 +50,10 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             var sp = services.BuildServiceProvider();
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>();
-            mtc.TenantInfo = new TenantInfo { Identifier = "abc" };
+            var mtc = new MultiTenantContext<TenantInfo>
+            {
+                TenantInfo = new TenantInfo { Identifier = "abc" }
+            };
             sp.GetRequiredService<IMultiTenantContextAccessor<TenantInfo>>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -58,7 +62,8 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             httpContextMock.Setup(c => c.Items).Returns(new Dictionary<object, object?>());
             var scheme = sp.GetRequiredService<IAuthenticationSchemeProvider>()
                 .GetSchemeAsync(CookieAuthenticationDefaults.AuthenticationScheme).Result;
-            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+                .Get(CookieAuthenticationDefaults.AuthenticationScheme);
             var principal = new ClaimsPrincipal(new ClaimsIdentity());
             var authTicket = new AuthenticationTicket(principal, CookieAuthenticationDefaults.AuthenticationScheme);
             authTicket.Properties.Items[Constants.TenantToken] = "abc";
@@ -91,8 +96,10 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
 
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>();
-            mtc.TenantInfo = new TenantInfo { Identifier = "abc" };
+            var mtc = new MultiTenantContext<TenantInfo>
+            {
+                TenantInfo = new TenantInfo { Identifier = "abc" }
+            };
             sp.GetRequiredService<IMultiTenantContextAccessor<TenantInfo>>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -101,7 +108,8 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             httpContextMock.Setup(c => c.Items).Returns(new Dictionary<object, object?>());
             var scheme = sp.GetRequiredService<IAuthenticationSchemeProvider>()
                 .GetSchemeAsync(CookieAuthenticationDefaults.AuthenticationScheme).Result;
-            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+                .Get(CookieAuthenticationDefaults.AuthenticationScheme);
             var principal = new ClaimsPrincipal(new ClaimsIdentity());
             var authTicket = new AuthenticationTicket(principal, CookieAuthenticationDefaults.AuthenticationScheme);
             authTicket.Properties.Items[Constants.TenantToken] = "abc";
@@ -114,7 +122,7 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
         }
 
         [Fact]
-        public void PassprincipalValidationIfTenantMatch()
+        public void PassPrincipalValidationIfTenantMatch()
         {
             var services = new ServiceCollection();
             services.AddLogging();
@@ -125,8 +133,10 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
 
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>();
-            mtc.TenantInfo = new TenantInfo { Identifier = "abc" };
+            var mtc = new MultiTenantContext<TenantInfo>
+            {
+                TenantInfo = new TenantInfo { Identifier = "abc" }
+            };
             sp.GetRequiredService<IMultiTenantContextAccessor<TenantInfo>>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -135,7 +145,8 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             httpContextMock.Setup(c => c.Items).Returns(new Dictionary<object, object?>());
             var scheme = sp.GetRequiredService<IAuthenticationSchemeProvider>()
                 .GetSchemeAsync(CookieAuthenticationDefaults.AuthenticationScheme).Result;
-            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+                .Get(CookieAuthenticationDefaults.AuthenticationScheme);
             var principal = new ClaimsPrincipal(new ClaimsIdentity());
             var authTicket = new AuthenticationTicket(principal, CookieAuthenticationDefaults.AuthenticationScheme);
             authTicket.Properties.Items[Constants.TenantToken] = "abc";
@@ -161,19 +172,24 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             var sp = services.BuildServiceProvider();
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>();
-            mtc.TenantInfo = new TenantInfo { Identifier = "abc1" };
+            var mtc = new MultiTenantContext<TenantInfo>
+            {
+                TenantInfo = new TenantInfo { Identifier = "abc1" }
+            };
             sp.GetRequiredService<IMultiTenantContextAccessor<TenantInfo>>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
             var httpContextMock = new Mock<HttpContext>();
             httpContextMock.Setup(c => c.RequestServices).Returns(sp);
-            var httpContextItems = new Dictionary<object, object?>();
-            httpContextItems[$"{Constants.TenantToken}__bypass_validate_principal__"] = true;
+            var httpContextItems = new Dictionary<object, object?>
+            {
+                [$"{Constants.TenantToken}__bypass_validate_principal__"] = true
+            };
             httpContextMock.Setup(c => c.Items).Returns(httpContextItems);
             var scheme = sp.GetRequiredService<IAuthenticationSchemeProvider>()
                 .GetSchemeAsync(CookieAuthenticationDefaults.AuthenticationScheme).Result;
-            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+                .Get(CookieAuthenticationDefaults.AuthenticationScheme);
             var principal = new ClaimsPrincipal(new ClaimsIdentity());
             var authTicket = new AuthenticationTicket(principal, CookieAuthenticationDefaults.AuthenticationScheme);
             authTicket.Properties.Items[Constants.TenantToken] = "abc2";
@@ -209,12 +225,15 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             // Trigger the ValidatePrincipal event
             var httpContextMock = new Mock<HttpContext>();
             httpContextMock.Setup(c => c.RequestServices).Returns(sp);
-            var httpContextItems = new Dictionary<object, object?>();
-            httpContextItems[$"{Constants.TenantToken}__bypass_validate_principal__"] = true;
+            var httpContextItems = new Dictionary<object, object?>
+            {
+                [$"{Constants.TenantToken}__bypass_validate_principal__"] = true
+            };
             httpContextMock.Setup(c => c.Items).Returns(httpContextItems);
             var scheme = sp.GetRequiredService<IAuthenticationSchemeProvider>()
                 .GetSchemeAsync(CookieAuthenticationDefaults.AuthenticationScheme).Result;
-            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+                .Get(CookieAuthenticationDefaults.AuthenticationScheme);
             var principal = new ClaimsPrincipal(new ClaimsIdentity());
             var authTicket = new AuthenticationTicket(principal, CookieAuthenticationDefaults.AuthenticationScheme);
             authTicket.Properties.Items[Constants.TenantToken] = "abc2";
@@ -239,8 +258,10 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
 
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>();
-            mtc.TenantInfo = new TenantInfo { Identifier = "abc1" };
+            var mtc = new MultiTenantContext<TenantInfo>
+            {
+                TenantInfo = new TenantInfo { Identifier = "abc1" }
+            };
             sp.GetRequiredService<IMultiTenantContextAccessor<TenantInfo>>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -249,7 +270,8 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             httpContextMock.Setup(c => c.Items).Returns(new Dictionary<object, object?>());
             var scheme = sp.GetRequiredService<IAuthenticationSchemeProvider>()
                 .GetSchemeAsync(CookieAuthenticationDefaults.AuthenticationScheme).Result;
-            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>()
+                .Get(CookieAuthenticationDefaults.AuthenticationScheme);
             var principal = new ClaimsPrincipal(new ClaimsIdentity());
             var authTicket = new AuthenticationTicket(principal, CookieAuthenticationDefaults.AuthenticationScheme);
             authTicket.Properties.Items[Constants.TenantToken] = "abc2";
@@ -278,7 +300,9 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             var schemeProvider = sp.GetRequiredService<IAuthenticationSchemeProvider>(); // Throws if fails
             Assert.IsType<MultiTenantAuthenticationSchemeProvider>(schemeProvider);
 
-            var strategy = sp.GetServices<IMultiTenantStrategy>().Where(s => s.GetType() == typeof(RemoteAuthenticationCallbackStrategy)).Single();
+            var strategy = sp
+                .GetServices<IMultiTenantStrategy>()
+                .Single(s => s.GetType() == typeof(RemoteAuthenticationCallbackStrategy));
             Assert.NotNull(strategy);
         }
 
@@ -310,7 +334,9 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
                 .WithRemoteAuthenticationCallbackStrategy();
             var sp = services.BuildServiceProvider();
 
-            var strategy = sp.GetServices<IMultiTenantStrategy>().Where(s => s.GetType() == typeof(RemoteAuthenticationCallbackStrategy)).Single();
+            var strategy = sp
+                .GetServices<IMultiTenantStrategy>()
+                .Single(s => s.GetType() == typeof(RemoteAuthenticationCallbackStrategy));
             Assert.NotNull(strategy);
         }
 
@@ -363,6 +389,32 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
         }
 
         [Fact]
+        public void ConfigurePerTenantAuthenticationConventions_UseDefaultChallengeSchemeOptionsIfNoTenantProp()
+        {
+            var services = new ServiceCollection();
+            services.AddOptions();
+            var defaultValue = "defaultScheme";
+            services.AddAuthentication(o => o.DefaultChallengeScheme = defaultValue)
+                .AddCookie()
+                .AddOpenIdConnect("defaultScheme", null!);
+            services.AddMultiTenant<TenantInfo>()
+                .WithPerTenantAuthenticationConventions();
+            var sp = services.BuildServiceProvider();
+
+            var ti1 = new TenantInfo
+            {
+                Id = "id1",
+                Identifier = "identifier1"
+            };
+
+            var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TenantInfo>>();
+            accessor.MultiTenantContext = new MultiTenantContext<TenantInfo> { TenantInfo = ti1 };
+
+            var options = sp.GetRequiredService<IAuthenticationSchemeProvider>();
+            Assert.Equal(defaultValue, options.GetDefaultChallengeSchemeAsync()!.Result!.Name);
+        }
+
+        [Fact]
         public void ConfigurePerTenantAuthentication_UseOpenIdConnectConvention()
         {
             var services = new ServiceCollection();
@@ -384,7 +436,8 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TestTenantInfo>>();
             accessor.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
 
-            var options = sp.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>().Get(OpenIdConnectDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>()
+                .Get(OpenIdConnectDefaults.AuthenticationScheme);
 
             Assert.Equal(ti1.OpenIdConnectAuthority, options.Authority);
             Assert.Equal(ti1.OpenIdConnectClientId, options.ClientId);
@@ -413,11 +466,44 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TestTenantInfo>>();
             accessor.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
 
-            var options = sp.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>().Get(OpenIdConnectDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>()
+                .Get(OpenIdConnectDefaults.AuthenticationScheme);
 
             Assert.Equal(ti1.OpenIdConnectAuthority, options.Authority);
             Assert.Equal(ti1.OpenIdConnectClientId, options.ClientId);
             Assert.Equal(ti1.OpenIdConnectClientSecret, options.ClientSecret);
+        }
+
+        [Fact]
+        public void ConfigurePerTenantAuthenticationConventions_UseDefaultOpenIdConnectOptionsIfNoTenantProp()
+        {
+            var services = new ServiceCollection();
+            var defaultValue = "https://defaultValue";
+            services.AddOptions().AddAuthentication()
+                .AddOpenIdConnect(options =>
+                {
+                    options.Authority = defaultValue;
+                    options.ClientId = defaultValue;
+                    options.ClientSecret = defaultValue;
+                });
+            services.AddMultiTenant<TenantInfo>()
+                .WithPerTenantAuthenticationConventions();
+            var sp = services.BuildServiceProvider();
+
+            var ti1 = new TenantInfo
+            {
+                Id = "id1",
+                Identifier = "identifier1"
+            };
+
+            var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TenantInfo>>();
+            accessor.MultiTenantContext = new MultiTenantContext<TenantInfo> { TenantInfo = ti1 };
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>()
+                .Get(OpenIdConnectDefaults.AuthenticationScheme);
+            Assert.Equal(defaultValue, options.Authority);
+            Assert.Equal(defaultValue, options.ClientId);
+            Assert.Equal(defaultValue, options.ClientSecret);
         }
 
         [Fact]
@@ -442,7 +528,8 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TestTenantInfo>>();
             accessor.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
 
-            var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>()
+                .Get(CookieAuthenticationDefaults.AuthenticationScheme);
 
             Assert.Equal(ti1.CookieLoginPath, options.LoginPath);
             Assert.Equal(ti1.CookieLogoutPath, options.LogoutPath);
@@ -471,11 +558,44 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TestTenantInfo>>();
             accessor.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
 
-            var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>().Get(CookieAuthenticationDefaults.AuthenticationScheme);
+            var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>()
+                .Get(CookieAuthenticationDefaults.AuthenticationScheme);
 
             Assert.Equal(ti1.CookieLoginPath, options.LoginPath);
             Assert.Equal(ti1.CookieLogoutPath, options.LogoutPath);
             Assert.Equal(ti1.CookieAccessDeniedPath, options.AccessDeniedPath);
+        }
+
+        [Fact]
+        public void ConfigurePerTenantAuthenticationConventions_UseDefaultCookieOptionsIfNoTenantProp()
+        {
+            var services = new ServiceCollection();
+            var defaultValue = "/defaultValue";
+            services.AddOptions().AddAuthentication().AddCookie(options =>
+            {
+                options.LoginPath = defaultValue;
+                options.LogoutPath = defaultValue;
+                options.AccessDeniedPath = defaultValue;
+            });
+            services.AddMultiTenant<TenantInfo>()
+                .WithPerTenantAuthenticationConventions();
+            var sp = services.BuildServiceProvider();
+
+            var ti1 = new TenantInfo
+            {
+                Id = "id1",
+                Identifier = "identifier1"
+            };
+
+            var accessor = sp.GetRequiredService<IMultiTenantContextAccessor<TenantInfo>>();
+            accessor.MultiTenantContext = new MultiTenantContext<TenantInfo> { TenantInfo = ti1 };
+
+            var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>()
+                .Get(CookieAuthenticationDefaults.AuthenticationScheme);
+
+            Assert.Equal(defaultValue, options.LoginPath);
+            Assert.Equal(defaultValue, options.LogoutPath);
+            Assert.Equal(defaultValue, options.AccessDeniedPath);
         }
 
         [Fact]
@@ -498,7 +618,7 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             var strategy = sp.GetRequiredService<IMultiTenantStrategy>();
             Assert.IsType<BasePathStrategy>(strategy);
         }
-        
+
         [Fact]
         public void AddBasePathStrategyDefaultRebaseFalse()
         {
@@ -513,7 +633,7 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test.Extensions
             var options = sp.GetRequiredService<IOptions<BasePathStrategyOptions>>();
             Assert.False(options.Value.RebaseAspNetCorePathBase);
         }
-        
+
         [Fact]
         public void AddBasePathStrategyWithOptions()
         {

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Finbuckle.MultiTenant.AspNetCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Finbuckle.MultiTenant.AspNetCore.Test.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Moq" Version="4.18.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,13 +20,13 @@
     <When Condition=" '$(TargetFramework)' == 'net6.0' ">
       <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.*" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.8" />
       </ItemGroup>
     </When>
     <When Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
       <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.*" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.28" />
       </ItemGroup>
     </When>
   </Choose>

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantMiddlewareShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantMiddlewareShould.cs
@@ -12,7 +12,7 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test
     public class MultiTenantMiddlewareShould
     {
         [Fact]
-        async void UseResolver()
+        public async void UseResolver()
         {
             var services = new ServiceCollection();
             services.AddMultiTenant<TenantInfo>().
@@ -34,7 +34,7 @@ namespace Finbuckle.MultiTenant.AspNetCore.Test
         }
 
         [Fact]
-        async void SetMultiTenantContextAccessor()
+        public async void SetMultiTenantContextAccessor()
         {
             var services = new ServiceCollection();
             services.AddMultiTenant<TenantInfo>().

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Finbuckle.MultiTenant.EntityFrameworkCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Finbuckle.MultiTenant.EntityFrameworkCore.Test.csproj
@@ -6,22 +6,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 
   <Choose>
     <When Condition=" '$(TargetFramework)' == 'net6.0' ">
       <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.*" />
-        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.*" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.8" />
       </ItemGroup>
     </When>
     <When Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
       <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.*" />
-        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.1.*" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.28" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.1.28" />
       </ItemGroup>
     </When>
   </Choose>

--- a/test/Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj
+++ b/test/Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj
@@ -6,25 +6,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
-    <PackageReference Include="Moq" Version="4.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Moq" Version="4.18.2" />
   </ItemGroup>
 
   <Choose>
     <When Condition=" '$(TargetFramework)' == 'net6.0' ">
       <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.*" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.*" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.*" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
       </ItemGroup>
     </When>
     <When Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
       <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.*" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.*" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.*" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.28" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.28" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="3.1.28" />
       </ItemGroup>
     </When>
   </Choose>


### PR DESCRIPTION
Refactor per-tenant authentication convention logic to allow default option values to fall through if no tenant property exists.

Closes #575 