### PR TITLE
doc updates

### DIFF
--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -192,7 +192,7 @@ The database context used with the EFCore store must derive from `EFCoreStoreDbC
 added:
 
 ```cs
-public class MultiTenantStoreDbContext : EFCoreStoreDbContext
+public class MultiTenantStoreDbContext : EFCoreStoreDbContext<TenantInfo>
 {
   protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
   {

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -215,7 +215,7 @@ method of the app's `Startup` class and provide types for the store's database c
 ```cs
 // Register to use the database context and TTenantInfo types show above.
 services.AddMultiTenant<TenantInfo>()
-        .WithEFCoreStore<MultiTenantStoreDbContext>()...
+        .WithEFCoreStore<MultiTenantStoreDbContext,TenantInfo>()...
 ```
 
 The contents of the store can be changed at runtime with the `TryAddAsync`,

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -209,7 +209,7 @@ This database context will have its own connection string (usually) separate fro
 Additionally, this database context can be entirely separate from any others an application might use if co-mingling the
 multitenant store and app entity models is not desired.
 
-Configure by calling `WithEFCoreStore<TEFCoreStoreDbContext>` after `AddMultiTenant<T>` in the `ConfigureServices`
+Configure by calling `WithEFCoreStore<TEFCoreStoreDbContext,ITenantInfo>` after `AddMultiTenant<T>` in the `ConfigureServices`
 method of the app's `Startup` class and provide types for the store's database context generic parameter:
 
 ```cs


### PR DESCRIPTION
`EFCoreStoreDbContext` is a generic class and only works with class which is inherits `ITenantInfo`. In documentation's store section,
````
public class MultiTenantStoreDbContext : EFCoreStoreDbContext
```` 
should be changed as 
````
public class MultiTenantStoreDbContext : EFCoreStoreDbContext<TenantInfo>
````

And also right after this section in documentation, 
````
// Register to use the database context and TTenantInfo types show above.
services.AddMultiTenant<TenantInfo>()
        .WithEFCoreStore<MultiTenantStoreDbContext>()...
````
should be
````
// Register to use the database context and TTenantInfo types show above.
services.AddMultiTenant<TenantInfo>()
        .WithEFCoreStore<MultiTenantStoreDbContext, TenantInfo>()...
````
because, `WithEFCoreStore` method accepts two generic argument. It's not work with only `MultiTenantStoreDbContext` as described in `Finbuckle` docs