### PR TITLE
Adds non-typed IMultiTenantContext interface

### DIFF
--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContext.cs
@@ -3,10 +3,15 @@
 
 namespace Finbuckle.MultiTenant
 {
-    public interface IMultiTenantContext<T>
+    public interface IMultiTenantContext
+    {
+        ITenantInfo? TenantInfo { get; }
+    }
+
+    public interface IMultiTenantContext<T> : IMultiTenantContext
         where T : class, ITenantInfo, new()
     {
-        T? TenantInfo { get; set; }
+        new T? TenantInfo { get; set; }
         StrategyInfo? StrategyInfo { get; set; }
         StoreInfo<T>? StoreInfo { get; set; }
     }

--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContext.cs
@@ -9,11 +9,11 @@ namespace Finbuckle.MultiTenant
         StrategyInfo? StrategyInfo { get; }
     }
 
-    public interface IMultiTenantContext<T> : IMultiTenantContext
+    public interface IMultiTenantContext<T>
         where T : class, ITenantInfo, new()
     {
-        new T? TenantInfo { get; set; }
-        new StrategyInfo? StrategyInfo { get; set; }
+        T? TenantInfo { get; set; }
+        StrategyInfo? StrategyInfo { get; set; }
         StoreInfo<T>? StoreInfo { get; set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContext.cs
@@ -6,13 +6,14 @@ namespace Finbuckle.MultiTenant
     public interface IMultiTenantContext
     {
         ITenantInfo? TenantInfo { get; }
+        StrategyInfo? StrategyInfo { get; }
     }
 
     public interface IMultiTenantContext<T> : IMultiTenantContext
         where T : class, ITenantInfo, new()
     {
         new T? TenantInfo { get; set; }
-        StrategyInfo? StrategyInfo { get; set; }
+        new StrategyInfo? StrategyInfo { get; set; }
         StoreInfo<T>? StoreInfo { get; set; }
     }
 }

--- a/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/IMultiTenantContextAccessor.cs
@@ -5,7 +5,7 @@ namespace Finbuckle.MultiTenant
 {
     public interface IMultiTenantContextAccessor
     {
-        object? MultiTenantContext { get; set; }
+        IMultiTenantContext? MultiTenantContext { get; set; }
     }
 
     public interface IMultiTenantContextAccessor<T> where T : class, ITenantInfo, new()

--- a/src/Finbuckle.MultiTenant/Abstractions/ITenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/Abstractions/ITenantResolver.cs
@@ -8,7 +8,7 @@ namespace Finbuckle.MultiTenant
 {
     public interface ITenantResolver
     {
-        Task<object?> ResolveAsync(object context);
+        Task<IMultiTenantContext?> ResolveAsync(object context);
     }
 
     public interface ITenantResolver<T>

--- a/src/Finbuckle.MultiTenant/Internal/MultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant/Internal/MultiTenantContextAccessor.cs
@@ -23,7 +23,7 @@ namespace Finbuckle.MultiTenant.Core
             }
         }
 
-        object? IMultiTenantContextAccessor.MultiTenantContext
+        IMultiTenantContext? IMultiTenantContextAccessor.MultiTenantContext
         {
             get => MultiTenantContext;
             set => MultiTenantContext = value as IMultiTenantContext<T> ?? MultiTenantContext;

--- a/src/Finbuckle.MultiTenant/Internal/MultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant/Internal/MultiTenantContextAccessor.cs
@@ -25,7 +25,7 @@ namespace Finbuckle.MultiTenant.Core
 
         IMultiTenantContext? IMultiTenantContextAccessor.MultiTenantContext
         {
-            get => MultiTenantContext;
+            get => MultiTenantContext as IMultiTenantContext;
             set => MultiTenantContext = value as IMultiTenantContext<T> ?? MultiTenantContext;
         }
     }

--- a/src/Finbuckle.MultiTenant/MultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant/MultiTenantContext.cs
@@ -6,7 +6,7 @@ namespace Finbuckle.MultiTenant
     /// <summary>
     /// Contains information for the multitenant tenant, store, and strategy.
     /// </summary>
-    public class MultiTenantContext<T> : IMultiTenantContext<T>
+    public class MultiTenantContext<T> : IMultiTenantContext<T>, IMultiTenantContext
         where T : class, ITenantInfo, new()
     {
         public T? TenantInfo { get; set; }

--- a/src/Finbuckle.MultiTenant/MultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant/MultiTenantContext.cs
@@ -12,5 +12,7 @@ namespace Finbuckle.MultiTenant
         public T? TenantInfo { get; set; }
         public StrategyInfo? StrategyInfo { get; set; }
         public StoreInfo<T>? StoreInfo { get; set; }
+
+        ITenantInfo? IMultiTenantContext.TenantInfo => TenantInfo;
     }
 }

--- a/src/Finbuckle.MultiTenant/TenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/TenantResolver.cs
@@ -81,7 +81,7 @@ namespace Finbuckle.MultiTenant
             return result;
         }
 
-        async Task<object?> ITenantResolver.ResolveAsync(object context)
+        async Task<IMultiTenantContext?> ITenantResolver.ResolveAsync(object context)
         {
             var multiTenantContext = await ResolveAsync(context);
             return multiTenantContext;

--- a/src/Finbuckle.MultiTenant/TenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/TenantResolver.cs
@@ -83,8 +83,7 @@ namespace Finbuckle.MultiTenant
 
         async Task<IMultiTenantContext?> ITenantResolver.ResolveAsync(object context)
         {
-            var multiTenantContext = await ResolveAsync(context);
-            return multiTenantContext;
+            return (await ResolveAsync(context)) as IMultiTenantContext;
         }
     }
 }


### PR DESCRIPTION
This PR add a non-typed `IMultiTenantContext` interface.

In my case, I'm in a class library and I don't have access to the typed `TenantInfo`. I would like to be able to inject the non-typed `IMultiTenantContextAccessor` to get the tenant. So, instead of returning an object for the `MultiTenantContext` property, I return in this PR a `IMultiTenantContext` with an `ITenantInfo? TenantInfo` property.