### PR TITLE
bug: OnTenantNotResolved not called correctly (#628)

### DIFF
--- a/src/Finbuckle.MultiTenant/TenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/TenantResolver.cs
@@ -38,47 +38,47 @@ public class TenantResolver<T> : ITenantResolver<T>, ITenantResolver
 
     public async Task<IMultiTenantContext<T>?> ResolveAsync(object context)
     {
-        IMultiTenantContext<T>? result = null;
-
+        string? identifier = null;
         foreach (var strategy in Strategies)
         {
             var _strategy = new MultiTenantStrategyWrapper(strategy, loggerFactory?.CreateLogger(strategy.GetType()) ?? NullLogger.Instance);
-            var identifier = await _strategy.GetIdentifierAsync(context);
+            identifier = await _strategy.GetIdentifierAsync(context);
 
             if (options.CurrentValue.IgnoredIdentifiers.Contains(identifier, StringComparer.OrdinalIgnoreCase))
             {
                 (loggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance).LogInformation("Ignored identifier: {Identifier}", identifier);
                 identifier = null;
             }
+            
+            if (identifier == null)
+                continue;
 
-            if (identifier != null)
+            foreach (var store in Stores)
             {
-                foreach (var store in Stores)
+                var _store = new MultiTenantStoreWrapper<T>(store, loggerFactory?.CreateLogger(store.GetType()) ?? NullLogger.Instance);
+                var tenantInfo = await _store.TryGetByIdentifierAsync(identifier);
+                if (tenantInfo == null)
+                    continue;
+
+                await options.CurrentValue.Events.OnTenantResolved(new TenantResolvedContext
                 {
-                    var _store = new MultiTenantStoreWrapper<T>(store, loggerFactory?.CreateLogger(store.GetType()) ?? NullLogger.Instance);
-                    var tenantInfo = await _store.TryGetByIdentifierAsync(identifier);
-                    if (tenantInfo != null)
-                    {
-                        result = new MultiTenantContext<T>();
-                        result.StoreInfo = new StoreInfo<T> { Store = store, StoreType = store.GetType() };
-                        result.StrategyInfo = new StrategyInfo { Strategy = strategy, StrategyType = strategy.GetType() };
-                        result.TenantInfo = tenantInfo;
-
-                        await options.CurrentValue.Events.OnTenantResolved(new TenantResolvedContext { Context = 
-                            context, TenantInfo = tenantInfo, StrategyType = strategy.GetType(), StoreType = store.GetType()});
-
-                        break;
-                    }
-                }
-
-                if (result != null)
-                    break;
-
-                await options.CurrentValue.Events.OnTenantNotResolved(new TenantNotResolvedContext { Context = context, Identifier = identifier });
+                    Context = context,
+                    TenantInfo = tenantInfo,
+                    StrategyType = strategy.GetType(),
+                    StoreType = store.GetType()
+                });
+                
+                return new MultiTenantContext<T>
+                {
+                    StoreInfo = new StoreInfo<T> { Store = store, StoreType = store.GetType() },
+                    StrategyInfo = new StrategyInfo { Strategy = strategy, StrategyType = strategy.GetType() },
+                    TenantInfo = tenantInfo
+                };
             }
         }
-
-        return result;
+        
+        await options.CurrentValue.Events.OnTenantNotResolved(new TenantNotResolvedContext { Context = context, Identifier = identifier });
+        return null;
     }
 
     // TODO move this to the base interface?


### PR DESCRIPTION
As mentioned in #628 OnTenantNotResolved does not get called correctly when no identifier is found in any strategy.

I added tests to cover this event as well as the OnTenantResolved event.