### PR TITLE
added basic sample to reproduce composite error

### DIFF
--- a/samples/net6.0/IdentitySample/Data/Client.cs
+++ b/samples/net6.0/IdentitySample/Data/Client.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace IdentitySample.Data;
+
+public record Client
+{
+    [Key]
+    public Guid Id { get; set; }
+    public string Name { get; set; }
+}

--- a/samples/net6.0/IdentitySample/Data/Migrations/20240527152701_Client.Designer.cs
+++ b/samples/net6.0/IdentitySample/Data/Migrations/20240527152701_Client.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IdentitySample.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IdentitySample.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240527152701_Client")]
+    partial class Client
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.2");

--- a/samples/net6.0/IdentitySample/Data/Migrations/20240527152701_Client.cs
+++ b/samples/net6.0/IdentitySample/Data/Migrations/20240527152701_Client.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IdentitySample.Migrations
+{
+    public partial class Client : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AspNetUserLogins",
+                table: "AspNetUserLogins");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AspNetUserLogins_LoginProvider_ProviderKey_TenantId",
+                table: "AspNetUserLogins");
+
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "AspNetUserLogins");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AspNetUserLogins",
+                table: "AspNetUserLogins",
+                columns: new[] { "LoginProvider", "ProviderKey", "TenantId" });
+
+            migrationBuilder.CreateTable(
+                name: "Client",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    TenantId = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Client", x => new { x.Id, x.TenantId });
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Client");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_AspNetUserLogins",
+                table: "AspNetUserLogins");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Id",
+                table: "AspNetUserLogins",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_AspNetUserLogins",
+                table: "AspNetUserLogins",
+                column: "Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserLogins_LoginProvider_ProviderKey_TenantId",
+                table: "AspNetUserLogins",
+                columns: new[] { "LoginProvider", "ProviderKey", "TenantId" },
+                unique: true);
+        }
+    }
+}

--- a/samples/net6.0/IdentitySample/Program.cs
+++ b/samples/net6.0/IdentitySample/Program.cs
@@ -54,4 +54,11 @@ app.UseAuthorization();
 
 app.MapRazorPages();
 
+app.MapGet("/create-client", (ApplicationDbContext applicationDbContext) =>
+{
+    applicationDbContext.Clients.Add(new Client { Name = "Client 1" });
+    applicationDbContext.SaveChanges();
+    return Results.Ok("Client created");
+});
+
 app.Run();


### PR DESCRIPTION
This reproduces the bug described in https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/238

To recreate this, all you need to do is start the application and goto https://localhost:7208/acme/create-client

You'll be present with the standard .NET development exception UI with the error `InvalidOperationException: Unable to track an entity of type 'Client' because its primary key property 'TenantId' is null.`