### PR TITLE
Add optional support for GetAllAsync() via HttpRemoteStore

### DIFF
--- a/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStore.cs
@@ -68,13 +68,11 @@ public class HttpRemoteStore<TTenantInfo> : IMultiTenantStore<TTenantInfo>
         throw new NotImplementedException();
     }
 
-    /// <summary>
-    /// Not implemented in this implementation.
-    /// </summary>
-    /// <exception cref="NotImplementedException"></exception>
-    public Task<IEnumerable<TTenantInfo>> GetAllAsync()
+    /// <inheritdoc />
+    /// <exception cref="NotImplementedException">When a not-found (404) status code is encountered</exception>
+    public async Task<IEnumerable<TTenantInfo>> GetAllAsync()
     {
-        throw new NotImplementedException();
+        return await _client.GetAllAsync(endpointTemplate);
     }
 
     /// <inheritdoc />

--- a/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStoreClient.cs
+++ b/src/Finbuckle.MultiTenant/Stores/HttpRemoteStore/HttpRemoteStoreClient.cs
@@ -1,6 +1,7 @@
 // Copyright Finbuckle LLC, Andrew White, and Contributors.
 // Refer to the solution LICENSE file for more information.
 
+using System.Net;
 using System.Text.Json;
 using Finbuckle.MultiTenant.Abstractions;
 
@@ -9,10 +10,13 @@ namespace Finbuckle.MultiTenant.Stores.HttpRemoteStore;
 public class HttpRemoteStoreClient<TTenantInfo> where TTenantInfo : class, ITenantInfo, new()
 {
     private readonly IHttpClientFactory clientFactory;
+    private readonly JsonSerializerOptions _defaultSerializerOptions;
 
-    public HttpRemoteStoreClient(IHttpClientFactory clientFactory)
+    public HttpRemoteStoreClient(IHttpClientFactory clientFactory, JsonSerializerOptions? serializerOptions = default)
     {
         this.clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+
+        _defaultSerializerOptions = serializerOptions ?? new JsonSerializerOptions(JsonSerializerDefaults.Web);
     }
 
     public async Task<TTenantInfo?> TryGetByIdentifierAsync(string endpointTemplate, string identifier)
@@ -25,8 +29,32 @@ public class HttpRemoteStoreClient<TTenantInfo> where TTenantInfo : class, ITena
             return null;
 
         var json = await response.Content.ReadAsStringAsync();
-        var result = JsonSerializer.Deserialize<TTenantInfo>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var result = JsonSerializer.Deserialize<TTenantInfo>(json, _defaultSerializerOptions);
 
         return result;
+    }
+
+    public async Task<IEnumerable<TTenantInfo>> GetAllAsync(string endpointTemplate)
+    {
+        var client = clientFactory.CreateClient(typeof(HttpRemoteStoreClient<TTenantInfo>).FullName!);
+        var uri = endpointTemplate.Replace(HttpRemoteStore<TTenantInfo>.DefaultEndpointTemplateIdentifierToken, string.Empty);
+        var response = await client.GetAsync(uri);
+
+
+        if (!response.IsSuccessStatusCode)
+        {
+            // Backwards compatibility check for service implementations that do not include this route.
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                throw new NotImplementedException();
+            }
+
+            return Enumerable.Empty<TTenantInfo>();
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<IEnumerable<TTenantInfo>>(json, _defaultSerializerOptions);
+
+        return result!;
     }
 }


### PR DESCRIPTION
I ran into this issue while converting from an EF store to HTTP in a project. My comment on issue https://github.com/Finbuckle/Finbuckle.MultiTenant/issues/808 mainly provides the need for this and I managed to implement it manually within my app, however I'd like to mainline this for future projects. I can definitely understand why people would not want this, which is why I based the implementation off the existing route template and will throw `NotImplementedException` in the case of the external http service having an undefined route for this implementation.

Feedback is greatly appreciated!