### PR TITLE
Add support for per-tenant UserRoles and reusing MultiTenantIdentityDbContext implementation for EFCoreStore

### DIFF
--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Refer to the solution LICENSE file for more information.
 
 using System.Linq;
+using Finbuckle.MultiTenant.Abstractions;
 using Finbuckle.MultiTenant.Internal;
 using Microsoft.EntityFrameworkCore;
 
@@ -15,15 +16,26 @@ public static class FinbuckleModelBuilderExtensions
     /// </summary>
     public static ModelBuilder ConfigureMultiTenant(this ModelBuilder modelBuilder)
     {
-            // Call IsMultiTenant() to configure the types marked with the MultiTenant Data Attribute
-            foreach (var clrType in modelBuilder.Model.GetEntityTypes()
-                                                 .Where(et => et.ClrType.HasMultiTenantAttribute())
-                                                 .Select(et => et.ClrType))
-            {
-                modelBuilder.Entity(clrType)
-                            .IsMultiTenant();
-            }
-
-            return modelBuilder;
+        // Call IsMultiTenant() to configure the types marked with the MultiTenant Data Attribute
+        foreach (var clrType in modelBuilder.Model.GetEntityTypes()
+                     .Where(et => et.ClrType.HasMultiTenantAttribute())
+                     .Select(et => et.ClrType))
+        {
+            modelBuilder.Entity(clrType)
+                .IsMultiTenant();
         }
+
+        return modelBuilder;
+    }
+
+    public static void ConfigureTenantInfoEntity<T>(this ModelBuilder modelBuilder) where T : class, ITenantInfo
+    {
+        modelBuilder.Entity<T>(entity =>
+        {
+            entity.HasKey(ti => ti.Id);
+            entity.Property(ti => ti.Id).HasMaxLength(Constants.TenantIdMaxLength);
+            entity.HasIndex(ti => ti.Identifier).IsUnique();
+        });
+    }
+
 }

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Finbuckle.MultiTenant.Abstractions;
 using Finbuckle.MultiTenant.EntityFrameworkCore.Stores.EFCoreStore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
@@ -19,7 +20,7 @@ public static class MultiTenantBuilderExtensions
     /// <returns>The same MultiTenantBuilder passed into the method.</returns>
     // ReSharper disable once InconsistentNaming
     public static MultiTenantBuilder<TTenantInfo> WithEFCoreStore<TEFCoreStoreDbContext, TTenantInfo>(this MultiTenantBuilder<TTenantInfo> builder)
-        where TEFCoreStoreDbContext : EFCoreStoreDbContext<TTenantInfo>
+        where TEFCoreStoreDbContext : DbContext, IEFCoreStoreDbContext<TTenantInfo>
         where TTenantInfo : class, ITenantInfo, new()
     {
         builder.Services.AddDbContext<TEFCoreStoreDbContext>(); // Note, will not override existing context if already added.

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantIdentityEntityFrameworkBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantIdentityEntityFrameworkBuilderExtensions.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using Finbuckle.MultiTenant.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+// ReSharper disable once CheckNamespace
+namespace Finbuckle.MultiTenant;
+
+/// <summary>
+/// Contains extension methods to <see cref="IdentityBuilder"/> for adding Entity Framework stores.
+/// </summary>
+public static class MultiTenantIdentityEntityFrameworkBuilderExtensions
+{
+    /// <summary>
+    /// Adds an Entity Framework implementation of identity information stores.
+    /// </summary>
+    /// <typeparam name="TContext">The Entity Framework database context to use.</typeparam>
+    /// <param name="builder">The <see cref="IdentityBuilder"/> instance this method extends.</param>
+    /// <returns>The <see cref="IdentityBuilder"/> instance this method extends.</returns>
+    public static IdentityBuilder AddEntityFrameworkStores<TContext>(this IdentityBuilder builder)
+        where TContext : DbContext, IMultiTenantDbContext
+    {
+        AddStores(builder.Services, builder.UserType, builder.RoleType, typeof(TContext));
+        return builder;
+    }
+
+    private static void AddStores(IServiceCollection services, Type userType, Type? roleType, Type contextType)
+    {
+        var identityUserType = FindGenericBaseType(userType, typeof(IdentityUser<>));
+        if (identityUserType == null)
+        {
+            throw new InvalidOperationException("NotIdentityUser");
+        }
+
+        var keyType = identityUserType.GenericTypeArguments[0];
+
+        if (roleType != null)
+        {
+            var identityRoleType = FindGenericBaseType(roleType, typeof(IdentityRole<>));
+            if (identityRoleType == null)
+            {
+                throw new InvalidOperationException("NotIdentityRole");
+            }
+
+            Type userStoreType;
+            Type roleStoreType;
+            var identityContext = FindGenericBaseType(contextType, typeof(IdentityDbContext<,,,,,,,>));
+            if (identityContext == null)
+            {
+                // If it's a custom DbContext, we can only add the default POCOs
+                userStoreType = typeof(MultiTenantUserStore<,,,>).MakeGenericType(userType, roleType, contextType, keyType);
+                roleStoreType = typeof(RoleStore<,,>).MakeGenericType(roleType, contextType, keyType);
+            }
+            else
+            {
+                userStoreType = typeof(MultiTenantUserStore<,,,,,,,,>).MakeGenericType(userType, roleType, contextType,
+                    identityContext.GenericTypeArguments[2],
+                    identityContext.GenericTypeArguments[3],
+                    identityContext.GenericTypeArguments[4],
+                    identityContext.GenericTypeArguments[5],
+                    identityContext.GenericTypeArguments[7],
+                    identityContext.GenericTypeArguments[6]);
+                roleStoreType = typeof(RoleStore<,,,,>).MakeGenericType(roleType, contextType,
+                    identityContext.GenericTypeArguments[2],
+                    identityContext.GenericTypeArguments[4],
+                    identityContext.GenericTypeArguments[6]);
+            }
+            services.TryAddScoped(typeof(IUserStore<>).MakeGenericType(userType), userStoreType);
+            services.TryAddScoped(typeof(IRoleStore<>).MakeGenericType(roleType), roleStoreType);
+        }
+        else
+        {   // No Roles
+            Type userStoreType;
+            var identityContext = FindGenericBaseType(contextType, typeof(IdentityUserContext<,,,,>));
+            if (identityContext == null)
+            {
+                // If it's a custom DbContext, we can only add the default POCOs
+                userStoreType = typeof(UserOnlyStore<,,>).MakeGenericType(userType, contextType, keyType);
+            }
+            else
+            {
+                userStoreType = typeof(UserOnlyStore<,,,,,>).MakeGenericType(userType, contextType,
+                    identityContext.GenericTypeArguments[1],
+                    identityContext.GenericTypeArguments[2],
+                    identityContext.GenericTypeArguments[3],
+                    identityContext.GenericTypeArguments[4]);
+            }
+            services.TryAddScoped(typeof(IUserStore<>).MakeGenericType(userType), userStoreType);
+        }
+    }
+
+    private static Type? FindGenericBaseType(Type currentType, Type genericBaseType)
+    {
+        var type = currentType;
+        while (type != null)
+        {
+            var genericType = type.IsGenericType ? type.GetGenericTypeDefinition() : null;
+            if (genericType != null && genericType == genericBaseType)
+            {
+                return type;
+            }
+            type = type.BaseType;
+        }
+        return null;
+    }
+}

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Finbuckle.MultiTenant.EntityFrameworkCore.csproj
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Finbuckle.MultiTenant.EntityFrameworkCore.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <LangVersion>12</LangVersion>
     <Title>Finbuckle.MultiTenant.EntityFrameworkCore</Title>
     <Description>Entity Framework Core support for Finbuckle.MultiTenant.</Description>
     <Nullable>enable</Nullable>

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
@@ -149,11 +149,14 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey, TUserClai
     where TUserToken : IdentityUserToken<TKey>
     where TKey : IEquatable<TKey>
 {
-    public ITenantInfo? TenantInfo { get; }
+    public virtual ITenantInfo? TenantInfo => _tenantInfo ?? _multiTenantContextAccessor?.MultiTenantContext.TenantInfo;
 
     public TenantMismatchMode TenantMismatchMode { get; set; } = TenantMismatchMode.Throw;
 
     public TenantNotSetMode TenantNotSetMode { get; set; } = TenantNotSetMode.Throw;
+
+    private readonly IMultiTenantContextAccessor? _multiTenantContextAccessor;
+    private readonly ITenantInfo? _tenantInfo;
 
     /// <summary>
     /// Constructs the database context instance and binds to the current tenant.
@@ -161,12 +164,12 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey, TUserClai
     /// <param name="multiTenantContextAccessor">The MultiTenantContextAccessor instance used to bind the context instance to a tenant.</param>
     protected MultiTenantIdentityDbContext(IMultiTenantContextAccessor multiTenantContextAccessor)
     {
-        TenantInfo = multiTenantContextAccessor.MultiTenantContext.TenantInfo;
+        _multiTenantContextAccessor = multiTenantContextAccessor;
     }
     
     protected MultiTenantIdentityDbContext(ITenantInfo tenantInfo)
     {
-        TenantInfo = tenantInfo;
+        _tenantInfo = tenantInfo;
     }
     
     /// <summary>
@@ -176,12 +179,12 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey, TUserClai
     /// <param name="options">The database options instance.</param>
     protected MultiTenantIdentityDbContext(IMultiTenantContextAccessor multiTenantContextAccessor, DbContextOptions options) : base(options)
     {
-        TenantInfo = multiTenantContextAccessor.MultiTenantContext.TenantInfo;
+        _multiTenantContextAccessor = multiTenantContextAccessor;
     }
 
     protected MultiTenantIdentityDbContext(ITenantInfo tenantInfo, DbContextOptions options) : base(options)
     {
-        TenantInfo = tenantInfo;
+        _tenantInfo = tenantInfo;
     }
 
     /// <inheritdoc />

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityUserRole.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantIdentityUserRole.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Microsoft.AspNetCore.Identity;
+
+namespace Finbuckle.MultiTenant.EntityFrameworkCore;
+
+public class MultiTenantIdentityUserRole<TKey>
+    : IdentityUserRole<TKey>
+    where TKey : IEquatable<TKey>
+{
+    public string? TenantId { get; set; }
+}

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantUserStore.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantUserStore.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finbuckle.MultiTenant.EntityFrameworkCore;
+
+public class MultiTenantUserStore<TUser, TRole, TContext, TKey>(
+    TContext context,
+    IdentityErrorDescriber? describer = null) : MultiTenantUserStore<TUser, TRole, TContext, TKey,
+    IdentityUserClaim<TKey>, MultiTenantIdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityUserToken<TKey>,
+    IdentityRoleClaim<TKey>>(context, describer)
+    where TUser : IdentityUser<TKey>
+    where TRole : IdentityRole<TKey>
+    where TContext : DbContext, IMultiTenantDbContext
+    where TKey : IEquatable<TKey>;
+
+public class MultiTenantUserStore<TUser, TRole, TContext,
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    TKey, TUserClaim, TUserRole, TUserLogin,
+    TUserToken, TRoleClaim>(
+    TContext context,
+    IdentityErrorDescriber? describer = null
+) : UserStore<TUser, TRole, TContext, TKey, TUserClaim, TUserRole, TUserLogin, TUserToken, TRoleClaim>(context,
+    describer)
+    where TUser : IdentityUser<TKey>
+    where TRole : IdentityRole<TKey>
+    where TContext : DbContext, IMultiTenantDbContext
+    where TKey : IEquatable<TKey>
+    where TUserClaim : IdentityUserClaim<TKey>, new()
+    where TUserRole : MultiTenantIdentityUserRole<TKey>, new()
+    where TUserLogin : IdentityUserLogin<TKey>, new()
+    where TUserToken : IdentityUserToken<TKey>, new()
+    where TRoleClaim : IdentityRoleClaim<TKey>, new()
+{
+    protected override Task<TUserRole> FindUserRoleAsync(TKey userId, TKey roleId, CancellationToken cancellationToken)
+    {
+        return Context.Set<TUserRole>().FindAsync([userId, roleId, context.TenantInfo?.Id], cancellationToken).AsTask();
+    }
+
+    protected override TUserRole CreateUserRole(TUser user, TRole role)
+    {
+        return new TUserRole
+        {
+            UserId = user.Id,
+            RoleId = role.Id,
+            TenantId = context.TenantInfo?.Id
+        };
+    }
+}

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStore.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStore.cs
@@ -11,64 +11,64 @@ using Microsoft.EntityFrameworkCore;
 namespace Finbuckle.MultiTenant.EntityFrameworkCore.Stores.EFCoreStore;
 
 public class EFCoreStore<TEFCoreStoreDbContext, TTenantInfo> : IMultiTenantStore<TTenantInfo>
-    where TEFCoreStoreDbContext : EFCoreStoreDbContext<TTenantInfo>
+    where TEFCoreStoreDbContext : DbContext, IEFCoreStoreDbContext<TTenantInfo>
     where TTenantInfo : class, ITenantInfo, new()
 {
     internal readonly TEFCoreStoreDbContext dbContext;
 
     public EFCoreStore(TEFCoreStoreDbContext dbContext)
     {
-            this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
-        }
+        this.dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
 
     public virtual async Task<TTenantInfo?> TryGetAsync(string id)
     {
-            return await dbContext.TenantInfo.AsNoTracking()
-                .Where(ti => ti.Id == id)
-                .SingleOrDefaultAsync();
-        }
+        return await dbContext.TenantInfos.AsNoTracking()
+            .Where(ti => ti.Id == id)
+            .SingleOrDefaultAsync();
+    }
 
     public virtual async Task<IEnumerable<TTenantInfo>> GetAllAsync()
     {
-            return await dbContext.TenantInfo.AsNoTracking().ToListAsync();
-        }
+        return await dbContext.TenantInfos.AsNoTracking().ToListAsync();
+    }
 
     public virtual async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
     {
-            return await dbContext.TenantInfo.AsNoTracking()
-                .Where(ti => ti.Identifier == identifier)
-                .SingleOrDefaultAsync();
-        }
+        return await dbContext.TenantInfos.AsNoTracking()
+            .Where(ti => ti.Identifier == identifier)
+            .SingleOrDefaultAsync();
+    }
 
     public virtual async Task<bool> TryAddAsync(TTenantInfo tenantInfo)
     {
-            await dbContext.TenantInfo.AddAsync(tenantInfo);
-            var result = await dbContext.SaveChangesAsync() > 0;
-            dbContext.Entry(tenantInfo).State = EntityState.Detached;
+        await dbContext.TenantInfos.AddAsync(tenantInfo);
+        var result = await dbContext.SaveChangesAsync() > 0;
+        dbContext.Entry(tenantInfo).State = EntityState.Detached;
             
-            return result;
-        }
+        return result;
+    }
 
     public virtual async Task<bool> TryRemoveAsync(string identifier)
     {
-            var existing = await dbContext.TenantInfo
-                .Where(ti => ti.Identifier == identifier)
-                .SingleOrDefaultAsync();
+        var existing = await dbContext.TenantInfos
+            .Where(ti => ti.Identifier == identifier)
+            .SingleOrDefaultAsync();
 
-            if (existing is null)
-            {
-                return false;
-            }
-
-            dbContext.TenantInfo.Remove(existing);
-            return await dbContext.SaveChangesAsync() > 0;
+        if (existing is null)
+        {
+            return false;
         }
+
+        dbContext.TenantInfos.Remove(existing);
+        return await dbContext.SaveChangesAsync() > 0;
+    }
 
     public virtual async Task<bool> TryUpdateAsync(TTenantInfo tenantInfo)
     {
-            dbContext.TenantInfo.Update(tenantInfo);
-            var result = await dbContext.SaveChangesAsync() > 0;
-            dbContext.Entry(tenantInfo).State = EntityState.Detached;
-            return result;
-        }
+        dbContext.TenantInfos.Update(tenantInfo);
+        var result = await dbContext.SaveChangesAsync() > 0;
+        dbContext.Entry(tenantInfo).State = EntityState.Detached;
+        return result;
+    }
 }

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStoreDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStoreDbContext.cs
@@ -11,14 +11,12 @@ public class EFCoreStoreDbContext<TTenantInfo> : DbContext
 {
     public EFCoreStoreDbContext(DbContextOptions options) : base(options)
     {
-        }
+    }
 
-    public DbSet<TTenantInfo> TenantInfo => Set<TTenantInfo>();
+    public DbSet<TTenantInfo> TenantInfos => Set<TTenantInfo>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-            modelBuilder.Entity<TTenantInfo>().HasKey(ti => ti.Id);
-            modelBuilder.Entity<TTenantInfo>().Property(ti => ti.Id).HasMaxLength(Internal.Constants.TenantIdMaxLength);
-            modelBuilder.Entity<TTenantInfo>().HasIndex(ti => ti.Identifier).IsUnique();
-        }
+        modelBuilder.ConfigureTenantInfoEntity<TTenantInfo>();
+    }
 }

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/IEFCoreStoreDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/IEFCoreStoreDbContext.cs
@@ -1,0 +1,9 @@
+﻿using Finbuckle.MultiTenant.Abstractions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finbuckle.MultiTenant.EntityFrameworkCore.Stores.EFCoreStore;
+
+public interface IEFCoreStoreDbContext<TTenantInfo> where TTenantInfo : class, ITenantInfo
+{
+    public DbSet<TTenantInfo> TenantInfos { get; }
+}


### PR DESCRIPTION
One not-so-obvious change is making MultiTenantIdentityDbContext.TenantInfo lazy, which was necessary because MultiTenantIdentityDbContext is activated as part of MultiTenantMiddleware before the tenant is resolved/MultiTenantContext is set.