### PR TITLE
fix: strategy wrapper no longer throws on a null context

### DIFF
--- a/src/Finbuckle.MultiTenant/Strategies/MultiTenantStrategyWrapper.cs
+++ b/src/Finbuckle.MultiTenant/Strategies/MultiTenantStrategyWrapper.cs
@@ -20,11 +20,6 @@ public class MultiTenantStrategyWrapper : IMultiTenantStrategy
 
     public async Task<string?> GetIdentifierAsync(object context)
     {
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
-
         string? identifier = null;
 
         try


### PR DESCRIPTION
strategy wrapper no longer throws on a null context, instead passes it to the actual strategy