### PR TITLE
Fix relative links between document pages

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -9,14 +9,14 @@ avoids the need to create separate authentication schemes for each tenant.
 
 Common authentication options are supported per-tenant as discussed below, but
 additional authentication options can be configured per-tenant using
-[per-tenant options](Options) as needed.
+[per-tenant options](../Options) as needed.
 
 See
 the [Per-Tenant Authentication Sample](https://github.com/Finbuckle/Finbuckle.MultiTenant/tree/master/samples/ASP.NET%20Core%203/PerTenantAuthenticationSample)
 for a demonstration of the features discussed in this topic.
 
 The sections below assume Finbuckle.MultiTenant is installed and configured. See
-[Getting Started](GettingStarted) for details.
+[Getting Started](../GettingStarted) for details.
 
 ## Using WithPerTenantAuthentication()
 
@@ -148,7 +148,7 @@ work.
 ## Other Authentication Options
 
 Internally `WithPerTenantAuthentication()` makes use of
-[per-tenant options](Options). For authentication options not covered by
+[per-tenant options](../Options). For authentication options not covered by
 `WithPerTenantAuthentication()`, per-tenant option can provide similar behavior.
 
 For example, if you want to configure JWT tokens so that each tenant has a

--- a/docs/ConfigurationAndUsage.md
+++ b/docs/ConfigurationAndUsage.md
@@ -3,7 +3,7 @@
 ## Configuration
 
 Finbuckle.MultiTenant uses the standard application builder pattern for its configuration. In addition to adding the
-services, configuration for one or more [MultiTenant Stores](Stores) and [MultiTenant Strategies](Strategies) are
+services, configuration for one or more [MultiTenant Stores](../Stores) and [MultiTenant Strategies](../Strategies) are
 required:
 
 ```csharp
@@ -40,7 +40,7 @@ for chaining method calls.
 ### WithStore Variants
 
 Adds and configures an IMultiTenantStore to the application. Only the last store configured will be used.
-See [MultiTenant Stores](Stores) for more information on each type.
+See [MultiTenant Stores](../Stores) for more information on each type.
 
 - `WithStore<TStore>`
 - `WithInMemoryStore<TTenantStore>`
@@ -52,7 +52,7 @@ See [MultiTenant Stores](Stores) for more information on each type.
 ### WithStrategy Variants
 
 Adds and configures an IMultiTenantStore to the application. Multiple strategies can be configured and each will be used
-in the order registered. See [MultiTenant Strategies](Strategies) for more information on each type.
+in the order registered. See [MultiTenant Strategies](../Strategies) for more information on each type.
 
 - `WithStrategy<TStrategy>`
 - `WithBasePathStrategy`
@@ -66,19 +66,19 @@ in the order registered. See [MultiTenant Strategies](Strategies) for more infor
 
 ### WithPerTenantAuthentication
 
-Configures support for per-tenant authentication. See [Per-Tenant Authentication](Authentication) for more details.
+Configures support for per-tenant authentication. See [Per-Tenant Authentication](../Authentication) for more details.
 
 ## Per-Tenant Options
 
 Finbuckle.MultiTenant integrates with the
 standard [.NET Options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options) (see also the [ASP.NET
 Core Options pattern](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options) and lets apps
-customize options distinctly for each tenant. See [Per-Tenant Options](Options) for more details.
+customize options distinctly for each tenant. See [Per-Tenant Options](../Options) for more details.
 
 ## Tenant Resolution
 
 Most of the capability enabled by Finbuckle.MultiTenant is utilized through its middleware and use
-the [Options pattern with per-tenant options](Options). For web applications the middleware will resolve the app's
+the [Options pattern with per-tenant options](../Options). For web applications the middleware will resolve the app's
 current tenant on each request using the configured strategies and stores, and the per-tenant
 options will alter the app's behavior as dependency injection passes the options to app components.
 

--- a/docs/CoreConcepts.md
+++ b/docs/CoreConcepts.md
@@ -41,7 +41,7 @@ The `MultiTenantContext<TTenantInfo>` contains information about the current ten
 
 Responsible for determining and returning a tenant identifier string for the current request.
 
-* Several strategies are provided based on host, route, etc. See [MultiTenant Strategies](Strategies) for more
+* Several strategies are provided based on host, route, etc. See [MultiTenant Strategies](../Strategies) for more
   information.
 * Custom strategies implementing `IMultiTenantStrategy` can be used as well.
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -55,14 +55,14 @@ information about
 the tenant such as its name and an identifier. `TenantInfo` is provided as a basic implementation, but a custom
 implementation can be used if more properties are needed.
 
-See [Core Concepts](CoreConcepts) for more information on `ITenantInfo`.
+See [Core Concepts](../CoreConcepts) for more information on `ITenantInfo`.
 
 `.WithHostStrategy()`
 
 The line tells the app that our "strategy" to determine the request tenant will be to look at the request host, which
 defaults to the extracting the subdomain as a tenant identifier.
 
-See [Strategies](Strategies) for more information.
+See [Strategies](../Strategies) for more information.
 
 `.WithConfigurationStore()`
 
@@ -70,7 +70,7 @@ This line tells the app that information for all tenants are in the `appsettings
 If a tenant in the store has the identifier found by the strategy, the tenant will be successfully resolved for the
 current request.
 
-See [Stores](Stores) for more information.
+See [Stores](../Stores) for more information.
 
 Finbuckle.MultiTenant comes with a collection of strategies and store types that can be mixed and matched in various
 ways.
@@ -103,17 +103,17 @@ configuration. If the current tenant could not be determined then `TenantInfo` w
 The `ITenantInfo` instance and the typed instance are also available using
 the `IMultiTenantContextAccessor<TTenantinfo>` interface which is available via dependency injection.
 
-See [Configuration and Usage](ConfigurationAndUsage) for more information.
+See [Configuration and Usage](../ConfigurationAndUsage) for more information.
 
 ## Advanced Usage
 
 The library builds on this basic functionality to provide a variety of higher level features. See the documentation for
 more details:
 
-* [Per-tenant Options](Options)
-* [Per-tenant Authentication](Authentication)
-* [Entity Framework Core Data Isolation](EFCore)
-* [ASP.NET Core Identity Data Isolation](Identity)
+* [Per-tenant Options](../Options)
+* [Per-tenant Authentication](../Authentication)
+* [Entity Framework Core Data Isolation](../EFCore)
+* [ASP.NET Core Identity Data Isolation](../Identity)
 
 ## Samples
 

--- a/docs/Identity.md
+++ b/docs/Identity.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 Finbuckle.MultiTenant has limited support for data isolation with ASP.NET Core Identity when Entity Framework Core is
-used as the backing store. It works similarly to [Data Isolation with Entity Framework Core](EFCore) except Identity
+used as the backing store. It works similarly to [Data Isolation with Entity Framework Core](../EFCore) except Identity
 calls into the database instead of your own code.
 
 See the Identity data isolation sample projects in
@@ -14,7 +14,7 @@ and integrate the Identity UI to work with a route multi-tenant strategy.
 ## Configuration
 
 Configuring an Identity db context to be multi-tenant is identical to that of a regular db context as described
-in [Data Isolation With Entity Framework Core](EFCore) with a few extra specifics to keep in mind.
+in [Data Isolation With Entity Framework Core](../EFCore) with a few extra specifics to keep in mind.
 
 The simplest approach is to derive a db context from `MultiTenantIdentityDbContext` (which itself derives
 from `IdentityDbContext`) and configure Identity to use the derived context.
@@ -27,7 +27,7 @@ designate the customized entity type as multi-tenant either:
   method (to ensure the Identity model exists).
 
 If not deriving from `MultiTenantIdentityDbContext` make sure to implement `IMultiTenantDbContext` and call the
-appropriate extension methods as described in [Data Isolation with Entity Framework Core](EFCore). In this case it is
+appropriate extension methods as described in [Data Isolation with Entity Framework Core](../EFCore). In this case it is
 required that base class `OnModelCreating` method is called **before** any multi-tenant extension methods.
 
 By default, all unique indexes will have the `TenantId` property added to prevent conflicts. Additionally,
@@ -59,7 +59,7 @@ a [slightly different method for configuring cookies](https://docs.microsoft.com
 but under the hood standard ASP.NET Core authentication is used.
 
 Finbuckle.MultiTenant can isolate Identity authentication per tenant so that user sessions are unique per tenant.
-See [per-tenant authentication](Authentication) for information on how to customize authentication options per tenant.
+See [per-tenant authentication](../Authentication) for information on how to customize authentication options per tenant.
 
 ## Identity Model Customization with MultiTenantIdentityDbContext
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -13,7 +13,7 @@ Core Options pattern](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/
 customize options distinctly for each tenant.
 
 Note: For authentication options, Finbuckle.MultiTenant provides special support
-for [per-tenant authentication](Authentication).
+for [per-tenant authentication](../Authentication).
 
 The current tenant determines which options are retrieved via
 the `IOptions<TOptions>`, `IOptionsSnapshot<TOptions>`, or `IOptionsMonitor<TOptions>` instances' `Value` property and
@@ -81,7 +81,7 @@ With standard options each tenant would get see the same exact options.
 
 This sections assumes a standard web application builder is configured and Finbuckle.MultiTenant is configured with
 a `TTenantInfo` type of `TenantInfo`.
-See [Getting Started](GettingStarted) for details.
+See [Getting Started](../GettingStarted) for details.
 
 To configure options per tenant, the standard `Configure` method variants on the service collection now all
 have `PerTenant` equivalents which accept a `Action<TOptions, TTenantInfo>` delegate. When the options are created at

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -1,7 +1,7 @@
 # MultiTenant Stores
 
 A MultiTenant store is responsible for retrieving information about a tenant based on an identifier string determined
-by [MultiTenant strategies](Strategies). The retrieved information is then used to create a `TenantInfo` object which
+by [MultiTenant strategies](../Strategies). The retrieved information is then used to create a `TenantInfo` object which
 provides the current tenant information to an app.
 
 Finbuckle.MultiTenant supports several "out-of-the-box" stores for resolving the tenant. Custom stores can be created by

--- a/docs/Strategies.md
+++ b/docs/Strategies.md
@@ -1,7 +1,7 @@
 # MultiTenant Strategies
 
 A multi-tenant strategy is responsible for defining how the tenant is determined. It ultimately produces an identifier
-string which is used to create a `TenantInfo` object with information from the [MultiTenant store](Stores).
+string which is used to create a `TenantInfo` object with information from the [MultiTenant store](../Stores).
 
 Finbuckle.MultiTenant supports several "out-of-the-box" strategies for resolving the tenant. Custom strategies can be
 created by implementing `IMultiTenantStrategy` or using `DelegateStrategy`.
@@ -270,4 +270,4 @@ This is a special strategy used for per-tenant authentication when remote authen
 OAuth (e.g. Log in via Facebook) are used.
 
 The strategy is configured internally when `WithPerTenantAuthentication` is called to
-configure [per-tenant authentication](Authentication).
+configure [per-tenant authentication](../Authentication).

--- a/docs/WhatsNew.md
+++ b/docs/WhatsNew.md
@@ -1,6 +1,6 @@
 # What's New in v<span class="_version">7.0.2</span>
 
-> This page only lists release update details specific to v<span class="_version">7.0.2</span>. [Release update details for all releases are shown in the history page.](History)
+> This page only lists release update details specific to v<span class="_version">7.0.2</span>. [Release update details for all releases are shown in the history page.](../History)
 
 <!--_release-notes-->
 ## [7.0.2](https://github.com/Finbuckle/Finbuckle.MultiTenant/compare/v7.0.1...v7.0.2) (2024-08-03)


### PR DESCRIPTION
Relative links between pages on the Docs part of the homepage does did not work.

E.g. from the page `https://www.finbuckle.com/MultiTenant/Docs/v7.0.2/Stores`, the link to `Strategies` results in the URL `https://www.finbuckle.com/Strategies` instead of `https://www.finbuckle.com/MultiTenant/Docs/v7.0.2/Strategies`

Current links are formatted in the .md-files as `[MultiTenant strategies](Strategies)`. Here the relative link is handled as a folder instead of a filename, resulting in the wrong URL.

Fixed all internal relative links to include `../`, e.g. `[MultiTenant strategies](../Strategies)`.