### PR TITLE
feat(cache): new fusion cache store project

### DIFF
--- a/Finbuckle.MultiTenant.sln
+++ b/Finbuckle.MultiTenant.sln
@@ -27,6 +27,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasePathStrategySample", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentitySample", "samples\net6.0\IdentitySample\IdentitySample.csproj", "{EF62B65E-C017-41D2-9D4F-EB3C6E5CD86D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Finbuckle.MultiTenant.Store.FusionCache", "src\Finbuckle.MultiTenant.Store.FusionCache\Finbuckle.MultiTenant.Store.FusionCache.csproj", "{7C9B7B46-9F0C-485A-914B-F6B6830AF0F4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Finbuckle.MultiTenant.Store.FusionCache.Test", "test\Finbuckle.MultiTenant.Store.FusionCache.Test\Finbuckle.MultiTenant.Store.FusionCache.Test.csproj", "{289D544D-29BE-42DE-B686-7C15EACCFAD4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -68,6 +72,14 @@ Global
 		{CF531F18-3EA7-4DC9-8546-A9FD2B9834A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF531F18-3EA7-4DC9-8546-A9FD2B9834A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF531F18-3EA7-4DC9-8546-A9FD2B9834A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C9B7B46-9F0C-485A-914B-F6B6830AF0F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C9B7B46-9F0C-485A-914B-F6B6830AF0F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C9B7B46-9F0C-485A-914B-F6B6830AF0F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C9B7B46-9F0C-485A-914B-F6B6830AF0F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{289D544D-29BE-42DE-B686-7C15EACCFAD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{289D544D-29BE-42DE-B686-7C15EACCFAD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{289D544D-29BE-42DE-B686-7C15EACCFAD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{289D544D-29BE-42DE-B686-7C15EACCFAD4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CEB62625-8CD8-459B-952F-932A213BD81D} = {CCC3146F-320C-4E1D-8017-056C9DCB6B0C}
@@ -79,5 +91,7 @@ Global
 		{CF531F18-3EA7-4DC9-8546-A9FD2B9834A7} = {32ACE1CC-3201-4AD2-9DA0-D3D7C31D2715}
 		{32ACE1CC-3201-4AD2-9DA0-D3D7C31D2715} = {78DD95B5-E466-4ED0-8824-36F78AB08174}
 		{EF62B65E-C017-41D2-9D4F-EB3C6E5CD86D} = {32ACE1CC-3201-4AD2-9DA0-D3D7C31D2715}
+		{7C9B7B46-9F0C-485A-914B-F6B6830AF0F4} = {CCC3146F-320C-4E1D-8017-056C9DCB6B0C}
+		{289D544D-29BE-42DE-B686-7C15EACCFAD4} = {DDDA7AB6-03C2-4499-BED3-E404CB6ADE69}
 	EndGlobalSection
 EndGlobal

--- a/src/Finbuckle.MultiTenant.Store.FusionCache/Finbuckle.MultiTenant.Store.FusionCache.csproj
+++ b/src/Finbuckle.MultiTenant.Store.FusionCache/Finbuckle.MultiTenant.Store.FusionCache.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Finbuckle.MultiTenant\Finbuckle.MultiTenant.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="ZiggyCreatures.FusionCache" Version="0.26.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/Finbuckle.MultiTenant.Store.FusionCache/FusionCacheStore.cs
+++ b/src/Finbuckle.MultiTenant.Store.FusionCache/FusionCacheStore.cs
@@ -1,0 +1,104 @@
+﻿using System.Text.Json;
+using Finbuckle.MultiTenant.Abstractions;
+using Microsoft.Extensions.Caching.Distributed;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Finbuckle.MultiTenant.Store.FusionCache;
+
+/// <summary>
+///  A store for tenant information that uses FusionCache as the backing store.Note that GetAllAsync is not implemented.
+/// </summary>
+/// <typeparam name="TTenantInfo"> The type of tenant information.</typeparam>
+public class FusionCacheStore<TTenantInfo> : IMultiTenantStore<TTenantInfo> where TTenantInfo : class, ITenantInfo, new()
+{
+    private readonly IFusionCache cache;
+    private readonly string keyPrefix;
+    private readonly TimeSpan? slidingExpiration;
+
+    /// <summary>
+    /// Constructor for FusionCacheStore.
+    /// </summary>
+    /// <param name="cache">IFusionCache instance for use as the store backing.</param>
+    /// <param name="keyPrefix">Prefix string added to cache entries.</param>
+    /// <param name="slidingExpiration">Amount of time to slide expiration with every access.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public FusionCacheStore(IFusionCache cache, string keyPrefix, TimeSpan? slidingExpiration)
+    {
+        this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        this.keyPrefix = keyPrefix ?? throw new ArgumentNullException(nameof(keyPrefix));
+        this.slidingExpiration = slidingExpiration;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryAddAsync(TTenantInfo tenantInfo)
+    {
+        var options = new FusionCacheEntryOptions()
+        {
+            Duration = slidingExpiration ?? TimeSpan.FromSeconds(0)
+        };
+        await cache.SetAsync($"{keyPrefix}id__{tenantInfo.Id}", tenantInfo, options);
+        await cache.SetAsync($"{keyPrefix}identifier__{tenantInfo.Identifier}", tenantInfo, options);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<TTenantInfo?> TryGetAsync(string id)
+    {
+        
+        var result =await cache.GetOrDefaultAsync<TTenantInfo?>($"{keyPrefix}id__{id}");
+
+        // Refresh the identifier version to keep things synced
+       if(result!=null)
+        {
+          await  cache.SetAsync($"{keyPrefix}identifier__{result.Identifier}", result, new FusionCacheEntryOptions()
+            {
+                Duration = slidingExpiration ?? TimeSpan.FromSeconds(0) //  if slidingExpiration is null, set to 0 and skip cache
+            });
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Not implemented in this implementation.
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
+    public Task<IEnumerable<TTenantInfo>> GetAllAsync()
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
+    {
+        var result =await cache.GetOrDefaultAsync<TTenantInfo?>($"{keyPrefix}identifier__{identifier}");
+        
+        if(result!=null)
+        {
+          await  cache.SetAsync($"{keyPrefix}identifier__{result.Identifier}", result, new FusionCacheEntryOptions()
+            {
+                Duration = slidingExpiration ?? TimeSpan.FromSeconds(0) //  if slidingExpiration is null, set to 0 and skip cache
+            });
+        }
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryRemoveAsync(string identifier)
+    {
+        var result = await TryGetByIdentifierAsync(identifier);
+        if (result == null)
+            return false;
+
+        await cache.RemoveAsync($"{keyPrefix}id__{result.Id}");
+        await cache.RemoveAsync($"{keyPrefix}identifier__{result.Identifier}");
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public Task<bool> TryUpdateAsync(TTenantInfo tenantInfo)
+    {
+        // Same as adding for distributed cache.
+        return TryAddAsync(tenantInfo);
+    }
+}

--- a/src/Finbuckle.MultiTenant.Store.FusionCache/MultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.Store.FusionCache/MultiTenantBuilderExtensions.cs
@@ -1,0 +1,22 @@
+using Finbuckle.MultiTenant.Abstractions;
+using Finbuckle.MultiTenant.Internal;
+using Finbuckle.MultiTenant.Stores.DistributedCacheStore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Finbuckle.MultiTenant.Store.FusionCache;
+
+public static class MultiTenantBuilderExtensionsFusionCache
+{
+    /// <summary>
+    /// Adds FusionCache to the application.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="slidingExpiration">The timespan for a cache entry's sliding expiration.</param>
+    public static MultiTenantBuilder<TTenantInfo> WithFusionCacheStore<TTenantInfo>(this MultiTenantBuilder<TTenantInfo> builder, TimeSpan? slidingExpiration)
+        where TTenantInfo : class, ITenantInfo, new()
+    {
+        var storeParams = slidingExpiration is null ? new object[] { Constants.TenantToken } : new object[] { Constants.TenantToken, slidingExpiration };
+
+        return builder.WithStore<FusionCacheStore<TTenantInfo>>(ServiceLifetime.Transient, storeParams);
+    }
+}

--- a/src/Finbuckle.MultiTenant/AssemblyInfo.cs
+++ b/src/Finbuckle.MultiTenant/AssemblyInfo.cs
@@ -7,3 +7,5 @@ using System.Runtime.CompilerServices;
 [assembly:InternalsVisibleTo("Finbuckle.MultiTenant.AspNetCore.Test")]
 [assembly:InternalsVisibleTo("Finbuckle.MultiTenant.EntityFrameworkCore")]
 [assembly:InternalsVisibleTo("Finbuckle.MultiTenant.EntityFrameworkCore.Test")]
+[assembly: InternalsVisibleTo("Finbuckle.MultiTenant.Store.FusionCache")]
+[assembly: InternalsVisibleTo("Finbuckle.MultiTenant.Store.FusionCache.Test")]

--- a/test/Finbuckle.MultiTenant.Store.FusionCache.Test/Finbuckle.MultiTenant.Store.FusionCache.Test.csproj
+++ b/test/Finbuckle.MultiTenant.Store.FusionCache.Test/Finbuckle.MultiTenant.Store.FusionCache.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Finbuckle.MultiTenant.Store.FusionCache\Finbuckle.MultiTenant.Store.FusionCache.csproj" />
+      <ProjectReference Include="..\Finbuckle.MultiTenant.Test\Finbuckle.MultiTenant.Test.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/Finbuckle.MultiTenant.Store.FusionCache.Test/FusionCacheStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Store.FusionCache.Test/FusionCacheStoreShould.cs
@@ -1,0 +1,146 @@
+using Finbuckle.MultiTenant.Abstractions;
+using Finbuckle.MultiTenant.Internal;
+
+using Finbuckle.MultiTenant.Test.Stores;
+
+using Microsoft.Extensions.DependencyInjection;
+using ZiggyCreatures.Caching.Fusion;
+
+
+namespace Finbuckle.MultiTenant.Store.FusionCache.Test;
+
+public class FusionCacheStoreShould : MultiTenantStoreTestBase
+{
+    [Fact]
+    public void ThrownOnGetAllTenantsFromStoreAsync()
+    {
+        var store = CreateTestStore();
+        Assert.Throws<NotImplementedException>(() => store.GetAllAsync().Wait());
+    }
+
+    [Fact]
+    public async Task RemoveDualEntriesOnRemove()
+    {
+        var store = CreateTestStore();
+
+        var r = await store.TryRemoveAsync("lol");
+        Assert.True(r);
+
+        var t1 = await store.TryGetAsync("lol-id");
+        var t2 = await store.TryGetByIdentifierAsync("lol");
+
+        Assert.Null(t1);
+        Assert.Null(t2);
+    }
+
+    [Fact]
+    public async Task RemoveReturnsFalseWhenNoMatchingIdentifierFound()
+    {
+        var store = CreateTestStore();
+
+        var r = await store.TryRemoveAsync("DoesNotExist");
+
+        Assert.False(r);
+    }
+
+    [Fact]
+    public async Task AddDualEntriesOnAddOrUpdate()
+    {
+        var store = CreateTestStore();
+
+        var t2 = await store.TryGetByIdentifierAsync("lol");
+        var t1 = await store.TryGetAsync("lol-id");
+
+        Assert.NotNull(t1);
+        Assert.NotNull(t2);
+        Assert.Equal("lol-id", t1.Id);
+        Assert.Equal("lol-id", t2.Id);
+        Assert.Equal("lol", t1.Identifier);
+        Assert.Equal("lol", t2.Identifier);
+    }
+
+    [Fact]
+    public async Task RefreshDualEntriesOnAddOrUpdate()
+    {
+        var store = CreateTestStore();
+        Thread.Sleep(2000);
+        var t1 = await store.TryGetAsync("lol-id");
+        Thread.Sleep(2000);
+        var t2 = await store.TryGetByIdentifierAsync("lol");
+
+        Assert.NotNull(t1);
+        Assert.NotNull(t2);
+        Assert.Equal("lol-id", t1.Id);
+        Assert.Equal("lol-id", t2.Id);
+        Assert.Equal("lol", t1.Identifier);
+        Assert.Equal("lol", t2.Identifier);
+    }
+
+    [Fact]
+    public async Task ExpireDualEntriesAfterTimespan()
+    {
+        var store = CreateTestStore();
+        Thread.Sleep(3100);
+        var t1 = await store.TryGetAsync("lol-id");
+        var t2 = await store.TryGetByIdentifierAsync("lol");
+
+        Assert.Null(t1);
+        Assert.Null(t2);
+    }
+
+    // Basic store functionality tested in MultiTenantStoresShould.cs
+
+    protected override IMultiTenantStore<TenantInfo> CreateTestStore()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions().AddFusionCache();
+        var sp = services.BuildServiceProvider();
+
+        
+        var store = new FusionCacheStore<TenantInfo>(sp.GetRequiredService<IFusionCache>(), Constants.TenantToken, TimeSpan.FromSeconds(3));
+
+        return PopulateTestStore(store);
+    }
+
+    [Fact]
+    public override void GetTenantInfoFromStoreById()
+    {
+        base.GetTenantInfoFromStoreById();
+    }
+
+    [Fact]
+    public override void ReturnNullWhenGettingByIdIfTenantInfoNotFound()
+    {
+        base.ReturnNullWhenGettingByIdIfTenantInfoNotFound();
+    }
+
+    [Fact]
+    public override void GetTenantInfoFromStoreByIdentifier()
+    {
+        base.GetTenantInfoFromStoreByIdentifier();
+    }
+
+    [Fact]
+    public override void ReturnNullWhenGettingByIdentifierIfTenantInfoNotFound()
+    {
+        base.ReturnNullWhenGettingByIdentifierIfTenantInfoNotFound();
+    }
+
+    [Fact]
+    public override void AddTenantInfoToStore()
+    {
+        base.AddTenantInfoToStore();
+    }
+
+    [Fact]
+    public override void RemoveTenantInfoFromStore()
+    {
+        base.RemoveTenantInfoFromStore();
+    }
+
+    [Fact]
+    public override void UpdateTenantInfoInStore()
+    {
+        base.UpdateTenantInfoInStore();
+    }
+}


### PR DESCRIPTION
After using FusionCache for a while, I decided to create this pull request to add a new store that use the library.
https://github.com/ZiggyCreatures/FusionCache

Using FusionCache over IDistributedCache offers several advantages:

- Resilience: FusionCache handles communication issues with Redis by providing fallback mechanisms to in-memory caching, preventing application failures.
- Performance: It enhances performance by reducing latency, as data is fetched from in-memory before querying Redis.
- Advanced Features: FusionCache includes built-in features such as retries, timeouts, and cache invalidation, which are not available in IDistributedCache.
- Non-blocking Configuration: It supports non-blocking operations, minimizing the impact of cache failures on the overall application.

Stores like IDistributedCacheStore should be ignored in case of Redis errors. Currently, especially during local development, I often encounter issues where, if Redis is not running, the communication error generated by IDistributedCache causes my application to return a 500 error.

![image](https://github.com/user-attachments/assets/e9f64daa-fc88-43de-83f7-172c6371d09a)

With the FusionCache store, after a Redis error, the application will continue running by moving on to the next store in the chain.

```
[17:06:10 WRN] FUSION [N=FusionCache I=f0d8f17fd51442d28e30f9427c99513e] (O=0HN6EGLMR9A6P K=__tenant__identifier__it): [DC] an error occurred while getting entry from distributed <s:ZiggyCreatures.Caching.Fusion.FusionCache>
StackExchange.Redis.RedisConnectionException: The message timed out in the backlog attempting to send because no connection became available (5000ms) - Last Connection Exception: UnableToConnect on localhost:6379/Interactive, Initializing/NotStarted, last: NONE, origin: BeginConnectAsync, outstanding: 0, last-read: 0s ago, last-write: 0s ago, keep-alive: 60s, state: Connecting, mgr: 10 of 10 available, last-heartbeat: never, global: 0s ago, v: 2.8.0.27420, command=HMGET, timeout: 5000, inst: 0, qu: 0, qs: 0, aw: False, bw: CheckingForTimeout, last-in: 0, cur-in: 0, sync-ops: 0, async-ops: 1, serverEndpoint: localhost:6379, conn-sec: n/a, aoc: 0, mc: 1/1/0, mgr: 10 of 10 available, clientName: MacBook-Air-di-Giuseppe(SE.Redis-v2.8.0.27420), IOCP: (Busy=0,Free=1000,Min=1,Max=1000), WORKER: (Busy=1,Free=32766,Min=8,Max=32767), POOL: (Threads=8,QueuedItems=0,CompletedItems=245,Timers=16), v: 2.8.0.27420 (Please take a look at this article for some common client-side issues that can cause timeouts: https://stackexchange.github.io/StackExchange.Redis/Timeouts)
 ---> StackExchange.Redis.RedisConnectionException: UnableToConnect on localhost:6379/Interactive, Initializing/NotStarted, last: NONE, origin: BeginConnectAsync, outstanding: 0, last-read: 0s ago, last-write: 0s ago, keep-alive: 60s, state: Connecting, mgr: 10 of 10 available, last-heartbeat: never, global: 0s ago, v: 2.8.0.27420
   --- End of inner exception stack trace ---
   at Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache.GetAndRefreshAsync(String key, Boolean getData, CancellationToken token)
   at Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache.GetAsync(String key, CancellationToken token)
   at ZiggyCreatures.Caching.Fusion.Internals.Distributed.DistributedCacheAccessor.<>c__DisplayClass14_0`1.<<TryGetEntryAsync>b__0>d.MoveNext() in /_/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Async.cs:line 159
--- End of stack trace from previous location ---
   at ZiggyCreatures.Caching.Fusion.Internals.RunUtils.RunAsyncFuncWithTimeoutAsync[TResult](Func`2 asyncFunc, TimeSpan timeout, Boolean cancelIfTimeout, Action`1 timedOutTaskProcessor, CancellationToken token) in /_/src/ZiggyCreatures.FusionCache/Internals/RunUtils.cs:line 43
   at ZiggyCreatures.Caching.Fusion.Internals.Distributed.DistributedCacheAccessor.TryGetEntryAsync[TValue](String operationId, String key, FusionCacheEntryOptions options, Boolean hasFallbackValue, Nullable`1 timeout, CancellationToken token) in /_/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Async.cs:line 158
[17:06:10 INF] Start processing HTTP request GET https://localhost:5201/api/Tenant/it

```

## Notes
Since it is an external library to this project and is available only for Net8, I have created the following projects in which I have added the dependency on the external library.

1. Finbuckle.MultiTenant.Store.FusionCache
2. Finbuckle.MultiTenant.Store.FusionCache.Test

Let me know what you think and if it could be integrated as a feature into the project.


