### PR TITLE
Make builds deterministic and se latest GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@v3
-#      - uses: actions/setup-dotnet@v3
+        uses: actions/checkout@v4
+#      - uses: actions/setup-dotnet@v4
 #        with:
 #          dotnet-version: '8.0.x'
       - name: build

--- a/.github/workflows/nuget-push-public.yml
+++ b/.github/workflows/nuget-push-public.yml
@@ -6,9 +6,9 @@ jobs:
   build-test-prep-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create the package
-        run: dotnet test -c Release && dotnet pack --no-build -c Release --output nupkgs
+        run: dotnet test -c Release -p:ContinuousIntegrationBuild=true && dotnet pack --no-build -c Release --output nupkgs
       - name: Publish the package to NuGet.org
         env:
           NUGET_KEY: ${{secrets.NUGET_KEY}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,14 @@ jobs:
   build-test-prep-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: build and test
         run: |
           dotnet restore
-          dotnet build -c Release --no-restore
+          dotnet build -c Release --no-restore -p:ContinuousIntegrationBuild=true
           dotnet test -c Release --no-build
       - name: setup semantic-release
         run: |

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,7 @@
         <PackageProjectUrl>https://www.finbuckle.com/MultiTenant</PackageProjectUrl>
         <RepositoryUrl>https://github.com/Finbuckle/Finbuckle.MultiTenant</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <PackageTags>finbuckle;multitenant;multitenancy;aspnet;aspnetcore;entityframework;entityframework-core;efcore</PackageTags>


### PR DESCRIPTION
This hopefully resolves [issues reported by NuGet package explorer](https://nuget.info/packages/Finbuckle.MultiTenant/8.0.0). Also using v4 definitions for GH actions as they are producing warnings due to sunsetting them. 