### PR TITLE
Compile regex just once for HostStrategy

### DIFF
--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/HostStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/HostStrategy.cs
@@ -10,9 +10,9 @@ using Microsoft.AspNetCore.Http;
 
 namespace Finbuckle.MultiTenant.AspNetCore.Strategies;
 
-public class HostStrategy : IMultiTenantStrategy
+public sealed class HostStrategy : IMultiTenantStrategy
 {
-    private readonly string regex;
+    private readonly Regex regex;
 
     public HostStrategy(string template)
     {
@@ -62,7 +62,7 @@ public class HostStrategy : IMultiTenantStrategy
             template = template.Replace(Constants.TenantToken, @"(?<identifier>[^\.]+)");
         }
 
-        this.regex = $"^{template}$";
+        this.regex = new Regex($"^{template}$", RegexOptions.ExplicitCapture | RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
     }
 
     public Task<string?> GetIdentifierAsync(object context)
@@ -77,9 +77,7 @@ public class HostStrategy : IMultiTenantStrategy
 
         string? identifier = null;
 
-        var match = Regex.Match(host.Host, regex,
-            RegexOptions.ExplicitCapture,
-            TimeSpan.FromMilliseconds(100));
+        var match = regex.Match(host.Host);
 
         if (match.Success)
         {


### PR DESCRIPTION
No need always create the regex over and over again (though it could be cached if regex cache isn't polluted). Now constructing regex in constructor with compiled flag and using it in following invocations.