### PR TITLE
Have EFCoreStore depend on an abstraction

### DIFF
--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Finbuckle.MultiTenant.Abstractions;
 using Finbuckle.MultiTenant.EntityFrameworkCore.Stores.EFCoreStore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
@@ -19,7 +20,7 @@ public static class MultiTenantBuilderExtensions
     /// <returns>The same MultiTenantBuilder passed into the method.</returns>
     // ReSharper disable once InconsistentNaming
     public static MultiTenantBuilder<TTenantInfo> WithEFCoreStore<TEFCoreStoreDbContext, TTenantInfo>(this MultiTenantBuilder<TTenantInfo> builder)
-        where TEFCoreStoreDbContext : EFCoreStoreDbContext<TTenantInfo>
+        where TEFCoreStoreDbContext : DbContext, IEFCoreStoreTenants<TTenantInfo>
         where TTenantInfo : class, ITenantInfo, new()
     {
         builder.Services.AddDbContext<TEFCoreStoreDbContext>(); // Note, will not override existing context if already added.

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStore.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStore.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Finbuckle.MultiTenant.EntityFrameworkCore.Stores.EFCoreStore;
 
 public class EFCoreStore<TEFCoreStoreDbContext, TTenantInfo> : IMultiTenantStore<TTenantInfo>
-    where TEFCoreStoreDbContext : EFCoreStoreDbContext<TTenantInfo>
+    where TEFCoreStoreDbContext : DbContext, IEFCoreStoreTenants<TTenantInfo>
     where TTenantInfo : class, ITenantInfo, new()
 {
     internal readonly TEFCoreStoreDbContext dbContext;

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStoreDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStoreDbContext.cs
@@ -11,14 +11,12 @@ public class EFCoreStoreDbContext<TTenantInfo> : DbContext, IEFCoreStoreTenants<
 {
     public EFCoreStoreDbContext(DbContextOptions options) : base(options)
     {
-        }
+    }
 
     public DbSet<TTenantInfo> TenantInfo => Set<TTenantInfo>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-            modelBuilder.Entity<TTenantInfo>().HasKey(ti => ti.Id);
-            modelBuilder.Entity<TTenantInfo>().Property(ti => ti.Id).HasMaxLength(Internal.Constants.TenantIdMaxLength);
-            modelBuilder.Entity<TTenantInfo>().HasIndex(ti => ti.Identifier).IsUnique();
-        }
+        modelBuilder.ApplyConfiguration(new TenantInfoEntityConfiguration<TTenantInfo>());
+    }
 }

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStoreDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/EFCoreStoreDbContext.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Finbuckle.MultiTenant.EntityFrameworkCore.Stores.EFCoreStore;
 
-public class EFCoreStoreDbContext<TTenantInfo> : DbContext
+public class EFCoreStoreDbContext<TTenantInfo> : DbContext, IEFCoreStoreTenants<TTenantInfo>
     where TTenantInfo : class, ITenantInfo, new()
 {
     public EFCoreStoreDbContext(DbContextOptions options) : base(options)

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/IEFCoreStoreTenants.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/IEFCoreStoreTenants.cs
@@ -1,0 +1,13 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more information.
+
+using Finbuckle.MultiTenant.Abstractions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Finbuckle.MultiTenant.EntityFrameworkCore.Stores.EFCoreStore;
+
+public interface IEFCoreStoreTenants<TTenantInfo>
+    where TTenantInfo : class, ITenantInfo, new()
+{
+    DbSet<TTenantInfo> TenantInfo { get; }
+}

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/TenantInfoEntityConfiguration.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore/TenantInfoEntityConfiguration.cs
@@ -1,0 +1,19 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more information.
+
+using Finbuckle.MultiTenant.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Finbuckle.MultiTenant.EntityFrameworkCore.Stores.EFCoreStore;
+
+public class TenantInfoEntityConfiguration<TTenantInfo> : IEntityTypeConfiguration<TTenantInfo>
+    where TTenantInfo : class, ITenantInfo, new()
+{
+    public virtual void Configure(EntityTypeBuilder<TTenantInfo> builder)
+    {
+        builder.HasKey(ti => ti.Id);
+        builder.Property(ti => ti.Id).HasMaxLength(Internal.Constants.TenantIdMaxLength);
+        builder.HasIndex(ti => ti.Identifier).IsUnique();
+    }
+}


### PR DESCRIPTION
## The issue:
I am using Finbuckle, but ran into an issue; I would like people to register on my main site `example.com`, and create an account there using ASP.NET Identity; `IdentityDbContext<MyTenantUser>`. Users created in that main database, are tenants using subdomains; `*.example.com`. So I need to implement those in a `EFCoreStoreDbContext<MyTenantInfo>`. So now I have 2 DbContexts, that should be in the same database, with relationships between the `MyTenantInfo` table and the `MyTenantUser` table. I would like to use only one DbContext, but both `EFCoreStoreDbContext` and `IdentityDbContext` are concrete classes and thus can't inherit from each other.

## The (proposed) solution:
Abstract the `DbSet<TTenantInfo> TenantInfo` getter into an interface, and change the generic constraint of `EFCoreStore` to this interface and `DbContext`. That way users of this library can implement the `TenantInfo` table on top of another `DbContext`.

## Example usage:

```cs
public class MultiTenantStoreDbContext : IdentityDbContext<TenantUser, TenantRole, int>, IEFCoreStoreTenants<MyTenantInfo>
{
    public MultiTenantStoreDbContext(DbContextOptions<MultiTenantStoreDbContext> options)
        : base(options)
    { }

    public DbSet<MyTenantInfo> TenantInfo => Set<MyTenantInfo>();

    protected override void OnModelCreating(ModelBuilder modelBuilder)
    {
        modelBuilder.ApplyConfiguration(new TenantInfoEntityConfiguration<MyTenantInfo>());

        modelBuilder.Entity<TenantUser>(entity =>
        {
            entity.HasOne(u => u.TenantInfo)
                .WithOne(t => t.User)
                .HasForeignKey<TenantUser>(u => u.TenantInfoId);
        });
    }
}

public class MyTenantInfo : ITenantInfo
{
    public string? Id { get; set; } = Guid.CreateVersion7().ToString();
    public string? Identifier { get; set; }
    public string? Name { get; set; }

    public string? ConnectionString { get; set; }

    public TenantUser? User { get; set; }
}


public class TenantUser : IdentityUser<int>
{
    public string? TenantInfoId { get; set; }
    public MyTenantInfo? TenantInfo { get; set; }
}
```