### PR TITLE
Add Context property to StoreResolveCompletedContext

### DIFF
--- a/src/Finbuckle.MultiTenant/Events/StoreResolveCompletedContext.cs
+++ b/src/Finbuckle.MultiTenant/Events/StoreResolveCompletedContext.cs
@@ -13,6 +13,11 @@ public class StoreResolveCompletedContext<TTenantInfo>
     where TTenantInfo : class, ITenantInfo, new()
 {
     /// <summary>
+    /// Gets or sets the context used for attempted tenant resolution.
+    /// </summary>
+    public object? Context { get; set; }
+
+    /// <summary>
     /// The MultiTenantStore instance that was run.
     /// </summary>
     public required IMultiTenantStore<TTenantInfo> Store { get; init; }

--- a/src/Finbuckle.MultiTenant/TenantResolver.cs
+++ b/src/Finbuckle.MultiTenant/TenantResolver.cs
@@ -64,13 +64,13 @@ public class TenantResolver<TTenantInfo> : ITenantResolver<TTenantInfo>
             if (identifier is not null && strategyResolveCompletedContext.Identifier is null)
                 tenantResoloverLogger.LogDebug("OnStrategyResolveCompleted set non-null Identifier to null");
             identifier = strategyResolveCompletedContext.Identifier;
-
+            
             if (options.CurrentValue.IgnoredIdentifiers.Contains(identifier, StringComparer.OrdinalIgnoreCase))
             {
-                tenantResoloverLogger.LogDebug("Ignored identifier: {Identifier}", identifier);
+                tenantResoloverLogger.LogDebug("Ignored identifier: {Identifier}", identifier);               
                 identifier = null;
             }
-
+            
             if (identifier == null)
                 continue;
 
@@ -82,7 +82,7 @@ public class TenantResolver<TTenantInfo> : ITenantResolver<TTenantInfo>
                 var tenantInfo = await wrappedStore.TryGetByIdentifierAsync(identifier).ConfigureAwait(false);
 
                 var storeResolveCompletedContext = new StoreResolveCompletedContext<TTenantInfo>
-                    { Store = store, Strategy = strategy, Identifier = identifier, TenantInfo = tenantInfo };
+                    { Context = context, Store = store, Strategy = strategy, Identifier = identifier, TenantInfo = tenantInfo };
                 await options.CurrentValue.Events.OnStoreResolveCompleted(storeResolveCompletedContext).ConfigureAwait(false);
                 if (tenantInfo is not null && storeResolveCompletedContext.TenantInfo is null)
                     tenantResoloverLogger.LogDebug("OnStoreResolveCompleted set non-null TenantInfo to null");


### PR DESCRIPTION
This change adds the context (i.e. HttpContext) to StoreResolveCompletedContext for the OnStoreResolveCompleted event. By making this change, I am able to workaround an inssue introduced in #628 that prevented me from redirecting to another page with the attempted identifier in the event that it was not found in the store.

Enhance tenant resolution by adding a new `Context` property to the `StoreResolveCompletedContext` class for additional context storage. Update `TenantResolver` to utilize the new property and improve logging of ignored identifiers.

There is a similar property in StrategyResolveCompletedContext. There are no related tests for this property so none were added here.