### PR TITLE
More multi-tenant dbcontext factories

### DIFF
--- a/docs/EFCore.md
+++ b/docs/EFCore.md
@@ -333,6 +333,20 @@ using var tenantDbContext = MultiTenantDbContext.Create<AppMultiTenantDbContext,
 var tenantDbContextWithOptions = MultiTenantDbContext.Create<AppMultiTenantDbContext, AppTenantInfo>(tenantInfo, 
 dbOptions);
 
+// create a database context instance for the tenant with an instance of other dependencies
+// the final parameter is params object[] so any number of dependency arguments can be used
+var tenantDbContextWithOptions = MultiTenantDbContext.Create<AppMultiTenantDbContext, AppTenantInfo>(tenantInfo, 
+dep1, dep2, dep3);
+
+// create a database context instance for the tenant with an instance from pulled from a given service provider
+var tenantDbContextWithOptions = MultiTenantDbContext.Create<AppMultiTenantDbContext, AppTenantInfo>(tenantInfo, 
+serviceProvider);
+
+// create a database context instance for the tenant with an instance from pulled from a given service provider
+// and provided explicitly via params object[]
+var tenantDbContextWithOptions = MultiTenantDbContext.Create<AppMultiTenantDbContext, AppTenantInfo>(tenantInfo, 
+serviceProvider, dep1, dep2, dep3);
+
 // loop through a bunch of tenant instances
 foreach (var tenant in tenants)
 {

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/MultiTenantDbContext/MultiTenantDbContextShould.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/MultiTenantDbContext/MultiTenantDbContextShould.cs
@@ -56,7 +56,7 @@ public class MultiTenantDbContextShould
     }
     
     [Fact]
-    public void WorkWithCreate()
+    public void WorkWithCreateDbOptions()
     {
         var tenant1 = new TenantInfo
         {
@@ -66,6 +66,41 @@ public class MultiTenantDbContextShould
         };
         var c =
             EntityFrameworkCore.MultiTenantDbContext.Create<TestBlogDbContext, TenantInfo>(tenant1, new DbContextOptions<TestBlogDbContext>());
+
+        Assert.NotNull(c);
+    }
+    
+    [Fact]
+    public void WorkWithCreateDependencies()
+    {
+        var tenant1 = new TenantInfo
+        {
+            Id = "abc",
+            Identifier = "abc",
+            Name = "abc"
+        };
+        var c =
+            EntityFrameworkCore.MultiTenantDbContext.Create<TestBlogDbContext, TenantInfo>(tenant1, new object());
+
+        Assert.NotNull(c);
+    }
+    
+    [Fact]
+    public void WorkWithCreateServiceProvider()
+    {
+        // create a sp
+        var services = new ServiceCollection();
+        services.AddTransient<object>(sp => 42);
+        var sp = services.BuildServiceProvider();
+        
+        var tenant1 = new TenantInfo
+        {
+            Id = "abc",
+            Identifier = "abc",
+            Name = "abc"
+        };
+        var c =
+            EntityFrameworkCore.MultiTenantDbContext.Create<TestBlogDbContext, TenantInfo>(tenant1, sp);
 
         Assert.NotNull(c);
     }

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/MultiTenantDbContext/TestEntitities.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/MultiTenantDbContext/TestEntitities.cs
@@ -18,6 +18,10 @@ public class TestBlogDbContext : EntityFrameworkCore.MultiTenantDbContext
     public TestBlogDbContext(IMultiTenantContextAccessor multiTenantContextAccessor, DbContextOptions options) : base(multiTenantContextAccessor, options)
     {
     }
+    
+    public TestBlogDbContext(IMultiTenantContextAccessor multiTenantContextAccessor, object dependency) : base(multiTenantContextAccessor)
+    {
+    }
 }
 
 [MultiTenant]


### PR DESCRIPTION
This adds `MultiTenantDbContext.Create` overloads to accept any number of dependency instance and/or a service provider. Addresses #977.