### PR TITLE
IMultiTenantContext done

### DIFF
--- a/src/Finbuckle.MultiTenant.Abstractions/AsyncLocalMultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant.Abstractions/AsyncLocalMultiTenantContextAccessor.cs
@@ -16,8 +16,8 @@ internal class AsyncLocalMultiTenantContextAccessor<TTenantInfo> : IMultiTenantC
     /// <inheritdoc />
     public IMultiTenantContext<TTenantInfo> MultiTenantContext
     {
-        get => AsyncLocalContext.Value ?? (AsyncLocalContext.Value = new MultiTenantContext<TTenantInfo>());
-        set => AsyncLocalContext.Value = value;
+        get => AsyncLocalContext.Value ?? (AsyncLocalContext.Value = new MultiTenantContext<TTenantInfo>(null));
+        private set => AsyncLocalContext.Value = value;
     }
 
     /// <inheritdoc />

--- a/src/Finbuckle.MultiTenant.Abstractions/IMultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant.Abstractions/IMultiTenantContext.cs
@@ -11,7 +11,7 @@ public interface IMultiTenantContext
     /// <summary>
     /// Information about the tenant for this context.
     /// </summary>
-    ITenantInfo? TenantInfo { get; }
+    ITenantInfo? TenantInfo { get; init; }
 
     /// <summary>
     /// True if a tenant has been resolved and TenantInfo is not null.
@@ -21,7 +21,7 @@ public interface IMultiTenantContext
     /// <summary>
     /// Information about the MultiTenant strategies for this context.
     /// </summary>
-    StrategyInfo? StrategyInfo { get; }
+    StrategyInfo? StrategyInfo { get; init; }
 }
 
 
@@ -36,10 +36,10 @@ public interface IMultiTenantContext<TTenantInfo> : IMultiTenantContext
     /// <summary>
     /// Information about the tenant for this context.
     /// </summary>
-    new TTenantInfo? TenantInfo { get; }
+    new TTenantInfo? TenantInfo { get; init; }
     
     /// <summary>
     /// Information about the MultiTenant stores for this context.
     /// </summary>
-    StoreInfo<TTenantInfo>? StoreInfo { get; set; }
+    StoreInfo<TTenantInfo>? StoreInfo { get; init; }
 }

--- a/src/Finbuckle.MultiTenant.Abstractions/MultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant.Abstractions/MultiTenantContext.cs
@@ -10,18 +10,46 @@ namespace Finbuckle.MultiTenant.Abstractions;
 public class MultiTenantContext<TTenantInfo> : IMultiTenantContext<TTenantInfo>
     where TTenantInfo : class, ITenantInfo, new()
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultiTenantContext{TTenantInfo}"/> class
+    /// with the specified tenant information.
+    /// </summary>
+    /// <param name="tenantInfo">The tenant information (may be null if not resolved).</param>
+    public MultiTenantContext(TTenantInfo? tenantInfo)
+    {
+        TenantInfo = tenantInfo;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultiTenantContext{TTenantInfo}"/> class
+    /// with the specified tenant information, strategy information, and store information.
+    /// </summary>
+    /// <param name="tenantInfo">The tenant information (may be null if not resolved).</param>
+    /// <param name="strategyInfo">The strategy that resolved the tenant (may be null).</param>
+    /// <param name="storeInfo">The store that provided the tenant information (may be null).</param>
+    public MultiTenantContext(TTenantInfo? tenantInfo, StrategyInfo? strategyInfo, StoreInfo<TTenantInfo>? storeInfo)
+    {
+        TenantInfo = tenantInfo;
+        StrategyInfo = strategyInfo;
+        StoreInfo = storeInfo;
+    }
+
     /// <inheritdoc />
-    public TTenantInfo? TenantInfo { get; set; }
+    public TTenantInfo? TenantInfo { get; init; }
 
     /// <inheritdoc />
     public bool IsResolved => TenantInfo != null;
 
     /// <inheritdoc />
-    public StrategyInfo? StrategyInfo { get; set; }
+    public StrategyInfo? StrategyInfo { get; init; }
 
     /// <inheritdoc />
-    public StoreInfo<TTenantInfo>? StoreInfo { get; set; }
+    public StoreInfo<TTenantInfo>? StoreInfo { get; init; }
 
     /// <inheritdoc />
-    ITenantInfo? IMultiTenantContext.TenantInfo => TenantInfo;
+    ITenantInfo? IMultiTenantContext.TenantInfo
+    {
+        get => TenantInfo;
+        init => TenantInfo = value as TTenantInfo;
+    }
 }

--- a/src/Finbuckle.MultiTenant.Abstractions/StaticMultiTenantContextAccessor.cs
+++ b/src/Finbuckle.MultiTenant.Abstractions/StaticMultiTenantContextAccessor.cs
@@ -9,5 +9,5 @@ internal class StaticMultiTenantContextAccessor<TTenantInfo>(TTenantInfo? tenant
     IMultiTenantContext IMultiTenantContextAccessor.MultiTenantContext => MultiTenantContext;
 
     public IMultiTenantContext<TTenantInfo> MultiTenantContext { get; } =
-        new MultiTenantContext<TTenantInfo> { TenantInfo = tenantInfo };
+        new MultiTenantContext<TTenantInfo>(tenantInfo: tenantInfo);
 }

--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -24,7 +24,7 @@ public static class FinbuckleHttpContextExtensions
             if (httpContext.Items.TryGetValue(typeof(IMultiTenantContext), out var mtc) && mtc is not null)
                 return (IMultiTenantContext<TTenantInfo>)mtc;
             
-            mtc = new MultiTenantContext<TTenantInfo>();
+            mtc = new MultiTenantContext<TTenantInfo>(null);
             httpContext.Items[typeof(IMultiTenantContext)] = mtc;
 
             return (IMultiTenantContext<TTenantInfo>)mtc;
@@ -56,12 +56,8 @@ public static class FinbuckleHttpContextExtensions
             if (resetServiceProviderScope)
                 httpContext.RequestServices = httpContext.RequestServices.CreateScope().ServiceProvider;
 
-            var multiTenantContext = new MultiTenantContext<TTenantInfo>
-            {
-                TenantInfo = tenantInfo,
-                StrategyInfo = null,
-                StoreInfo = null
-            };
+            var multiTenantContext =
+                new MultiTenantContext<TTenantInfo>(tenantInfo: tenantInfo, strategyInfo: null, storeInfo: null);
 
             var setter = httpContext.RequestServices.GetRequiredService<IMultiTenantContextSetter>();
             setter.MultiTenantContext = multiTenantContext;

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/HttpContextExtensionShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/HttpContextExtensionShould.cs
@@ -15,10 +15,7 @@ public class HttpContextExtensionShould
     public void GetExistingMultiTenantContext()
     {
             var ti = new TenantInfo { Id = "test" };
-            var mtc = new MultiTenantContext<TenantInfo>
-            {
-                TenantInfo = ti
-            };
+            var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: ti);
 
             var httpContextMock = new Mock<HttpContext>();
             var itemsDict = new Dictionary<object, object?>
@@ -51,10 +48,7 @@ public class HttpContextExtensionShould
     public void ReturnTenantInfo()
     {
             var ti = new TenantInfo { Id = "test" };
-            var mtc = new MultiTenantContext<TenantInfo>
-            {
-                TenantInfo = ti
-            };
+            var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: ti);
 
             var httpContextMock = new Mock<HttpContext>();
             var itemsDict = new Dictionary<object, object?>

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
@@ -47,10 +47,7 @@ public class MultiTenantBuilderExtensionsShould
             var sp = services.BuildServiceProvider();
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>
-            {
-                TenantInfo = new TenantInfo { Identifier = "abc" }
-            };
+            var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: new TenantInfo { Identifier = "abc" });
             sp.GetRequiredService<IMultiTenantContextSetter>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -93,10 +90,7 @@ public class MultiTenantBuilderExtensionsShould
 
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>
-            {
-                TenantInfo = new TenantInfo { Identifier = "abc" }
-            };
+            var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: new TenantInfo { Identifier = "abc" });
             sp.GetRequiredService<IMultiTenantContextSetter>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -130,10 +124,7 @@ public class MultiTenantBuilderExtensionsShould
 
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>
-            {
-                TenantInfo = new TenantInfo { Identifier = "abc" }
-            };
+            var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: new TenantInfo { Identifier = "abc" });
             sp.GetRequiredService<IMultiTenantContextSetter>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -169,10 +160,7 @@ public class MultiTenantBuilderExtensionsShould
             var sp = services.BuildServiceProvider();
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>
-            {
-                TenantInfo = new TenantInfo { Identifier = "abc1" }
-            };
+            var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: new TenantInfo { Identifier = "abc1" });
             sp.GetRequiredService<IMultiTenantContextSetter>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -213,10 +201,7 @@ public class MultiTenantBuilderExtensionsShould
             var sp = services.BuildServiceProvider();
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>
-            {
-                TenantInfo = new TenantInfo { Identifier = "abc1" }
-            };
+            var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: new TenantInfo { Identifier = "abc1" });
             sp.GetRequiredService<IMultiTenantContextSetter>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -255,10 +240,7 @@ public class MultiTenantBuilderExtensionsShould
 
 
             // Fake a resolved tenant
-            var mtc = new MultiTenantContext<TenantInfo>
-            {
-                TenantInfo = new TenantInfo { Identifier = "abc1" }
-            };
+            var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: new TenantInfo { Identifier = "abc1" });
             sp.GetRequiredService<IMultiTenantContextSetter>().MultiTenantContext = mtc;
 
             // Trigger the ValidatePrincipal event
@@ -355,7 +337,7 @@ public class MultiTenantBuilderExtensionsShould
             };
 
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
-            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
+            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo>(tenantInfo: ti1);
 
             var options = sp.GetRequiredService<IAuthenticationSchemeProvider>();
             var scheme = await options.GetDefaultChallengeSchemeAsync();
@@ -382,7 +364,7 @@ public class MultiTenantBuilderExtensionsShould
             };
 
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
-            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
+            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo>(tenantInfo: ti1);
 
             var options = sp.GetRequiredService<IAuthenticationSchemeProvider>();
             Assert.NotNull(options);
@@ -412,7 +394,7 @@ public class MultiTenantBuilderExtensionsShould
             };
 
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
-            setter.MultiTenantContext = new MultiTenantContext<TenantInfo> { TenantInfo = ti1 };
+            setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenantInfo: ti1);
 
             var options = sp.GetRequiredService<IAuthenticationSchemeProvider>();
             Assert.NotNull(options);
@@ -443,7 +425,7 @@ public class MultiTenantBuilderExtensionsShould
             };
 
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
-            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
+            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo>(tenantInfo: ti1);
 
             var options = sp.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>()
                 .Get(OpenIdConnectDefaults.AuthenticationScheme);
@@ -474,7 +456,7 @@ public class MultiTenantBuilderExtensionsShould
             };
             
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
-            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
+            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo>(tenantInfo: ti1);
 
             var options = sp.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>()
                 .Get(OpenIdConnectDefaults.AuthenticationScheme);
@@ -508,7 +490,7 @@ public class MultiTenantBuilderExtensionsShould
             };
             
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
-            setter.MultiTenantContext = new MultiTenantContext<TenantInfo> { TenantInfo = ti1 };
+            setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenantInfo: ti1);
 
             var options = sp.GetRequiredService<IOptionsSnapshot<OpenIdConnectOptions>>()
                 .Get(OpenIdConnectDefaults.AuthenticationScheme);
@@ -538,7 +520,7 @@ public class MultiTenantBuilderExtensionsShould
             };
 
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
-            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
+            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo>(tenantInfo: ti1);
 
             var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>()
                 .Get(CookieAuthenticationDefaults.AuthenticationScheme);
@@ -568,7 +550,7 @@ public class MultiTenantBuilderExtensionsShould
             };
 
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
-            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo> { TenantInfo = ti1 };
+            setter.MultiTenantContext = new MultiTenantContext<TestTenantInfo>(tenantInfo: ti1);
 
             var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>()
                 .Get(CookieAuthenticationDefaults.AuthenticationScheme);
@@ -600,7 +582,7 @@ public class MultiTenantBuilderExtensionsShould
             };
 
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
-            setter.MultiTenantContext = new MultiTenantContext<TenantInfo> { TenantInfo = ti1 };
+            setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenantInfo: ti1);
 
             var options = sp.GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>()
                 .Get(CookieAuthenticationDefaults.AuthenticationScheme);

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantAuthenticationSchemeProviderShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/MultiTenantAuthenticationSchemeProviderShould.cs
@@ -38,11 +38,10 @@ public class MultiTenantAuthenticationSchemeProviderShould
                 Identifier = "tenant2"
             };
             
-            var mtc = new MultiTenantContext<TenantInfo>();
+            var mtc = new MultiTenantContext<TenantInfo>(tenant1);
             var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
             setter.MultiTenantContext = mtc;
 
-            mtc.TenantInfo = tenant1;
             var schemeProvider = sp.GetRequiredService<IAuthenticationSchemeProvider>();
 
             var option = await schemeProvider.GetDefaultChallengeSchemeAsync();
@@ -50,7 +49,8 @@ public class MultiTenantAuthenticationSchemeProviderShould
             Assert.NotNull(option);
             Assert.Equal("tenant1Scheme", option.Name);
 
-            mtc.TenantInfo = tenant2;
+            mtc = new MultiTenantContext<TenantInfo>(tenant2);
+            setter.MultiTenantContext = mtc;
             option = await schemeProvider.GetDefaultChallengeSchemeAsync();
             
             Assert.NotNull(option);

--- a/test/Finbuckle.MultiTenant.Test/MultiTenantContextShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/MultiTenantContextShould.cs
@@ -8,17 +8,14 @@ public class MultiTenantContextShould
     [Fact]
     public void ReturnFalseForIsResolvedIfTenantInfoIsNull()
     {
-        IMultiTenantContext<TenantInfo> context = new MultiTenantContext<TenantInfo>();
+        IMultiTenantContext<TenantInfo> context = new MultiTenantContext<TenantInfo>(null);
         Assert.False(context.IsResolved);
     }
         
     [Fact]
     public void ReturnTrueIsResolvedIfTenantInfoIsNotNull()
     {
-        var context = new MultiTenantContext<TenantInfo>
-        {
-            TenantInfo = new TenantInfo()
-        };
+        var context = new MultiTenantContext<TenantInfo>(tenantInfo: new TenantInfo());
 
         Assert.True(context.IsResolved);
     }
@@ -26,17 +23,14 @@ public class MultiTenantContextShould
     [Fact]
     public void ReturnFalseForIsResolvedIfTenantInfoIsNull_NonGeneric()
     {
-        IMultiTenantContext context = new MultiTenantContext<TenantInfo>();
+        IMultiTenantContext context = new MultiTenantContext<TenantInfo>(null);
         Assert.False(context.IsResolved);
     }
         
     [Fact]
     public void ReturnTrueIsResolvedIfTenantInfoIsNotNull_NonGeneric()
     {
-        var context = new MultiTenantContext<TenantInfo>
-        {
-            TenantInfo = new TenantInfo()
-        };
+        var context = new MultiTenantContext<TenantInfo>(tenantInfo: new TenantInfo());
 
         IMultiTenantContext iContext = context;
         Assert.True(iContext.IsResolved);

--- a/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsCacheShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsCacheShould.cs
@@ -26,10 +26,10 @@ public class MultiTenantOptionsCacheShould
     public void AddNamedOptionsForCurrentTenantOnlyOnAdd(string? name)
     {
         var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
+        var tc = new MultiTenantContext<TenantInfo>(ti);
         var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
+        var tcs = (IMultiTenantContextSetter)tca;
+        tcs.MultiTenantContext = tc;
         var cache = new MultiTenantOptionsCache<TestOptions>(tca);
 
         var options = new TestOptions();
@@ -43,7 +43,7 @@ public class MultiTenantOptionsCacheShould
         Assert.False(result);
 
         // Change the tenant id and confirm options can be added again.
-        ti.Id = "diff_id";
+        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(new TenantInfo { Id = "diff" });
         result = cache.TryAdd(name, options);
         Assert.True(result);
     }
@@ -81,10 +81,10 @@ public class MultiTenantOptionsCacheShould
     public void GetOrAddNamedOptionForCurrentTenantOnly(string? name)
     {
         var ti = new TenantInfo { Id = "test-id-123"};
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
+        var tc = new MultiTenantContext<TenantInfo>(ti);
         var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
+        var tcs = (IMultiTenantContextSetter)tca;
+        tcs.MultiTenantContext = tc;
         var cache = new MultiTenantOptionsCache<TestOptions>(tca);
 
         var options = new TestOptions();
@@ -107,9 +107,7 @@ public class MultiTenantOptionsCacheShould
     [Fact]
     public void ThrowsIfGetOrAddFactoryIsNull()
     {
-        var tc = new MultiTenantContext<TenantInfo>();
         var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
         var cache = new MultiTenantOptionsCache<TestOptions>(tca);
 
         Assert.Throws<ArgumentNullException>(() => cache.GetOrAdd("", null!));
@@ -118,10 +116,6 @@ public class MultiTenantOptionsCacheShould
     [Fact]
     public void ThrowIfConstructorParamIsNull()
     {
-        var tc = new MultiTenantContext<TenantInfo>();
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
-
         Assert.Throws<ArgumentNullException>(() => new MultiTenantOptionsCache<TestOptions>(null!));
     }
 
@@ -132,10 +126,10 @@ public class MultiTenantOptionsCacheShould
     public void RemoveNamedOptionsForCurrentTenantOnly(string? name)
     {
         var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
+        var tc = new MultiTenantContext<TenantInfo>(ti);
         var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
+        var tcs = (IMultiTenantContextSetter)tca;
+        tcs.MultiTenantContext = tc;
         var cache = new MultiTenantOptionsCache<TestOptions>(tca);
 
         var options = new TestOptions();
@@ -176,10 +170,10 @@ public class MultiTenantOptionsCacheShould
     public void ClearOptionsForCurrentTenantOnly()
     {
         var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
+        var tc = new MultiTenantContext<TenantInfo>(ti);
         var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
+        var tcs = (IMultiTenantContextSetter)tca;
+        tcs.MultiTenantContext = tc;
         var cache = new MultiTenantOptionsCache<TestOptions>(tca);
 
         var options = new TestOptions();
@@ -217,10 +211,10 @@ public class MultiTenantOptionsCacheShould
     public void ClearOptionsForTenantIdOnly()
     {
         var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
+        var tc = new MultiTenantContext<TenantInfo>(ti);
         var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
+        var tcs = (IMultiTenantContextSetter)tca;
+        tcs.MultiTenantContext = tc;
         var cache = new MultiTenantOptionsCache<TestOptions>(tca);
 
         var options = new TestOptions();
@@ -256,10 +250,10 @@ public class MultiTenantOptionsCacheShould
     public void ClearAllOptionsForClearAll()
     {
         var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
+        var tc = new MultiTenantContext<TenantInfo>(ti);
         var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
+        var tcs = (IMultiTenantContextSetter)tca;
+        tcs.MultiTenantContext = tc;
         var cache = new MultiTenantOptionsCache<TestOptions>(tca);
 
         var options = new TestOptions();


### PR DESCRIPTION
IMultiTenantContext and its implementations are now immutable for better safety especially in the AsyncLocal context used in most cases.