### PR TITLE
feat: ITenantInfo inherits IClonable

### DIFF
--- a/Finbuckle.MultiTenant.slnx
+++ b/Finbuckle.MultiTenant.slnx
@@ -14,5 +14,6 @@
     <Project Path="test\Finbuckle.MultiTenant.EntityFrameworkCore.Test\Finbuckle.MultiTenant.EntityFrameworkCore.Test.csproj" Type="Classic C#" />
     <Project Path="test\Finbuckle.MultiTenant.Options.Test\Finbuckle.MultiTenant.Options.Test.csproj" Type="Classic C#" />
     <Project Path="test\Finbuckle.MultiTenant.Test\Finbuckle.MultiTenant.Test.csproj" Type="Classic C#" />
+      <Project Path="test\Finbuckle.MultiTenant.Abstractions.Test\Finbuckle.MultiTenant.Abstractions.Test.csproj" Type="Classic C#" />
   </Folder>
 </Solution>

--- a/docs/CoreConcepts.md
+++ b/docs/CoreConcepts.md
@@ -32,6 +32,8 @@ The `MultiTenantContext<TTenantInfo>` contains information about the current ten
 * Implements `IMultiTenantContext` and `IMultiTenantContext<TTenantInfo>` which can be obtained from dependency injection.
 * Includes `TenantInfo`, `StrategyInfo`, and `StoreInfo` properties with details on the current tenant, how it was
   determined, and from where its information was retrieved.
+* **Copies** the `TenantInfo` when getting to avoid accidental changes to the stored tenant information.
+* **Copies** the `TenantInfo` when setting to avoid accidental changes to the stored tenant information.
 * Can be obtained in ASP.NET Core by calling the `GetMultiTenantContext()` method on the current request's `HttpContext`
   object. The implementation used with ASP.NET Core middleware has read only properties. The `HttpContext` extension
   method `TrySetTenantInfo` can be used to manually set the current tenant, but normally the middleware handles this.

--- a/src/Finbuckle.MultiTenant.Abstractions/IMultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant.Abstractions/IMultiTenantContext.cs
@@ -10,6 +10,7 @@ public interface IMultiTenantContext
 {
     /// <summary>
     /// Information about the tenant for this context.
+    /// <remarks>This property gets and inits a copy of the ITenantInfo.</remarks>
     /// </summary>
     ITenantInfo? TenantInfo { get; init; }
 
@@ -24,8 +25,6 @@ public interface IMultiTenantContext
     StrategyInfo? StrategyInfo { get; init; }
 }
 
-
-
 /// <summary>
 /// Generic interface for the multi-tenant context.
 /// </summary>
@@ -35,6 +34,7 @@ public interface IMultiTenantContext<TTenantInfo> : IMultiTenantContext
 {
     /// <summary>
     /// Information about the tenant for this context.
+    /// <remarks>This property gets and inits a copy of the TTenantInfo.</remarks>
     /// </summary>
     new TTenantInfo? TenantInfo { get; init; }
     

--- a/src/Finbuckle.MultiTenant.Abstractions/ITenantInfo.cs
+++ b/src/Finbuckle.MultiTenant.Abstractions/ITenantInfo.cs
@@ -6,7 +6,7 @@ namespace Finbuckle.MultiTenant.Abstractions;
 /// <summary>
 /// Interface for basic tenant information.
 /// </summary>
-public interface ITenantInfo
+public interface ITenantInfo : ICloneable
 {
     
     /// <summary>

--- a/src/Finbuckle.MultiTenant.Abstractions/MultiTenantContext.cs
+++ b/src/Finbuckle.MultiTenant.Abstractions/MultiTenantContext.cs
@@ -35,7 +35,11 @@ public class MultiTenantContext<TTenantInfo> : IMultiTenantContext<TTenantInfo>
     }
 
     /// <inheritdoc />
-    public TTenantInfo? TenantInfo { get; init; }
+    public TTenantInfo? TenantInfo
+    {
+        get => (TTenantInfo?)field?.Clone();
+        init => field = (TTenantInfo?)value?.Clone();
+    }
 
     /// <inheritdoc />
     public bool IsResolved => TenantInfo != null;

--- a/src/Finbuckle.MultiTenant.Abstractions/TenantInfo.cs
+++ b/src/Finbuckle.MultiTenant.Abstractions/TenantInfo.cs
@@ -25,4 +25,15 @@ public class TenantInfo : ITenantInfo
     
     /// <inheritdoc />
     public string? Name { get; set; }
+
+    /// <inheritdoc />
+    public object Clone()
+    {
+        return new TenantInfo()
+        {
+            Id = this.Id,
+            Identifier = this.Identifier,
+            Name = this.Name
+        };
+    }
 }

--- a/test/Finbuckle.MultiTenant.Abstractions.Test/Finbuckle.MultiTenant.Abstractions.Test.csproj
+++ b/test/Finbuckle.MultiTenant.Abstractions.Test/Finbuckle.MultiTenant.Abstractions.Test.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Finbuckle.MultiTenant.Abstractions\Finbuckle.MultiTenant.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/Finbuckle.MultiTenant.Abstractions.Test/MultiTenantContextShould.cs
+++ b/test/Finbuckle.MultiTenant.Abstractions.Test/MultiTenantContextShould.cs
@@ -1,0 +1,38 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more information.
+
+using Finbuckle.MultiTenant.Abstractions;
+using Xunit;
+
+namespace Finbuckle.MultiTenant.Options.Test;
+
+public class MultiTenantContextShould
+{
+    [Fact]
+    public void CloneTenantInfoWhenSetting()
+    {
+        var ti = new TenantInfo { Id = "test", Name = "Test Tenant", Identifier = "test-identifier" };
+        var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: ti);
+
+        // Modify original tenant info after setting it in the context
+        ti.Name = "Modified Tenant";
+
+        // The tenant info in the context should not be affected
+        Assert.Equal("Test Tenant", mtc.TenantInfo!.Name);
+    }
+
+    [Fact]
+    public void CloneTenantInfoWhenGetting()
+    {
+        var ti = new TenantInfo { Id = "test", Name = "Test Tenant", Identifier = "test-identifier" };
+        var mtc = new MultiTenantContext<TenantInfo>(tenantInfo: ti);
+
+        var retrievedTenantInfo = mtc.TenantInfo!;
+
+        // Modify the retrieved tenant info
+        retrievedTenantInfo.Name = "Modified Tenant";
+
+        // The tenant info in the context should not be affected
+        Assert.Equal("Test Tenant", mtc.TenantInfo!.Name);
+    }
+}

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/HttpContextExtensionShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/HttpContextExtensionShould.cs
@@ -61,7 +61,7 @@ public class HttpContextExtensionShould
 
             var returnedTi = httpContextMock.Object.GetTenantInfo<TenantInfo>();
             
-            Assert.Same(ti, returnedTi);
+            Assert.Equivalent(ti, returnedTi);
         }
 
     [Fact]
@@ -93,7 +93,7 @@ public class HttpContextExtensionShould
             context.SetTenantInfo(ti2, false);
             var ti = context.GetTenantInfo<TenantInfo>();
             
-            Assert.Same(ti2, ti);
+            Assert.Equivalent(ti2, ti);
         }
 
     [Fact]

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Extensions/MultiTenantBuilderExtensionsShould.cs
@@ -36,6 +36,24 @@ public class MultiTenantBuilderExtensionsShould
         public string? OpenIdConnectAuthority { get; set; }
         public string? OpenIdConnectClientId { get; set; }
         public string? OpenIdConnectClientSecret { get; set; }
+        
+        public object Clone()
+        {
+            return new TestTenantInfo
+            {
+                Id = this.Id,
+                Identifier = this.Identifier,
+                Name = this.Name,
+                ConnectionString = this.ConnectionString,
+                ChallengeScheme = this.ChallengeScheme,
+                CookieLoginPath = this.CookieLoginPath,
+                CookieLogoutPath = this.CookieLogoutPath,
+                CookieAccessDeniedPath = this.CookieAccessDeniedPath,
+                OpenIdConnectAuthority = this.OpenIdConnectAuthority,
+                OpenIdConnectClientId = this.OpenIdConnectClientId,
+                OpenIdConnectClientSecret = this.OpenIdConnectClientSecret
+            };
+        }
     }
 
     [Fact]

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Routing/ExcludeFromMultiTenantResolutionShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Routing/ExcludeFromMultiTenantResolutionShould.cs
@@ -1,14 +1,4 @@
-﻿using Finbuckle.MultiTenant.Abstractions;
-using Finbuckle.MultiTenant.AspNetCore.Extensions;
-using Finbuckle.MultiTenant.AspNetCore.Strategies;
-using Finbuckle.MultiTenant.Extensions;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Xunit;
-
-namespace Finbuckle.MultiTenant.AspNetCore.Test.Routing;
+﻿namespace Finbuckle.MultiTenant.AspNetCore.Test.Routing;
 
 public class ExcludeFromMultiTenantResolutionShould
 {

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/SessionStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/SessionStrategyShould.cs
@@ -1,15 +1,8 @@
 // Copyright Finbuckle LLC, Andrew White, and Contributors.
 // Refer to the solution LICENSE file for more information.
 
-using System.Runtime.InteropServices;
-using Finbuckle.MultiTenant.Abstractions;
-using Finbuckle.MultiTenant.AspNetCore.Extensions;
 using Finbuckle.MultiTenant.AspNetCore.Strategies;
-using Finbuckle.MultiTenant.Extensions;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 

--- a/test/Finbuckle.MultiTenant.Options.Test/MultiTenantOptionsCacheShould.cs
+++ b/test/Finbuckle.MultiTenant.Options.Test/MultiTenantOptionsCacheShould.cs
@@ -99,6 +99,7 @@ public class MultiTenantOptionsCacheShould
 
         // Confirm different tenant on same object is an add (ie it didn't exist there).
         ti.Id = "diff_id";
+        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
         result = cache.GetOrAdd(name, () => options2);
         Assert.Same(options2, result);
     }
@@ -139,6 +140,7 @@ public class MultiTenantOptionsCacheShould
 
         // Add under a different tenant.
         ti.Id = "diff_id";
+        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
         result = cache.TryAdd(name, options);
         Assert.True(result);
         result = cache.TryAdd("diffName", options);
@@ -183,11 +185,13 @@ public class MultiTenantOptionsCacheShould
 
         // Add under a different tenant.
         ti.Id = "diff_id";
+        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
         result = cache.TryAdd("", options);
         Assert.True(result);
 
         // Clear options on first tenant.
         ti.Id = "test-id-123";
+        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
         cache.Clear();
 
         // Assert options cleared on this tenant.
@@ -224,6 +228,7 @@ public class MultiTenantOptionsCacheShould
 
         // Add under a different tenant.
         ti.Id = "diff_id";
+        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
         result = cache.TryAdd("", options);
         Assert.True(result);
 
@@ -263,6 +268,7 @@ public class MultiTenantOptionsCacheShould
 
         // Add under a different tenant.
         ti.Id = "diff_id";
+        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
         result = cache.TryAdd("", options);
         Assert.True(result);
 


### PR DESCRIPTION
BREAKING CHANGE: Implementations of `ITenantInfo` must also implement `IClonable`. This is to ensure the tenant information on the `MultiTenantContext` is immutable.