### PR TITLE
Feat/identity db context types all multi tenant

### DIFF
--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/EntityTypeBuilderExtensions.cs
@@ -20,6 +20,26 @@ public static class EntityTypeBuilderExtensions
     }
 
     /// <summary>
+    /// Marks an entity as non-multi-tenant, removing any tenant-based query filters.
+    /// </summary>
+    /// <param name="builder">The <see cref="EntityTypeBuilder"/> instance.</param>
+    /// <returns>The same <see cref="EntityTypeBuilder"/> instance for method chaining.</returns>
+    /// <remarks>
+    /// This method is useful for excluding specific entities from tenant isolation in a multi-tenant context.
+    /// It sets the multi-tenant annotation to false and removes the tenant query filter if it exists.
+    /// </remarks>
+    public static EntityTypeBuilder IsNotMultiTenant(this EntityTypeBuilder builder)
+    {
+        builder.HasAnnotation(Constants.MultiTenantAnnotationName, false);
+        //remove the named query filter if it exists
+        var existingFilter = builder.Metadata.FindDeclaredQueryFilter(Abstractions.Constants.TenantToken);
+        if(existingFilter is not null)
+            builder.Metadata.SetQueryFilter(Abstractions.Constants.TenantToken, null);
+        
+        return builder;
+    }
+    
+    /// <summary>
     /// Adds multi-tenant support for an entity via a named query filter.
     /// </summary>
     /// <param name="builder">The typed <see cref="EntityTypeBuilder"/> instance.</param>

--- a/src/Finbuckle.MultiTenant.Identity.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
+++ b/src/Finbuckle.MultiTenant.Identity.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
@@ -13,7 +13,7 @@ namespace Finbuckle.MultiTenant.Identity.EntityFrameworkCore;
 /// <summary>
 /// An Identity database context that enforces tenant integrity on multi-tenant entity types.
 /// <remarks>
-/// All Identity entity types are multi-tenant by default.
+/// All Identity entity types are multi-tenant by default and have the tenant ID added to the unique index.
 /// </remarks>
 /// </summary>
 public class MultiTenantIdentityDbContext : MultiTenantIdentityDbContext<IdentityUser>
@@ -29,21 +29,12 @@ public class MultiTenantIdentityDbContext : MultiTenantIdentityDbContext<Identit
         DbContextOptions options) : base(multiTenantContextAccessor, options)
     {
     }
-
-    /// <inheritdoc />
-    protected override void OnModelCreating(ModelBuilder builder)
-    {
-        base.OnModelCreating(builder);
-
-        builder.Entity<IdentityUser>().IsMultiTenant().AdjustUniqueIndexes();
-    }
 }
 
 /// <summary>
 /// An Identity database context that enforces tenant integrity on multi-tenant entity types.
 /// <remarks>
-/// <typeparamref name="TUser"/> is not multi-tenant by default.
-/// All other Identity entity types are multi-tenant by default.
+/// All Identity entity types are multi-tenant by default and have the tenant ID added to the unique index.
 /// </remarks>
 /// </summary>
 /// <typeparam name="TUser">The <see cref="IdentityUser"/> derived type.</typeparam>
@@ -61,28 +52,19 @@ public class MultiTenantIdentityDbContext<TUser> : MultiTenantIdentityDbContext<
         DbContextOptions options) : base(multiTenantContextAccessor, options)
     {
     }
-
-    /// <inheritdoc />
-    protected override void OnModelCreating(ModelBuilder builder)
-    {
-        base.OnModelCreating(builder);
-
-        builder.Entity<IdentityRole>().IsMultiTenant().AdjustUniqueIndexes();
-    }
 }
 
 /// <summary>
 /// An Identity database context that enforces tenant integrity on multi-tenant entity types.
 /// <remarks>
-/// <typeparamref name="TUser"/> and <typeparamref name="TRole"/> are not multi-tenant by default.
-/// All other Identity entity types are multi-tenant by default.
+/// All Identity entity types are multi-tenant by default and have the tenant ID added to the unique index.
 /// </remarks>
 /// </summary>
 /// <typeparam name="TUser">The <see cref="IdentityUser{TKey}"/> derived type.</typeparam>
 /// <typeparam name="TRole">The <see cref="IdentityRole{TKey}"/> derived type.</typeparam>
 /// <typeparam name="TKey">The key type.</typeparam>
-public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey> : MultiTenantIdentityDbContext<TUser, TRole, TKey
-    , IdentityUserClaim<TKey>, IdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityRoleClaim<TKey>,
+public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey> : MultiTenantIdentityDbContext<TUser, TRole,
+    TKey, IdentityUserClaim<TKey>, IdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityRoleClaim<TKey>,
     IdentityUserToken<TKey>>
     where TUser : IdentityUser<TKey>
     where TRole : IdentityRole<TKey>
@@ -99,25 +81,13 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey> : MultiTe
         DbContextOptions options) : base(multiTenantContextAccessor, options)
     {
     }
-
-    /// <inheritdoc />
-    protected override void OnModelCreating(ModelBuilder builder)
-    {
-        base.OnModelCreating(builder);
-
-        builder.Entity<IdentityUserClaim<TKey>>().IsMultiTenant().AdjustUniqueIndexes();
-        builder.Entity<IdentityUserRole<TKey>>().IsMultiTenant().AdjustUniqueIndexes();
-        builder.Entity<IdentityUserLogin<TKey>>().IsMultiTenant().AdjustUniqueIndexes();
-        builder.Entity<IdentityRoleClaim<TKey>>().IsMultiTenant().AdjustUniqueIndexes();
-        builder.Entity<IdentityUserToken<TKey>>().IsMultiTenant().AdjustUniqueIndexes();
-    }
 }
 
 /// <summary>
 /// An Identity database context that enforces tenant integrity on entity types
 /// marked with the <see cref="MultiTenantAttribute"/> annotation or attribute.
 /// <remarks>
-/// No Identity entity types are multi-tenant by default.
+/// All Identity entity types are multi-tenant by default and have the tenant ID added to the unique index.
 /// </remarks>
 /// </summary>
 /// <typeparam name="TUser">The <see cref="IdentityUser{TKey}"/> derived type.</typeparam>
@@ -173,6 +143,14 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey, TUserClai
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
+        
+        builder.Entity<TUser>().IsMultiTenant().AdjustUniqueIndexes();
+        builder.Entity<TRole>().IsMultiTenant().AdjustUniqueIndexes();
+        builder.Entity<TUserClaim>().IsMultiTenant().AdjustUniqueIndexes();
+        builder.Entity<TUserRole>().IsMultiTenant().AdjustUniqueIndexes();
+        builder.Entity<TUserLogin>().IsMultiTenant().AdjustUniqueIndexes();
+        builder.Entity<TRoleClaim>().IsMultiTenant().AdjustUniqueIndexes();
+        builder.Entity<TUserToken>().IsMultiTenant().AdjustUniqueIndexes();
         builder.ConfigureMultiTenant();
     }
 

--- a/src/Finbuckle.MultiTenant.Identity.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
+++ b/src/Finbuckle.MultiTenant.Identity.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
@@ -65,7 +65,7 @@ public class MultiTenantIdentityDbContext<TUser> : MultiTenantIdentityDbContext<
 /// <typeparam name="TKey">The key type.</typeparam>
 public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey> : MultiTenantIdentityDbContext<TUser, TRole,
     TKey, IdentityUserClaim<TKey>, IdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityRoleClaim<TKey>,
-    IdentityUserToken<TKey>>
+    IdentityUserToken<TKey>, IdentityUserPasskey<TKey>>
     where TUser : IdentityUser<TKey>
     where TRole : IdentityRole<TKey>
     where TKey : IEquatable<TKey>
@@ -84,8 +84,7 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey> : MultiTe
 }
 
 /// <summary>
-/// An Identity database context that enforces tenant integrity on entity types
-/// marked with the <see cref="MultiTenantAttribute"/> annotation or attribute.
+/// An Identity database context that enforces tenant integrity on multi-tenant entity types
 /// <remarks>
 /// All Identity entity types are multi-tenant by default and have the tenant ID added to the unique index.
 /// </remarks>
@@ -98,8 +97,10 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey> : MultiTe
 /// <typeparam name="TUserLogin">The <see cref="IdentityUserLogin{TKey}"/> derived type.</typeparam>
 /// <typeparam name="TRoleClaim">The <see cref="IdentityRoleClaim{TKey}"/> derived type.</typeparam>
 /// <typeparam name="TUserToken">The <see cref="IdentityUserToken{TKey}"/> derived type.</typeparam>
+/// <typeparam name="TUserPasskey">The <see cref="IdentityUserPasskey{TKey}"/> derived type.</typeparam>
 public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim,
-    TUserToken> : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>,
+    TUserToken, TUserPasskey> :
+    IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken, TUserPasskey>,
     IMultiTenantDbContext
     where TUser : IdentityUser<TKey>
     where TRole : IdentityRole<TKey>
@@ -108,6 +109,7 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey, TUserClai
     where TUserLogin : IdentityUserLogin<TKey>
     where TRoleClaim : IdentityRoleClaim<TKey>
     where TUserToken : IdentityUserToken<TKey>
+    where TUserPasskey : IdentityUserPasskey<TKey>
     where TKey : IEquatable<TKey>
 {
     /// <inheritdoc />
@@ -143,7 +145,7 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey, TUserClai
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
-        
+
         builder.Entity<TUser>().IsMultiTenant().AdjustUniqueIndexes();
         builder.Entity<TRole>().IsMultiTenant().AdjustUniqueIndexes();
         builder.Entity<TUserClaim>().IsMultiTenant().AdjustUniqueIndexes();
@@ -151,6 +153,8 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey, TUserClai
         builder.Entity<TUserLogin>().IsMultiTenant().AdjustUniqueIndexes();
         builder.Entity<TRoleClaim>().IsMultiTenant().AdjustUniqueIndexes();
         builder.Entity<TUserToken>().IsMultiTenant().AdjustUniqueIndexes();
+        if(SchemaVersion == IdentitySchemaVersions.Version3)
+            builder.Entity<TUserPasskey>().IsMultiTenant().AdjustUniqueIndexes();
         builder.ConfigureMultiTenant();
     }
 

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/EntityTypeBuilderExtensions/TestDbContext.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/EntityTypeBuilderExtensions/TestDbContext.cs
@@ -15,6 +15,7 @@ public class TestDbContext(Action<ModelBuilder>? config, TenantInfo tenantInfo, 
     public DbSet<MyThingWithTenantId>? MyThingsWithTenantIds { get; set; }
     public DbSet<MyThingWithIntTenantId>? MyThingsWithIntTenantId { get; set; }
     public DbSet<MyMultiTenantThingWithAttribute>? MyMultiTenantThingsWithAttribute { get; set; }
+    public DbSet<MyNonMultiTenantThing>? MyNonMultiTenantThings { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -46,6 +47,11 @@ public class DynamicModelCacheKeyFactory : IModelCacheKeyFactory
 }
 
 public class MyMultiTenantThing
+{
+    public int Id { get; set; }
+}
+
+public class MyNonMultiTenantThing
 {
     public int Id { get; set; }
 }

--- a/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/DynamicModelCacheKeyFactory.cs
+++ b/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/DynamicModelCacheKeyFactory.cs
@@ -1,0 +1,18 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more information.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test;
+
+/// <summary>
+/// Dynamic model cache key factory for tests to force model rebuilds when options vary.
+/// Returns a new object instance for each call to bypass EF Core model caching.
+/// </summary>
+public class DynamicModelCacheKeyFactory : IModelCacheKeyFactory
+{
+    public object Create(DbContext context) => new object();
+    public object Create(DbContext context, bool designTime) => new object();
+}
+

--- a/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RootNamespace>Finbucke.MultiTenant.Identity.EntityFrameworkCore.Test</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/MultiTenanIdentitytDbContextShould.cs
+++ b/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/MultiTenanIdentitytDbContextShould.cs
@@ -56,68 +56,68 @@ public class MultiTenantIdentityDbContextShould
     }
 
     [Theory]
-    [InlineData(typeof(IdentityUser), true)]
-    [InlineData(typeof(IdentityRole), true)]
-    [InlineData(typeof(IdentityUserClaim<string>), true)]
-    [InlineData(typeof(IdentityUserRole<string>), true)]
-    [InlineData(typeof(IdentityUserLogin<string>), true)]
-    [InlineData(typeof(IdentityRoleClaim<string>), true)]
-    [InlineData(typeof(IdentityUserToken<string>), true)]
-    public void SetMultiTenantOnIdentityDbContextVariant_None(Type entityType, bool isMultiTenant)
+    [InlineData(typeof(IdentityUser))]
+    [InlineData(typeof(IdentityRole))]
+    [InlineData(typeof(IdentityUserClaim<string>))]
+    [InlineData(typeof(IdentityUserRole<string>))]
+    [InlineData(typeof(IdentityUserLogin<string>))]
+    [InlineData(typeof(IdentityRoleClaim<string>))]
+    [InlineData(typeof(IdentityUserToken<string>))]
+    public void SetMultiTenantOnIdentityDbContextVariant_None(Type entityType)
     {
         var tenant1 = new TenantInfo(Id: "abc", Identifier: "abc", Name: "abc");
         using var c = MultiTenantDbContext.Create<TestIdentityDbContext, TenantInfo>(tenant1);
 
-        Assert.Equal(isMultiTenant, c.Model.FindEntityType(entityType).IsMultiTenant());
+        Assert.True(c.Model.FindEntityType(entityType).IsMultiTenant());
     }
 
     [Theory]
-    [InlineData(typeof(IdentityUser), false)]
-    [InlineData(typeof(IdentityRole), true)]
-    [InlineData(typeof(IdentityUserClaim<string>), true)]
-    [InlineData(typeof(IdentityUserRole<string>), true)]
-    [InlineData(typeof(IdentityUserLogin<string>), true)]
-    [InlineData(typeof(IdentityRoleClaim<string>), true)]
-    [InlineData(typeof(IdentityUserToken<string>), true)]
-    public void SetMultiTenantOnIdentityDbContextVariant_TUser(Type entityType, bool isMultiTenant)
+    [InlineData(typeof(IdentityUser))]
+    [InlineData(typeof(IdentityRole))]
+    [InlineData(typeof(IdentityUserClaim<string>))]
+    [InlineData(typeof(IdentityUserRole<string>))]
+    [InlineData(typeof(IdentityUserLogin<string>))]
+    [InlineData(typeof(IdentityRoleClaim<string>))]
+    [InlineData(typeof(IdentityUserToken<string>))]
+    public void SetMultiTenantOnIdentityDbContextVariant_TUser(Type entityType)
     {
         var tenant1 = new TenantInfo(Id: "abc", Identifier: "abc", Name: "abc");
         using var c = MultiTenantDbContext.Create<TestIdentityDbContextTUser, TenantInfo>(tenant1);
 
-        Assert.Equal(isMultiTenant, c.Model.FindEntityType(entityType).IsMultiTenant());
+        Assert.True(c.Model.FindEntityType(entityType).IsMultiTenant());
     }
 
     [Theory]
-    [InlineData(typeof(IdentityUser), false)]
-    [InlineData(typeof(IdentityRole), false)]
-    [InlineData(typeof(IdentityUserClaim<string>), true)]
-    [InlineData(typeof(IdentityUserRole<string>), true)]
-    [InlineData(typeof(IdentityUserLogin<string>), true)]
-    [InlineData(typeof(IdentityRoleClaim<string>), true)]
-    [InlineData(typeof(IdentityUserToken<string>), true)]
-    public void SetMultiTenantOnIdentityDbContextVariant_TUser_TRole(Type entityType, bool isMultiTenant)
+    [InlineData(typeof(IdentityUser))]
+    [InlineData(typeof(IdentityRole))]
+    [InlineData(typeof(IdentityUserClaim<string>))]
+    [InlineData(typeof(IdentityUserRole<string>))]
+    [InlineData(typeof(IdentityUserLogin<string>))]
+    [InlineData(typeof(IdentityRoleClaim<string>))]
+    [InlineData(typeof(IdentityUserToken<string>))]
+    public void SetMultiTenantOnIdentityDbContextVariant_TUser_TRole(Type entityType)
     {
         var tenant1 = new TenantInfo(Id: "abc", Identifier: "abc", Name: "abc");
         using var c =
             MultiTenantDbContext.Create<TestIdentityDbContextTUserTRole, TenantInfo>(tenant1);
 
-        Assert.Equal(isMultiTenant, c.Model.FindEntityType(entityType).IsMultiTenant());
+        Assert.True(c.Model.FindEntityType(entityType).IsMultiTenant());
     }
 
     [Theory]
-    [InlineData(typeof(IdentityUser), false)]
-    [InlineData(typeof(IdentityRole), false)]
-    [InlineData(typeof(IdentityUserClaim<string>), false)]
-    [InlineData(typeof(IdentityUserRole<string>), false)]
-    [InlineData(typeof(IdentityUserLogin<string>), false)]
-    [InlineData(typeof(IdentityRoleClaim<string>), false)]
-    [InlineData(typeof(IdentityUserToken<string>), false)]
-    public void SetMultiTenantOnIdentityDbContextVariant_All(Type entityType, bool isMultiTenant)
+    [InlineData(typeof(IdentityUser))]
+    [InlineData(typeof(IdentityRole))]
+    [InlineData(typeof(IdentityUserClaim<string>))]
+    [InlineData(typeof(IdentityUserRole<string>))]
+    [InlineData(typeof(IdentityUserLogin<string>))]
+    [InlineData(typeof(IdentityRoleClaim<string>))]
+    [InlineData(typeof(IdentityUserToken<string>))]
+    public void SetMultiTenantOnIdentityDbContextVariant_All(Type entityType)
     {
         var tenant1 = new TenantInfo(Id: "abc", Identifier: "abc", Name: "abc");
         using var c = MultiTenantDbContext.Create<TestIdentityDbContextAll, TenantInfo>(tenant1);
 
-        Assert.Equal(isMultiTenant, c.Model.FindEntityType(entityType).IsMultiTenant());
+        Assert.True(c.Model.FindEntityType(entityType).IsMultiTenant());
     }
 
     [Fact]

--- a/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/TestIdentityDbContext.cs
+++ b/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/TestIdentityDbContext.cs
@@ -2,10 +2,9 @@
 // Refer to the solution LICENSE file for more information.
 
 using Finbuckle.MultiTenant.Abstractions;
-using Finbuckle.MultiTenant.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
-namespace Finbucke.MultiTenant.Identity.EntityFrameworkCore.Test;
+namespace Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test;
 
 public class TestIdentityDbContext : MultiTenantIdentityDbContext
 {

--- a/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/TestIdentityDbContextAll.cs
+++ b/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/TestIdentityDbContextAll.cs
@@ -2,15 +2,14 @@
 // Refer to the solution LICENSE file for more information.
 
 using Finbuckle.MultiTenant.Abstractions;
-using Finbuckle.MultiTenant.Identity.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
-namespace Finbucke.MultiTenant.Identity.EntityFrameworkCore.Test;
+namespace Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test;
 
 public class TestIdentityDbContextAll : MultiTenantIdentityDbContext<IdentityUser, IdentityRole, string,
     IdentityUserClaim<string>, IdentityUserRole<string>, IdentityUserLogin<string>, IdentityRoleClaim<string>,
-    IdentityUserToken<string>>
+    IdentityUserToken<string>, IdentityUserPasskey<string>>
 {
     public TestIdentityDbContextAll(IMultiTenantContextAccessor multiTenantContextAccessor) : base(
         multiTenantContextAccessor)

--- a/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/TestIdentityDbContextTUser.cs
+++ b/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/TestIdentityDbContextTUser.cs
@@ -2,11 +2,10 @@
 // Refer to the solution LICENSE file for more information.
 
 using Finbuckle.MultiTenant.Abstractions;
-using Finbuckle.MultiTenant.Identity.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
-namespace Finbucke.MultiTenant.Identity.EntityFrameworkCore.Test;
+namespace Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test;
 
 public class TestIdentityDbContextTUser : MultiTenantIdentityDbContext<IdentityUser>
 {

--- a/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/TestIdentityDbContextTUserTRole.cs
+++ b/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/TestIdentityDbContextTUserTRole.cs
@@ -2,11 +2,10 @@
 // Refer to the solution LICENSE file for more information.
 
 using Finbuckle.MultiTenant.Abstractions;
-using Finbuckle.MultiTenant.Identity.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
-namespace Finbucke.MultiTenant.Identity.EntityFrameworkCore.Test;
+namespace Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test;
 
 public class TestIdentityDbContextTUserTRole : MultiTenantIdentityDbContext<IdentityUser, IdentityRole, string>
 {


### PR DESCRIPTION
- change default for `MultiTenantIdentityDbContext` variants for all Identity entities to be multi-tenant
- add `IsNotMultiTenant` fluent method to "un-multi-tenant" and entity in `OnModelCreating`
- add Identity passkey support