### PR TITLE
fix: delegate strategy correctly resolves at runtime with derived types

### DIFF
--- a/docs/Strategies.md
+++ b/docs/Strategies.md
@@ -65,8 +65,8 @@ in the order configured.
 
 Configure by calling `WithDelegateStrategy` after `AddMultiTenant<TTenantInfo>` A `Func<object, Task<string?>>`is passed
 in which will be used with each request to resolve the tenant. A lambda or async lambda can be used as the parameter.
-Alternatively, `WithDelegateStrategy<TContext, TTenantInfo>` accepts a typed context parameter. Tenant resolution will
-ignore this strategy if the context is not of the correct type:
+Alternatively, `WithDelegateStrategy<TContext, TTenantInfo>` accepts a typed context parameter. Tenant 
+resolution will ignore this strategy if the context type does not match or cannot be cast to the specified type:
 
 ```csharp
 // use async logic to get the tenant identifier

--- a/src/Finbuckle.MultiTenant/DependencyInjection/MultiTenantBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant/DependencyInjection/MultiTenantBuilderExtensions.cs
@@ -187,13 +187,13 @@ public static class MultiTenantBuilderExtensions
         Func<TContext, Task<string?>> doStrategy)
         where TTenantInfo : class, ITenantInfo, new()
     {
-        ArgumentNullException.ThrowIfNull(doStrategy, nameof(doStrategy));
+        ArgumentNullException.ThrowIfNull(doStrategy);
 
         Func<object, Task<string?>> wrapStrategy = context =>
         {
-            if (context.GetType() == typeof(TContext))
+            if (context is TContext typed)
             {
-                return doStrategy((TContext)context);
+                return doStrategy(typed);
             }
 
             return Task.FromResult<string?>(null);


### PR DESCRIPTION
This is the same fix as #1053  but for v9