### PR TITLE
fix: enable entity tracking by default on `MultiTenantDbContext` and …

### DIFF
--- a/Finbuckle.MultiTenant.slnx
+++ b/Finbuckle.MultiTenant.slnx
@@ -4,7 +4,7 @@
         <Project Path="samples\WebApiSample\WebApiSample.csproj" />
     </Folder>
     <Folder Name="/src/">
-        <Project Path="src/Finbuckle.MultiTenant.Abstractions\Finbuckle.MultiTenant.Abstractions.csproj" />
+        <Project Path="src\Finbuckle.MultiTenant.Abstractions\Finbuckle.MultiTenant.Abstractions.csproj" />
         <Project Path="src\Finbuckle.MultiTenant.AspNetCore\Finbuckle.MultiTenant.AspNetCore.csproj" />
         <Project Path="src\Finbuckle.MultiTenant.EntityFrameworkCore\Finbuckle.MultiTenant.EntityFrameworkCore.csproj" />
         <Project Path="src\Finbuckle.MultiTenant.Identity.EntityFrameworkCore\Finbuckle.MultiTenant.Identity.EntityFrameworkCore.csproj" />

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Finbuckle.MultiTenant is primarily supported by its [GitHub sponsors](https://gi
 Additional support is provided by the following organizations:
 
 <p><a href="https://www.digitalocean.com/">
-  <img src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg" alt="Digital Ocean logo" height="40">
+
+  <img src="https://cdn.brandfetch.io/idvF37rNoN/w/800/h/137/theme/dark/logo.png?c=1dxbfHSJFAPEGdCLU4o5B" alt="Digital Ocean logo" height="40">
 </a></p>
 
 <p><a href="https://www.github.com/">

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -26,7 +26,7 @@ MultiTenant is primarily supported by its [GitHub sponsors](https://github.com/s
 Additional support is provided by the following organizations:
 
 <p><a href="https://www.digitalocean.com/">
-  <img src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg" alt="Digital Ocean logo" height="40">
+  <img src="https://cdn.brandfetch.io/idvF37rNoN/w/800/h/137/theme/dark/logo.png?c=1dxbfHSJFAPEGdCLU4o5B" alt="Digital Ocean logo" height="40">
 </a></p>
 
 <p><a href="https://www.github.com/">


### PR DESCRIPTION
V10 intended to have the new `EnforceMultiTenantTracking` enabled by default on `MultiTenantDbContext` and `MultiTenantIdentityDbContext`. This PR fixes that.

Fixes #1050 