### PR TITLE
fix store skip take order bug

### DIFF
--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Stores/EFCoreStore.cs
@@ -45,7 +45,7 @@ public class EFCoreStore<TEFCoreStoreDbContext, TTenantInfo> : IMultiTenantStore
     /// <inheritdoc />
     public virtual async Task<IEnumerable<TTenantInfo>> GetAllAsync(int take, int skip)
     {
-        return await dbContext.TenantInfo.Take(take).Skip(skip).AsNoTracking().ToListAsync().ConfigureAwait(false);
+        return await dbContext.TenantInfo.Skip(skip).Take(take).AsNoTracking().ToListAsync().ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/src/Finbuckle.MultiTenant/Stores/ConfigurationStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/ConfigurationStore.cs
@@ -102,7 +102,7 @@ public class ConfigurationStore<TTenantInfo> : IMultiTenantStore<TTenantInfo> wh
     /// <inheritdoc />
     public Task<IEnumerable<TTenantInfo>> GetAllAsync(int take, int skip)
     {
-        return Task.FromResult(tenantMap.Values.Take(take).Skip(skip).ToList().AsEnumerable());
+        return Task.FromResult(tenantMap.Values.Skip(skip).Take(take).ToList().AsEnumerable());
     }
 
     /// <inheritdoc />

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Stores/EFCoreStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Stores/EFCoreStoreShould.cs
@@ -183,4 +183,10 @@ public class EfCoreStoreShould
     {
         await base.GetAllTenantsFromStoreAsync();
     }
+    
+    [Fact]
+    public override async Task GetAllTenantsFromStoreAsyncSkip1Take1()
+    {
+        await base.GetAllTenantsFromStoreAsyncSkip1Take1();
+    }
 }

--- a/test/Finbuckle.MultiTenant.Test/Stores/ConfigurationStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/ConfigurationStoreShould.cs
@@ -132,4 +132,10 @@ public class ConfigurationStoreShould : MultiTenantStoreTestBase
     {
         await base.GetAllTenantsFromStoreAsync();
     }
+    
+    [Fact]
+    public override async Task GetAllTenantsFromStoreAsyncSkip1Take1()
+    {
+        await base.GetAllTenantsFromStoreAsyncSkip1Take1();
+    }
 }


### PR DESCRIPTION
Summary
This PR addresses modifications to tenant retrieval methods to ensure consistency in the order of operations (Skip before Take) across different stores. It also adds new test cases to validate the updated behavior.
Main Changes
Updated the GetAllAsync methods in EFCoreStore and ConfigurationStore to call Skip before Take for consistent logic.
Added new unit test methods in EFCoreStoreShould and ConfigurationStoreShould to verify the updated logic (Skip before Take).
Minor formatting adjustments in test files (handling of newlines).