### PR TITLE
chore: make the ci build use .NET lockfile for deterministic builds t…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           dotnet-version: 10
       - name: build
-        run: dotnet build
+        run: dotnet build -p:ContinuousIntegrationBuild=true
       - name: test Finbuckle.MultiTenant
         run: dotnet test --no-build -v q -f net${{ matrix.dotnet }}
         working-directory: ./test/Finbuckle.MultiTenant.Test


### PR DESCRIPTION
…o match release workflows.