### PR TITLE
Feat/multitenant db improvements

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -73,7 +73,7 @@ will be replaced with the identifier for each specific tenant. For example, a
 `CookieLoginPath` of "/\_\_tenant\_\_/Identity/Account/Login" will result in
 "/initech/Identity/Account/Login" for the Initech tenant.
 
-The code setup is straight-forward:
+The code setup is straightforward:
 
 ```csharp
 using Finbuckle.MultiTenant;
@@ -149,7 +149,7 @@ work.
 
 Internally `WithPerTenantAuthentication()` makes use of
 [per-tenant options](Options). For authentication options not covered by
-`WithPerTenantAuthentication()`, per-tenant option can provide similar behavior.
+`WithPerTenantAuthentication()`, per-tenant options can provide similar behavior.
 
 For example, if you want to configure JWT tokens so that each tenant has a
 different recognized authority for token validation we can add a field to the

--- a/docs/ConfigurationAndUsage.md
+++ b/docs/ConfigurationAndUsage.md
@@ -39,8 +39,8 @@ chaining method calls.
 
 ### WithStore Variants
 
-Adds and configures an IMultiTenantStore for your app. Only the last store configured will be used.
-See [MultiTenant Stores](Stores) for more information on each type.
+Adds and configures an `IMultiTenantStore` for your app. Multiple stores can be configured and each will be checked
+in the order registered. See [MultiTenant Stores](Stores) for more information on each type.
 
 - `WithStore<TStore>`
 - `WithInMemoryStore`

--- a/docs/CoreConcepts.md
+++ b/docs/CoreConcepts.md
@@ -5,8 +5,8 @@ However, there are a few important specifics to be aware of. The items below mak
 
 ## `ITenantInfo` and `TenantInfo`
 
-A `TenantInfo` instance contains information about a tenant. Often this will be the "current" tenant in the context an
-app. These instances' type must implement `ITenantInfo` which defines properties
+A `TenantInfo` instance contains information about a tenant. Often this will be the "current" tenant in the context of an
+app. The type of these instances must implement `ITenantInfo` which defines properties
 for `Id` and `Identifier`. `TenantInfo` is a basic implementation provided by the library which also includes a `Name` property.
 
 When calling `AddMultiTenant<TTenantInfo>` the type passed into the
@@ -17,8 +17,8 @@ type parameter defines the `ITenantInfo` implementation used throughout the libr
   crazy symbols in a web app where the identifier will be part of the URL). Unlike `Id`, `Identifier` can be changed if
   necessary.
 
-The library provides `TenantInfo` as a base implementation. Your app can and should define a custom class implementing `ITenantInfo` (or inheriting from `TenantInfo`) and add custom 
-properties as needed. It is recommended to keep these
+The library provides `TenantInfo` as a base implementation. Your app can and should define a custom class implementing
+`ITenantInfo` (or inheriting from `TenantInfo`) and add custom properties as needed. It is recommended to keep these
 classes lightweight since they are often queried. Keep heavier associated data in an external area that can be pulled in
 when needed via the tenant `Id`.
 

--- a/docs/EFCore.md
+++ b/docs/EFCore.md
@@ -311,9 +311,11 @@ Now whenever this database context is used it will only set and query records fo
 ## Binding the Tenant to the DbContext
 
 It is recommended that the tenant associated with an instance of your DbContext is set at the time of creation and is
-immutable. When implementing `IMultiTenantDbContext` directly, you may choose to only expose a getter for `TenantInfo`
-to enforce this. `MultiTenantDbContext` and `MultiTenantIdentityDbContext` expose a public setter for `TenantInfo` to
-support advanced scenarios such as pooled context reuse, but the setter should be used with caution:
+immutable. When implementing `IMultiTenantDbContext` directly, note that the interface requires a setter for
+`TenantInfo`. If you want `TenantInfo` to remain effectively immutable to consumers of your concrete DbContext, you can
+implement the interface setter explicitly and expose only a public getter on the concrete type. `MultiTenantDbContext`
+and `MultiTenantIdentityDbContext` expose a public setter for `TenantInfo` to support advanced scenarios such as
+pooled context reuse, but the setter should be used with caution:
 
 > **Warning:** Changing `TenantInfo` on a context that already has tracked entities can cause data isolation
 > violations. Always call `ChangeTracker.Clear()` before reassigning `TenantInfo` to ensure no stale, cross-tenant

--- a/docs/EFCore.md
+++ b/docs/EFCore.md
@@ -9,8 +9,8 @@ supports each of these models by associating a connection string with each tenan
 ## Separate Databases
 
 If each tenant uses a separate database then add a `ConnectionString` property to the app's `TenantInfo`
-implementation. and use it in the `OnConfiguring` method of the database context class. The tenant info can be obtained
-by injecting a `IMultiTenantContextAccessor<TTenantInfo>` into the database context class constructor.
+implementation and use it in the `OnConfiguring` method of the database context class. The tenant info can be obtained
+by injecting an `IMultiTenantContextAccessor<TTenantInfo>` into the database context class constructor.
 
 ```csharp
 public class AppTenantInfo : ITenantInfo
@@ -43,6 +43,10 @@ public class MyAppDbContext : DbContext
 This approach does not require the added complexity described below for a shared database approach, but does come with
 its own complexity in operating and maintaining a larger number of database instances and infrastructure.
 
+> **Warning:** If using [pooled db contexts](https://learn.microsoft.com/en-us/ef/core/performance/advanced-performance-topics#dbcontext-pooling),
+> `OnConfiguring` is only called when a context instance is first created and is not called again when that instance is
+> reused from the pool. This means per-tenant connection strings resolved inside `OnConfiguring` will **not** be updated on reuse.
+
 ## Shared Database
 
 In shared database scenarios it is important to make sure that queries and commands for a tenant do not affect the data
@@ -65,14 +69,14 @@ flexibility. These approaches are both explained in detail further below.
 
 ## Hybrid Per-tenant and Shared Databases
 
-When using a shared database context based on `IMultiTenantDbContext` it is simple extend into a hybrid approach simply
+When using a shared database context based on `IMultiTenantDbContext` it is simple to extend into a hybrid approach
 by assigning some tenants to a separate shared database (or its own completely isolated database) via a tenant info
 connection string property as described above in [separate databases](#separate-databases).
 
 ## Configuring and Using a Shared Database
 
 Whether implementing `IMultiTenantDbContext` directly or deriving from `MultiTenantDbContext`, the context will need to
-know which entity types should be treated as multi-tenant (i.e. which entity types are to be isolated per tenant) When
+know which entity types should be treated as multi-tenant (i.e. which entity types are to be isolated per tenant). When
 the database context is initialized, a shadow property named `TenantId` is added to the data model for designated entity
 types. This property is used internally to filter all requests and commands. If there already is a defined string
 property named `TenantId` then it will be used.
@@ -145,8 +149,8 @@ protected override void OnModelCreating(ModelBuilder builder)
 This approach is more flexible than using the `[MultiTenant]` attribute because it can be used for types which do not
 have the attribute, e.g. from another assembly.
 
-`IsMultiTenant()` returns an `MultiTenantEntityTypeBuilder` instance which enables further multi-tenant configuration of
-the entity type via `AdjustKey`,`AdjustIndex`, `AdjustIndexes`, and `AdjustUniqueIndexes`. See [Keys and Indexes](#keys-and-indexes) for
+`IsMultiTenant()` returns a `MultiTenantEntityTypeBuilder` instance which enables further multi-tenant configuration of
+the entity type via `AdjustKey`, `AdjustIndex`, `AdjustIndexes`, and `AdjustUniqueIndexes`. See [Keys and Indexes](#keys-and-indexes) for
 more details.
 
 ### Excluding Entities from Multi-Tenancy
@@ -216,7 +220,7 @@ public class MyDbContext : DbContext, IMultiTenantDbContext
 }
 ```
 
-The database context will need to ensure that these properties haves values, either through constructors, setters, or
+The database context will need to ensure that these properties have values, either through constructors, setters, or
 default values.
 
 Finally, call the library extension methods as described below. This requires overriding the `OnModelCreating`,
@@ -266,7 +270,7 @@ Now whenever this database context is used, it will only set and query records f
 ## Deriving from `MultiTenantDbContext`
 
 This approach is easier but requires inheriting from `MultiTenantDbContext` which may not always be possible if you
-already have a base class. `MultiTenantDbContext` a pre-configured implementation of `IMultiTenantDbContext` with the
+already have a base class. `MultiTenantDbContext` is a pre-configured implementation of `IMultiTenantDbContext` with the
 helper methods as described above in
 [Adding MultiTenant Functionality to an Existing DbContext](#adding-multitenant-functionality-to-an-existing-dbcontext)
 
@@ -306,21 +310,67 @@ Now whenever this database context is used it will only set and query records fo
 
 ## Binding the Tenant to the DbContext
 
-It is recommended that the tenant associated with an instance of your DbContext is set at the time of creation and is 
-immutable. MultiTenant is designed with this in mind and `IMultiTenantDbContext` only has a getter for 
-the `TenantInfo` property. It is possible to define a setter on your own `IMultiTenantDbContext` implementation but 
-doing so will make it difficult ensure data isolation and consistency.
+It is recommended that the tenant associated with an instance of your DbContext is set at the time of creation and is
+immutable. When implementing `IMultiTenantDbContext` directly, you may choose to only expose a getter for `TenantInfo`
+to enforce this. `MultiTenantDbContext` and `MultiTenantIdentityDbContext` expose a public setter for `TenantInfo` to
+support advanced scenarios such as pooled context reuse, but the setter should be used with caution:
+
+> **Warning:** Changing `TenantInfo` on a context that already has tracked entities can cause data isolation
+> violations. Always call `ChangeTracker.Clear()` before reassigning `TenantInfo` to ensure no stale, cross-tenant
+> entities remain in tracking.
+
+```csharp
+// safe way to rebind a context to a different tenant
+dbContext.ChangeTracker.Clear();
+dbContext.TenantInfo = newTenantInfo;
+```
 
 ## Dependency Injection Instantiation
 
-For many cases, such as typical ASP.NET Core apps, normal dependency injection registration of a database context is
-sufficient. The `AddDbContext` will register the context as a service and provide the necessary dependencies. Injected
-instances will automatically be associated with the current tenant.
+For most apps, such as typical ASP.NET Core apps, the `AddMultiTenantDbContext` extension method is the recommended
+way to register a shared-database context. It registers the context as a scoped service, automatically binds
+`TenantInfo` from the current request's tenant, and wires up `EnforceMultiTenantOnTracking` so that tracked entities
+are stamped with the correct `TenantId`.
 
-When registering the database context as a service for use with dependency injection it is important to take into
-account whether the connection string and/or provider will vary per-tenant. If so, it is recommended to set the
-connection string and provider in the `OnConfiguring` database context method as described above rather than in the
-`AddDbContext` service registration method.
+```csharp
+// Program.cs
+builder.Services.AddMultiTenantDbContext<BloggingDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+```
+
+If the connection string or provider varies per tenant, use the overload that provides access to the scoped
+`IServiceProvider`:
+
+```csharp
+builder.Services.AddMultiTenantDbContext<BloggingDbContext>((sp, options) =>
+{
+    var tenantInfo = sp.GetRequiredService<IMultiTenantContextAccessor<AppTenantInfo>>()
+                       .MultiTenantContext.TenantInfo;
+    options.UseSqlServer(tenantInfo?.ConnectionString);
+});
+```
+
+A parameterless overload is also available when options are configured via `OnConfiguring` in the context class itself:
+
+```csharp
+builder.Services.AddMultiTenantDbContext<BloggingDbContext>();
+```
+
+### Pooled DbContext
+
+For high-throughput scenarios, `AddPooledMultiTenantDbContext` registers a pooled factory alongside a scoped service
+that rents a context from the pool each request, clears its change tracker, and rebinds `TenantInfo` to the current
+tenant before returning it:
+
+```csharp
+builder.Services.AddPooledMultiTenantDbContext<BloggingDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")),
+    poolSize: 1024); // optional, defaults to 1024
+```
+
+> Because pooled contexts are reused across requests, the context's `OnConfiguring` method will only be called on the
+> initial context instance creation. Any per-tenant logic such as providers or connection string will **not** be updated
+> in the reused context. Use `AddMultiTenantDbContext` instead if connection strings vary per tenant.
 
 ## Factory Instantiation
 
@@ -362,8 +412,8 @@ foreach (var tenant in tenants)
 ```
 
 Make sure to dispose of the database context instance when it is no longer needed, or better yet use a `using` block or
-variable. This method will work for any database context class expecting a `IMultiTenantContextAccessor` in its
-constructor and an options DbContextOptions<T> in its constructor.
+variable. This method will work for any database context class expecting an `IMultiTenantContextAccessor` in its
+constructor and a `DbContextOptions<T>` in its constructor.
 
 ## Design Time Instantiation
 
@@ -372,23 +422,23 @@ challenging. By default, for things like migrations and command line tools Entit
 instance of the context using dependency injection, however usually no valid tenant exists in these cases and DI fails.
 For this reason it is recommended to use
 a [design time factory](https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dbcontext-creation#from-a-design-time-factory)
-wherein a dummy `TenantInfo` with the desired connection string and passed to the database context creation factory
+wherein a dummy `TenantInfo` with the desired connection string is passed to the database context creation factory
 as described above.
 
 ## Adding Data
 
 Added entities are automatically associated with the current `TenantInfo`. If an entity is associated with a different
 `TenantInfo` then a `MultiTenantException` is thrown in `SaveChanges` or `SaveChangesAsync`. This behavior can be
-altered by changing the values of [TenantMisMatchMode](#tenant-mismatch-mode) and
+altered by changing the values of [TenantMismatchMode](#tenant-mismatch-mode) and
 [TenantNotSetMode](#tenant-not-set-mode) on the `IMultiTenantDbContext`.
 
 > EF Core will require a non-null value when adding an entity that has `TenantId` as a part of the primary key.
 > If the `TenantId` property is not settable (e.g. it is a shadow property), EF Core will require a non-null value.
-> MultiTenant will ensure a `TenantId` is assigned if you call the `EnforceMultiTenantOnTracking` extension 
+> MultiTenant will ensure a `TenantId` is assigned if you call the `EnforceMultiTenantOnTracking` extension
 > method of `IMultiTenantDbContext` on your db context. See [EF Core Tracking](#ef-core-tracking) for more details.
 
 ```csharp
-Blog  myBlog = new Blog{ TenantId = "1", Title = "My Blog" };
+Blog myBlog = new Blog{ TenantId = "1", Title = "My Blog" };
 
 // Add the blog to a db context for a tenant.
 var myTenantInfo = new TenantInfo { Id = "1", Identifier = "tenant-1" };
@@ -440,12 +490,12 @@ var tenantBlogs = db.Blogs.IgnoreQueryFilters(Abstractions.Constants.TenantToken
 
 Updated or deleted entities are checked to make sure they are associated with the `TenantInfo`. If an entity is
 associated with a different `TenantInfo` then a `MultiTenantException` is thrown in `SaveChanges` or `SaveChangesAsync`.
-This behavior can be altered by changing the values of [TenantMisMatchMode](#tenant-mismatch-mode) and 
+This behavior can be altered by changing the values of [TenantMismatchMode](#tenant-mismatch-mode) and
 [TenantNotSetMode](#tenant-not-set-mode) on the `IMultiTenantDbContext`.
 
 ```csharp
 // Add a blog for a tenant.
-Blog  myBlog = new Blog{ TenantId = "1", Title = "My Blog" };
+Blog myBlog = new Blog{ TenantId = "1", Title = "My Blog" };
 var myTenantInfo = new TenantInfo { Id = "1", Identifier = "tenant-1" };
 var myDbContext = MultiTenantDbContext.Create<BloggingDbContext, TenantInfo>(myTenantInfo);
 myDbContext.Blogs.Add(myBlog);
@@ -474,8 +524,9 @@ key and/or indexes. The `MultiTenantEntityTypeBuilder` instance returned from `I
 methods for this purpose:
 
 * `AdjustKey(IMutableKey, ModelBuilder)` - Alters the existing defined key to add the implicit `TenantId`. Note that
-  this will also impact entities with a dependent foreign key and may add an implicit `TenantId` there as well. 
-  This will also require the use of `EnforceMultiTenantOnTracking` as described below in [EFCore Tracking](#efcore-tracking).
+  this will also impact entities with a dependent foreign key and may add an implicit `TenantId` there as well.
+  This will also require the use of `EnforceMultiTenantOnTracking` as described below in [EF Core Tracking](#ef-core-tracking).
+
 ```csharp
 protected override void OnModelCreating(ModelBuilder builder)
 {
@@ -484,18 +535,22 @@ protected override void OnModelCreating(ModelBuilder builder)
     builder.Entity<MyEntityType>().IsMultiTenant().AdjustKey(key, builder).AdjustIndexes();
 }
 ```
-* `AdjustIndex(IMutableIndex)` - Alters an existing index include the implicit `TenantId`.
+
+* `AdjustIndex(IMutableIndex)` - Alters an existing index to include the implicit `TenantId`.
 * `AdjustIndexes()` - Alters all existing indexes to include the implicit `TenantId`.
 * `AdjustUniqueIndexes()` - Alters only all existing unique indexes to include the implicit `TenantId`.
 
 ## EF Core Tracking
 
-When attaching an entity to tracking in EFCore using either `Add` or `Attach`, all primary keys are required 
-to be non-null. MultiTenant will ensure a `TenantId` is assigned if you call the 
-`EnforceMultiTenantOnTracking` extension method of `IMultiTenantDbContext` on your db context. If no `TenantId` is 
-initially set then the current `TenantId` of the db context will be used. This applies to both explicit `TenantId` 
+When attaching an entity to tracking in EF Core using either `Add` or `Attach`, all primary keys are required
+to be non-null. MultiTenant will ensure a `TenantId` is assigned if you call the
+`EnforceMultiTenantOnTracking` extension method of `IMultiTenantDbContext` on your db context. If no `TenantId` is
+initially set then the current `TenantId` of the db context will be used. This applies to both explicit `TenantId`
 properties and implicit `TenantId` shadow properties. It is recommended to call `EnforceMultiTenantOnTracking`
 in your db context constructor.
+
+> When using `AddMultiTenantDbContext` or `AddPooledMultiTenantDbContext`, `EnforceMultiTenantOnTracking` is called
+> automatically during context resolution and does not need to be called again in the constructor.
 
 ## Tenant Mismatch Mode
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -57,7 +57,7 @@ See [Core Concepts](CoreConcepts) for more information on `TenantInfo`.
 `.WithHostStrategy()`
 
 The line tells the app that our "strategy" to determine the request tenant will be to look at the request host, which
-defaults to the extracting the subdomain as a tenant identifier.
+defaults to extracting the subdomain as a tenant identifier.
 
 See [Strategies](Strategies) for more information.
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -39,7 +39,7 @@ correct values for the current tenant are used.
 
 ## Options Basics
 
-Consider a typical scenario in ASP.Net Core, starting with a simple class:
+Consider a typical scenario in ASP.NET Core, starting with a simple class:
 
 ```csharp
 public class MyOptions
@@ -80,7 +80,7 @@ public MyController : Controller
 httpContext.RequestServices.GetServices<IOptionsSnapshot<MyOptions>();
 ```
 
-With standard options each tenant would get see the same exact options.
+With standard options each tenant would see the same exact options.
 
 ## Customizing Options Per Tenant
 

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -18,7 +18,7 @@ The examples in this documentation use the `TenantInfo` basic implementation.
 ## IMultiTenantStore and Custom Stores
 
 If the provided MultiTenant stores are not suitable then a custom store can be created by
-implementing `IMultiTenantStore<TTenantInfo>`. The library will set the type parameter`TTenantInfo` to match the type
+implementing `IMultiTenantStore<TTenantInfo>`. The library will set the type parameter `TTenantInfo` to match the type
 parameter passed to `AddMultiTenant<TTenantInfo>` at compile time. The interface defines `AddAsync`, `UpdateAsync`,
 `RemoveAsync`, `GetByIdentifierAsync`, `GetAsync`, and `GetAllAsync` methods. `GetByIdentifierAsync`
 and `GetAsync` should return null if there is no suitable tenant match.
@@ -188,14 +188,14 @@ builder.Services.AddMultiTenant<TenantInfo>()
 
 > NuGet package: Finbuckle.MultiTenant
 
-Sends the tenant identifier, provided by the multitenant strategy, to an http(s) endpoint to get a `TenantInfo` object
+Sends the tenant identifier, provided by the multi-tenant strategy, to an http(s) endpoint to get a `TenantInfo` object
 in return.
 
 This store is usually case-insensitive when retrieving tenant information by tenant identifier, but the remote server
 might be more restrictive.
 
 Make sure the tenant info type will support basic JSON serialization and deserialization via `System.Text.Json`.
-This strategy will attempt to deserialize the tenant using
+This store will attempt to deserialize the tenant using
 the [System.Text.Json web defaults](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-configure-options?pivots=dotnet-6-0#web-defaults-for-jsonserializeroptions).
 
 For a successful request, the store expects a 200 response code and a json body with properties `Id`, `Identifier`
@@ -250,7 +250,7 @@ Uses the [distributed cache](https://docs.microsoft.com/en-us/aspnet/core/perfor
 mechanism. The distributed cache can use Redis, SQL Server, NCache, or an in-memory (for testing purposes)
 implementation. A sliding expiration is also supported. The store does not interact with any other stores by default.
 Make sure the tenant info type will support basic JSON serialization and deserialization via `System.Text.Json`.
-This strategy will attempt to deserialize the tenant using
+This store will attempt to deserialize the tenant using
 the [System.Text.Json web defaults](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-configure-options?pivots=dotnet-6-0#web-defaults-for-jsonserializeroptions).
 
 Each tenant info instance is actually stored twice in the cache, once using the Tenant ID as the key and another using

--- a/docs/Strategies.md
+++ b/docs/Strategies.md
@@ -307,7 +307,7 @@ builder.Services.AddMultiTenant<TenantInfo>()
 Uses an HTTP request header to determine the tenant identifier. By default, the header with key `__tenant__` is used,
 but a custom key can also be used.
 
-Configure by calling `WithHeaderStrategy` after `AddMultiTenant<TTenantInfo>`. An overload to accept a custom claim type
+Configure by calling `WithHeaderStrategy` after `AddMultiTenant<TTenantInfo>`. An overload to accept a custom header key
 is also available:
 
 ```csharp

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantDbContextExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantDbContextExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright Finbuckle LLC, Andrew White, and Contributors.
 // Refer to the solution LICENSE file for more information.
 
+using System.Runtime.CompilerServices;
 using Finbuckle.MultiTenant.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,6 +12,9 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore.Extensions;
 /// </summary>
 public static class MultiTenantDbContextExtensions
 {
+    private static readonly ConditionalWeakTable<DbContext, object?> TrackingHandlerRegistry = new();
+    private static readonly Lock TrackingHandlerRegistryLock = new();
+
     /// <summary>
     /// Ensures a TenantId property is set when an entity is attached.
     /// </summary>
@@ -19,18 +23,28 @@ public static class MultiTenantDbContextExtensions
     public static void EnforceMultiTenantOnTracking<TContext>(this TContext context)
         where TContext : DbContext, IMultiTenantDbContext
     {
-        // Configure event to handle newly tracked entities.
-        context.ChangeTracker.Tracking += (sender, args) =>
+        // need to lock and track if the event handler has been registered already so that multiple
+        // calls to EnforceMultiTenantOnTracking do not register multiple instances
+        lock (TrackingHandlerRegistryLock)
         {
-            // Honor TenantNotSetMode on tracking from attach multi-tenant entities.
-            if (!args.Entry.Metadata.IsMultiTenant() || args.FromQuery ||
-                args.Entry.Context is not IMultiTenantDbContext multiTenantDbContext) return;
+            if (TrackingHandlerRegistry.TryGetValue(context, out _))
+                return;
 
-            if (multiTenantDbContext.TenantInfo is null)
-                throw new MultiTenantException("MultiTenant Entity cannot be attached if TenantInfo is null.");
+            // Configure event to handle newly tracked entities.
+            context.ChangeTracker.Tracking += (sender, args) =>
+            {
+                if (!args.Entry.Metadata.IsMultiTenant() || args.FromQuery ||
+                    args.Entry.Context is not IMultiTenantDbContext multiTenantDbContext) return;
 
-            args.Entry.Property("TenantId").CurrentValue ??= multiTenantDbContext.TenantInfo.Id;
-        };
+                if (multiTenantDbContext.TenantInfo is null)
+                    throw new MultiTenantException("MultiTenant Entity cannot be attached if TenantInfo is null.");
+
+                var tenantIdProperty = args.Entry.Property("TenantId");
+                tenantIdProperty.CurrentValue ??= multiTenantDbContext.TenantInfo.Id;
+            };
+
+            TrackingHandlerRegistry.Add(context, null);
+        }
     }
 
     /// <summary>

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ServiceCollectionExtensions.cs
@@ -40,4 +40,59 @@ public static class ServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Registers a MultiTenant db context as a scoped service.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The <see cref="DbContext"/> type to register. Must implement
+    /// <see cref="IMultiTenantDbContext"/> so tenant context can be applied.
+    /// </typeparam>
+    /// <param name="services">The service collection to add registrations to.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+    public static IServiceCollection AddMultiTenantDbContext<T>(this IServiceCollection services)
+        where T : DbContext, IMultiTenantDbContext
+        => services.AddMultiTenantDbContext<T>((_, _) => { });
+
+    /// <summary>
+    /// Registers a MultiTenant db context as a scoped service.
+    /// </summary>
+    /// <param name="services">The service collection to add registrations to.</param>
+    /// <param name="optionsAction">An action to configure the <see cref="DbContextOptionsBuilder"/>.</param>
+    /// <typeparam name="T">
+    /// The <see cref="DbContext"/> type to register. Must implement
+    /// <see cref="IMultiTenantDbContext"/> so tenant context can be applied.
+    /// </typeparam>
+    /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+    public static IServiceCollection AddMultiTenantDbContext<T>(this IServiceCollection services,
+        Action<DbContextOptionsBuilder> optionsAction)
+        where T : DbContext, IMultiTenantDbContext
+        => services.AddMultiTenantDbContext<T>((_, b) => optionsAction(b));
+
+    /// <summary>
+    /// Registers a MultiTenant db context as a scoped service.
+    /// </summary>
+    /// <param name="services">The service collection to add registrations to.</param>
+    /// <param name="optionsAction">An action to configure the <see cref="DbContextOptionsBuilder"/> with access to the <see cref="IServiceProvider"/>.</param>
+    /// <typeparam name="T">
+    /// The <see cref="DbContext"/> type to register. Must implement
+    /// <see cref="IMultiTenantDbContext"/> so tenant context can be applied.
+    /// </typeparam>
+    /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+    public static IServiceCollection AddMultiTenantDbContext<T>(this IServiceCollection services,
+        Action<IServiceProvider, DbContextOptionsBuilder> optionsAction)
+        where T : DbContext, IMultiTenantDbContext
+    {
+        services.AddDbContextFactory<T>(optionsAction);
+        services.AddScoped<T>(sp =>
+        {
+            var factory = sp.GetRequiredService<IDbContextFactory<T>>();
+            var context = factory.CreateDbContext();
+            context.EnforceMultiTenantOnTracking();
+
+            return context;
+        });
+
+        return services;
+    }
 }

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,43 @@
+using Finbuckle.MultiTenant.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Finbuckle.MultiTenant.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="IServiceCollection"/> extension methods for Finbuckle.MultiTenant.EntityFrameworkCore.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a pooled factory for a MultiTenant db context.
+    /// </summary>
+    /// <param name="services">The service collection to add registrations to.</param>
+    /// <param name="optionsAction">An action to configure the <see cref="DbContextOptionsBuilder"/> for the pooled factory.</param>
+    /// <param name="poolSize">The maximum number of <typeparamref name="T"/> instances retained by the pool. Defaults to 1024.</param>
+    /// <typeparam name="T">
+    /// The <see cref="DbContext"/> type to resolve from the pool. Must implement
+    /// <see cref="IMultiTenantDbContext"/> so tenant context can be applied.
+    /// </typeparam>
+    /// <returns>The same <see cref="IServiceCollection"/> instance for chaining.</returns>
+    public static IServiceCollection AddPooledMultiTenantDbContext<T>(this IServiceCollection services,
+        Action<DbContextOptionsBuilder> optionsAction,
+        int poolSize = 1024)
+        where T : DbContext, IMultiTenantDbContext
+    {
+        services.AddPooledDbContextFactory<T>(optionsAction, poolSize);
+        services.AddScoped<T>(sp =>
+        {
+            var pooledFactory = sp.GetRequiredService<IDbContextFactory<T>>();
+            var context = pooledFactory.CreateDbContext();
+            context.ChangeTracker.Clear();
+            var tenantInfo = sp.GetRequiredService<IMultiTenantContextAccessor>().MultiTenantContext.TenantInfo;
+            context.TenantInfo = tenantInfo;
+            context.EnforceMultiTenantOnTracking();
+
+            return context;
+        });
+
+        return services;
+    }
+}

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more information.
+
 using Finbuckle.MultiTenant.Abstractions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -88,6 +91,8 @@ public static class ServiceCollectionExtensions
         {
             var factory = sp.GetRequiredService<IDbContextFactory<T>>();
             var context = factory.CreateDbContext();
+            var tenantInfo = sp.GetRequiredService<IMultiTenantContextAccessor>().MultiTenantContext.TenantInfo;
+            context.TenantInfo = tenantInfo;
             context.EnforceMultiTenantOnTracking();
 
             return context;

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/IMultiTenantDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/IMultiTenantDbContext.cs
@@ -11,9 +11,12 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore;
 public interface IMultiTenantDbContext
 {
     /// <summary>
-    /// Gets the current tenant information for this context.
+    /// Gets or sets the current tenant information for this context.
     /// </summary>
-    ITenantInfo? TenantInfo { get; }
+    /// <remarks>
+    /// Setting the <see cref="ITenantInfo"/> may cause conflicts for entities already being tracked. Use with caution.
+    /// </remarks>
+    ITenantInfo? TenantInfo { get; set; }
 
     /// <summary>
     /// Gets the mode used to handle entities where TenantId does not match the current tenant.

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/MultiTenantDbContext.cs
@@ -14,8 +14,7 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore;
 public abstract class MultiTenantDbContext : DbContext, IMultiTenantDbContext
 {
     /// <inheritdoc />
-    // internal set for testing
-    public ITenantInfo? TenantInfo { get; internal set; }
+    public ITenantInfo? TenantInfo { get; set; }
 
     /// <inheritdoc />
     public TenantMismatchMode TenantMismatchMode { get; set; } = TenantMismatchMode.Throw;

--- a/src/Finbuckle.MultiTenant.Identity.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
+++ b/src/Finbuckle.MultiTenant.Identity.EntityFrameworkCore/MultiTenantIdentityDbContext.cs
@@ -113,7 +113,7 @@ public abstract class MultiTenantIdentityDbContext<TUser, TRole, TKey, TUserClai
     where TKey : IEquatable<TKey>
 {
     /// <inheritdoc />
-    public ITenantInfo? TenantInfo { get; }
+    public ITenantInfo? TenantInfo { get; set; }
 
     /// <inheritdoc />
     public TenantMismatchMode TenantMismatchMode { get; set; } = TenantMismatchMode.Throw;

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/MultiTenantDbContextExtensions/MultiTenantDbContextExtensionShould.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/MultiTenantDbContextExtensions/MultiTenantDbContextExtensionShould.cs
@@ -2,10 +2,12 @@
 // Refer to the solution LICENSE file for more information.
 
 using System.Data.Common;
+using System.Reflection;
 using Finbuckle.MultiTenant.Abstractions;
 using Finbuckle.MultiTenant.EntityFrameworkCore.Extensions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Xunit;
 
 namespace Finbuckle.MultiTenant.EntityFrameworkCore.Test.Extensions.MultiTenantDbContextExtensions;
@@ -376,4 +378,84 @@ public class MultiTenantDbContextExtensionsShould
             _connection.Close();
         }
     }
+
+    [Fact]
+    public void AddOneTrackingHandlerWhenEnforceMultiTenantOnTrackingCalledTwice()
+    {
+        var tenant = new TenantInfo { Id = "abc", Identifier = "abc", Name = "abc" };
+        using var db = new TestDbContext(tenant, _options);
+
+        db.EnforceMultiTenantOnTracking();
+        db.EnforceMultiTenantOnTracking();
+
+        var stateManager = typeof(ChangeTracker)
+            .GetField("_stateManager", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(db.ChangeTracker)
+            ?? typeof(ChangeTracker)
+                .GetProperty("StateManager", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.GetValue(db.ChangeTracker);
+
+        Assert.NotNull(stateManager);
+
+        var trackingDelegateField = stateManager!.GetType()
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public)
+            .FirstOrDefault(f => typeof(MulticastDelegate).IsAssignableFrom(f.FieldType) &&
+                                 f.Name.Contains("Tracking", StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotNull(trackingDelegateField);
+
+        var trackingDelegate = trackingDelegateField!.GetValue(stateManager) as MulticastDelegate;
+        Assert.Equal(1, trackingDelegate?.GetInvocationList().Length ?? 0);
+    }
+
+    [Fact]
+    public void SetTenantIdOnAttachWhenTenantNotSetModeIsThrow()
+    {
+        try
+        {
+            _connection.Open();
+            var tenant = new TenantInfo { Id = "abc", Identifier = "abc", Name = "abc" };
+
+            using var db = new TestDbContext(tenant, _options);
+            db.Database.EnsureDeleted();
+            db.Database.EnsureCreated();
+            db.TenantNotSetMode = TenantNotSetMode.Throw;
+            db.EnforceMultiTenantOnTracking();
+
+            var blog = new Blog { Title = "attached" };
+            db.Attach(blog);
+
+            Assert.Equal(tenant.Id, db.Entry(blog).Property("TenantId").CurrentValue);
+        }
+        finally
+        {
+            _connection.Close();
+        }
+    }
+
+    [Fact]
+    public void SetTenantIdWhenAddingEntity()
+    {
+        try
+        {
+            _connection.Open();
+            var tenant = new TenantInfo { Id = "abc", Identifier = "abc", Name = "abc" };
+
+            using var db = new TestDbContext(tenant, _options);
+            db.Database.EnsureDeleted();
+            db.Database.EnsureCreated();
+            db.TenantNotSetMode = TenantNotSetMode.Throw;
+            db.EnforceMultiTenantOnTracking();
+
+            var blog = new Blog { Title = "state-change" };
+            db.Add(blog);
+
+            Assert.Equal(tenant.Id, db.Entry(blog).Property("TenantId").CurrentValue);
+        }
+        finally
+        {
+            _connection.Close();
+        }
+    }
+
 }

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsShould.cs
@@ -12,7 +12,7 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore.Test.Extensions.ServiceColle
 
 public class ServiceCollectionExtensionsShould
 {
-    private static IServiceProvider BuildServiceProvider(string dbName)
+    private static IServiceProvider BuildPooledServiceProvider(string dbName)
     {
         var services = new ServiceCollection();
         services.AddMultiTenant<TenantInfo>();
@@ -22,10 +22,21 @@ public class ServiceCollectionExtensionsShould
         return services.BuildServiceProvider();
     }
 
-    [Fact]
-    public void ReusesPooledContextInstance()
+    private static IServiceProvider BuildNonPooledServiceProvider(string dbName)
     {
-        var sp = BuildServiceProvider("pool-reuse-test");
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.AddMultiTenantDbContext<NonPooledTestDbContext>(
+            options => options.UseSqlite($"DataSource={dbName};Mode=Memory;Cache=Shared"));
+        return services.BuildServiceProvider();
+    }
+
+    // AddPooledMultiTenantDbContext tests
+
+    [Fact]
+    public void AddPooledMultiTenantDbContext_ReusesPooledContextInstance()
+    {
+        var sp = BuildPooledServiceProvider("pool-reuse-test");
         var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
         var tenant = new TenantInfo { Id = "tenant-a", Identifier = "tenant-a" };
         setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenant);
@@ -44,9 +55,9 @@ public class ServiceCollectionExtensionsShould
     }
 
     [Fact]
-    public void ClearsChangeTrackerAndRebindsTenantOnReuse()
+    public void AddPooledMultiTenantDbContext_ClearsChangeTrackerAndRebindsTenantOnReuse()
     {
-        var sp = BuildServiceProvider("pool-clear-rebind-test");
+        var sp = BuildPooledServiceProvider("pool-clear-rebind-test");
         var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
         var tenantA = new TenantInfo { Id = "tenant-a", Identifier = "tenant-a" };
         var tenantB = new TenantInfo { Id = "tenant-b", Identifier = "tenant-b" };
@@ -69,6 +80,122 @@ public class ServiceCollectionExtensionsShould
         Assert.Empty(ctx2.ChangeTracker.Entries());
         Assert.Equal(tenantB.Id, ctx2.TenantInfo!.Id);
     }
+
+    // AddMultiTenantDbContext tests
+
+    [Fact]
+    public void AddMultiTenantDbContext_RegistersDbContextAsScoped()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.AddMultiTenantDbContext<NonPooledTestDbContext>(
+            options => options.UseSqlite("DataSource=:memory:"));
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(NonPooledTestDbContext));
+        Assert.NotNull(descriptor);
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void AddMultiTenantDbContext_CreatesNewInstancePerScope()
+    {
+        var sp = BuildNonPooledServiceProvider("non-pooled-new-instance");
+        var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
+        var tenant = new TenantInfo { Id = "tenant-a", Identifier = "tenant-a" };
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenant);
+
+        NonPooledTestDbContext ctx1;
+        using (var scope1 = sp.CreateScope())
+        {
+            ctx1 = scope1.ServiceProvider.GetRequiredService<NonPooledTestDbContext>();
+        }
+
+        using var scope2 = sp.CreateScope();
+        var ctx2 = scope2.ServiceProvider.GetRequiredService<NonPooledTestDbContext>();
+
+        Assert.False(ReferenceEquals(ctx1, ctx2));
+    }
+
+    [Fact]
+    public void AddMultiTenantDbContext_SetsTenantInfoOnContext()
+    {
+        var sp = BuildNonPooledServiceProvider("non-pooled-tenant-info");
+        var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
+        var tenant = new TenantInfo { Id = "tenant-x", Identifier = "tenant-x" };
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenant);
+
+        using var scope = sp.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<NonPooledTestDbContext>();
+
+        Assert.Equal("tenant-x", ctx.TenantInfo!.Id);
+    }
+
+    [Fact]
+    public void AddMultiTenantDbContext_EnforcesMultiTenantOnTracking()
+    {
+        var sp = BuildNonPooledServiceProvider("non-pooled-tracking");
+        var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
+        var tenant = new TenantInfo { Id = "tenant-t", Identifier = "tenant-t" };
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenant);
+
+        using var scope = sp.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<NonPooledTestDbContext>();
+        ctx.Add(new NonPooledBlog { Title = "test" });
+
+        var tenantId = ctx.ChangeTracker.Entries().Single().Property("TenantId").CurrentValue;
+        Assert.Equal("tenant-t", tenantId);
+    }
+
+    [Fact]
+    public void AddMultiTenantDbContext_ServiceProviderOverloadPassesServiceProviderToOptionsAction()
+    {
+        string? capturedValue = null;
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.AddSingleton("test-connection-string");
+        services.AddMultiTenantDbContext<NonPooledTestDbContext>((sp, options) =>
+        {
+            capturedValue = sp.GetRequiredService<string>();
+            options.UseSqlite("DataSource=:memory:");
+        });
+
+        var provider = services.BuildServiceProvider();
+        var setter = provider.GetRequiredService<IMultiTenantContextSetter>();
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(
+            new TenantInfo { Id = "t", Identifier = "t" });
+
+        using var scope = provider.CreateScope();
+        _ = scope.ServiceProvider.GetRequiredService<NonPooledTestDbContext>();
+
+        Assert.Equal("test-connection-string", capturedValue);
+    }
+
+    [Fact]
+    public void AddMultiTenantDbContext_ParameterlessOverloadRegistersDbContextAsScoped()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.AddMultiTenantDbContext<NonPooledTestDbContext>();
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(NonPooledTestDbContext));
+        Assert.NotNull(descriptor);
+        Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+    }
+}
+
+public class NonPooledTestDbContext(
+    IMultiTenantContextAccessor multiTenantContextAccessor,
+    DbContextOptions<NonPooledTestDbContext> options)
+    : EntityFrameworkCore.MultiTenantDbContext(multiTenantContextAccessor, options)
+{
+    public DbSet<NonPooledBlog>? Blogs { get; set; }
+}
+
+[MultiTenant]
+public class NonPooledBlog
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
 }
 
 public class PooledTestDbContext(

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsShould.cs
@@ -181,6 +181,32 @@ public class ServiceCollectionExtensionsShould
         Assert.NotNull(descriptor);
         Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
     }
+
+    /// <summary>
+    /// Regression test: AddMultiTenantDbContext must set TenantInfo from the scoped
+    /// IMultiTenantContextAccessor even when the DbContext does NOT inherit from
+    /// MultiTenantDbContext (i.e. no constructor-injected accessor).
+    /// Without the explicit assignment in the scoped factory lambda, TenantInfo would
+    /// remain null for such custom contexts.
+    /// </summary>
+    [Fact]
+    public void AddMultiTenantDbContext_SetsTenantInfoOnCustomContext_WithoutConstructorInjection()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.AddMultiTenantDbContext<CustomIMultiTenantDbContext>(
+            options => options.UseSqlite("DataSource=:memory:"));
+
+        var sp = services.BuildServiceProvider();
+        var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
+        var tenant = new TenantInfo { Id = "tenant-custom", Identifier = "tenant-custom" };
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenant);
+
+        using var scope = sp.CreateScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<CustomIMultiTenantDbContext>();
+
+        Assert.Equal("tenant-custom", ctx.TenantInfo!.Id);
+    }
 }
 
 public class NonPooledTestDbContext(
@@ -208,6 +234,31 @@ public class PooledTestDbContext(
 
 [MultiTenant]
 public class PooledBlog
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+}
+
+/// <summary>
+/// A DbContext that implements IMultiTenantDbContext directly, WITHOUT inheriting from
+/// MultiTenantDbContext and WITHOUT constructor-injecting IMultiTenantContextAccessor.
+/// TenantInfo must be wired up externally by the service registration.
+/// </summary>
+public class CustomIMultiTenantDbContext(DbContextOptions<CustomIMultiTenantDbContext> options)
+    : DbContext(options), IMultiTenantDbContext
+{
+    public ITenantInfo? TenantInfo { get; set; }
+    public TenantMismatchMode TenantMismatchMode { get; } = TenantMismatchMode.Throw;
+    public TenantNotSetMode TenantNotSetMode { get; } = TenantNotSetMode.Throw;
+
+    public DbSet<CustomBlog>? Blogs { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.ConfigureMultiTenant();
+}
+
+[MultiTenant]
+public class CustomBlog
 {
     public int Id { get; set; }
     public string? Title { get; set; }

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsShould.cs
@@ -1,0 +1,88 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more information.
+
+using Finbuckle.MultiTenant.Abstractions;
+using Finbuckle.MultiTenant.EntityFrameworkCore.Extensions;
+using Finbuckle.MultiTenant.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Finbuckle.MultiTenant.EntityFrameworkCore.Test.Extensions.ServiceCollectionExtensions;
+
+public class ServiceCollectionExtensionsShould
+{
+    private static IServiceProvider BuildServiceProvider(string dbName)
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.AddPooledMultiTenantDbContext<PooledTestDbContext>(
+            options => options.UseSqlite($"DataSource={dbName};Mode=Memory;Cache=Shared"),
+            poolSize: 1);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void ReusesPooledContextInstance()
+    {
+        var sp = BuildServiceProvider("pool-reuse-test");
+        var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
+        var tenant = new TenantInfo { Id = "tenant-a", Identifier = "tenant-a" };
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenant);
+
+        PooledTestDbContext ctx1;
+        using (var scope1 = sp.CreateScope())
+        {
+            ctx1 = scope1.ServiceProvider.GetRequiredService<PooledTestDbContext>();
+        }
+        // scope1 disposed – context returned to pool
+
+        using var scope2 = sp.CreateScope();
+        var ctx2 = scope2.ServiceProvider.GetRequiredService<PooledTestDbContext>();
+
+        Assert.True(ReferenceEquals(ctx1, ctx2));
+    }
+
+    [Fact]
+    public void ClearsChangeTrackerAndRebindsTenantOnReuse()
+    {
+        var sp = BuildServiceProvider("pool-clear-rebind-test");
+        var setter = sp.GetRequiredService<IMultiTenantContextSetter>();
+        var tenantA = new TenantInfo { Id = "tenant-a", Identifier = "tenant-a" };
+        var tenantB = new TenantInfo { Id = "tenant-b", Identifier = "tenant-b" };
+
+        // Scope 1: track an unsaved entity
+        using (var scope1 = sp.CreateScope())
+        {
+            setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenantA);
+            var ctx1 = scope1.ServiceProvider.GetRequiredService<PooledTestDbContext>();
+            ctx1.Add(new PooledBlog { Title = "unsaved" });
+            Assert.Single(ctx1.ChangeTracker.Entries());
+        }
+        // ctx1 returned to pool with state intact; AddPooledMultiTenantDbContext clears it on next resolution
+
+        // Scope 2: same pooled context instance, but cleared and rebound to tenantB
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(tenantB);
+        using var scope2 = sp.CreateScope();
+        var ctx2 = scope2.ServiceProvider.GetRequiredService<PooledTestDbContext>();
+
+        Assert.Empty(ctx2.ChangeTracker.Entries());
+        Assert.Equal(tenantB.Id, ctx2.TenantInfo!.Id);
+    }
+}
+
+public class PooledTestDbContext(
+    IMultiTenantContextAccessor multiTenantContextAccessor,
+    DbContextOptions<PooledTestDbContext> options)
+    : EntityFrameworkCore.MultiTenantDbContext(multiTenantContextAccessor, options)
+{
+    public DbSet<PooledBlog>? Blogs { get; set; }
+}
+
+[MultiTenant]
+public class PooledBlog
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+}
+


### PR DESCRIPTION
This PR primarily delivers EF Core improvements for multi-tenant applications:

- Breaking change: Adds setter to `IMultiTenantDbContext`
- Breaking change: remove the awkward `IMultiTenantContextAccessor` on `MultiTenantDbContext`
- Adds AddMultiTenantDbContext helper methods for tenant-aware DbContext registration.
- Adds AddPooledMultiTenantDbContext support for pooled DbContext scenarios with tenant rebinding safeguards.
- Improves multi-tenant EF Core behavior and reliability in runtime tracking enforcement.
- General docs improvements.