### PR TITLE
Prevent multiple event handlers for EnforceMultiTenantOnTracking

### DIFF
--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantDbContextExtensions.cs
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/Extensions/MultiTenantDbContextExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright Finbuckle LLC, Andrew White, and Contributors.
 // Refer to the solution LICENSE file for more information.
 
+using System.Runtime.CompilerServices;
 using Finbuckle.MultiTenant.Abstractions;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,6 +12,9 @@ namespace Finbuckle.MultiTenant.EntityFrameworkCore.Extensions;
 /// </summary>
 public static class MultiTenantDbContextExtensions
 {
+    private static readonly ConditionalWeakTable<DbContext, object?> TrackingHandlerRegistry = new();
+    private static readonly Lock TrackingHandlerRegistryLock = new();
+
     /// <summary>
     /// Ensures a TenantId property is set when an entity is attached.
     /// </summary>
@@ -19,18 +23,28 @@ public static class MultiTenantDbContextExtensions
     public static void EnforceMultiTenantOnTracking<TContext>(this TContext context)
         where TContext : DbContext, IMultiTenantDbContext
     {
-        // Configure event to handle newly tracked entities.
-        context.ChangeTracker.Tracking += (sender, args) =>
+        // need to lock and track if the event handler has been registered already so that multiple
+        // calls to EnforceMultiTenantOnTracking do not register multiple instances
+        lock (TrackingHandlerRegistryLock)
         {
-            // Honor TenantNotSetMode on tracking from attach multi-tenant entities.
-            if (!args.Entry.Metadata.IsMultiTenant() || args.FromQuery ||
-                args.Entry.Context is not IMultiTenantDbContext multiTenantDbContext) return;
+            if (TrackingHandlerRegistry.TryGetValue(context, out _))
+                return;
 
-            if (multiTenantDbContext.TenantInfo is null)
-                throw new MultiTenantException("MultiTenant Entity cannot be attached if TenantInfo is null.");
+            // Configure event to handle newly tracked entities.
+            context.ChangeTracker.Tracking += (sender, args) =>
+            {
+                if (!args.Entry.Metadata.IsMultiTenant() || args.FromQuery ||
+                    args.Entry.Context is not IMultiTenantDbContext multiTenantDbContext) return;
 
-            args.Entry.Property("TenantId").CurrentValue ??= multiTenantDbContext.TenantInfo.Id;
-        };
+                if (multiTenantDbContext.TenantInfo is null)
+                    throw new MultiTenantException("MultiTenant Entity cannot be attached if TenantInfo is null.");
+
+                var tenantIdProperty = args.Entry.Property("TenantId");
+                tenantIdProperty.CurrentValue ??= multiTenantDbContext.TenantInfo.Id;
+            };
+
+            TrackingHandlerRegistry.Add(context, null);
+        }
     }
 
     /// <summary>

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/MultiTenantDbContextExtensions/MultiTenantDbContextExtensionShould.cs
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Extensions/MultiTenantDbContextExtensions/MultiTenantDbContextExtensionShould.cs
@@ -2,10 +2,12 @@
 // Refer to the solution LICENSE file for more information.
 
 using System.Data.Common;
+using System.Reflection;
 using Finbuckle.MultiTenant.Abstractions;
 using Finbuckle.MultiTenant.EntityFrameworkCore.Extensions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Xunit;
 
 namespace Finbuckle.MultiTenant.EntityFrameworkCore.Test.Extensions.MultiTenantDbContextExtensions;
@@ -376,4 +378,84 @@ public class MultiTenantDbContextExtensionsShould
             _connection.Close();
         }
     }
+
+    [Fact]
+    public void AddOneTrackingHandlerWhenEnforceMultiTenantOnTrackingCalledTwice()
+    {
+        var tenant = new TenantInfo { Id = "abc", Identifier = "abc", Name = "abc" };
+        using var db = new TestDbContext(tenant, _options);
+
+        db.EnforceMultiTenantOnTracking();
+        db.EnforceMultiTenantOnTracking();
+
+        var stateManager = typeof(ChangeTracker)
+            .GetField("_stateManager", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(db.ChangeTracker)
+            ?? typeof(ChangeTracker)
+                .GetProperty("StateManager", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.GetValue(db.ChangeTracker);
+
+        Assert.NotNull(stateManager);
+
+        var trackingDelegateField = stateManager!.GetType()
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public)
+            .FirstOrDefault(f => typeof(MulticastDelegate).IsAssignableFrom(f.FieldType) &&
+                                 f.Name.Contains("Tracking", StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotNull(trackingDelegateField);
+
+        var trackingDelegate = trackingDelegateField!.GetValue(stateManager) as MulticastDelegate;
+        Assert.Equal(1, trackingDelegate?.GetInvocationList().Length ?? 0);
+    }
+
+    [Fact]
+    public void SetTenantIdOnAttachWhenTenantNotSetModeIsThrow()
+    {
+        try
+        {
+            _connection.Open();
+            var tenant = new TenantInfo { Id = "abc", Identifier = "abc", Name = "abc" };
+
+            using var db = new TestDbContext(tenant, _options);
+            db.Database.EnsureDeleted();
+            db.Database.EnsureCreated();
+            db.TenantNotSetMode = TenantNotSetMode.Throw;
+            db.EnforceMultiTenantOnTracking();
+
+            var blog = new Blog { Title = "attached" };
+            db.Attach(blog);
+
+            Assert.Equal(tenant.Id, db.Entry(blog).Property("TenantId").CurrentValue);
+        }
+        finally
+        {
+            _connection.Close();
+        }
+    }
+
+    [Fact]
+    public void SetTenantIdWhenAddingEntity()
+    {
+        try
+        {
+            _connection.Open();
+            var tenant = new TenantInfo { Id = "abc", Identifier = "abc", Name = "abc" };
+
+            using var db = new TestDbContext(tenant, _options);
+            db.Database.EnsureDeleted();
+            db.Database.EnsureCreated();
+            db.TenantNotSetMode = TenantNotSetMode.Throw;
+            db.EnforceMultiTenantOnTracking();
+
+            var blog = new Blog { Title = "state-change" };
+            db.Add(blog);
+
+            Assert.Equal(tenant.Id, db.Entry(blog).Property("TenantId").CurrentValue);
+        }
+        finally
+        {
+            _connection.Close();
+        }
+    }
+
 }


### PR DESCRIPTION
This pull request improves the reliability of multi-tenant enforcement in Entity Framework Core contexts by ensuring that the tracking event handler for setting the `TenantId` property is registered only once per `DbContext` instance. It also introduces new tests to validate this behavior and confirm correct tenant assignment when entities are attached or added.

Enhancements to event handler registration:

* Added a `ConditionalWeakTable` and locking mechanism in `MultiTenantDbContextExtensions` to ensure the tracking event handler is registered only once per `DbContext`, preventing duplicate handler registrations when `EnforceMultiTenantOnTracking` is called multiple times. [[1]](diffhunk://#diff-945b0e21ee2480c4ace7e0e04a3c1abe39fe5443666dfb936637fe20783afb1eR4) [[2]](diffhunk://#diff-945b0e21ee2480c4ace7e0e04a3c1abe39fe5443666dfb936637fe20783afb1eR15-R17) [[3]](diffhunk://#diff-945b0e21ee2480c4ace7e0e04a3c1abe39fe5443666dfb936637fe20783afb1eR26-R47)

Testing improvements:

* Added a test to verify that calling `EnforceMultiTenantOnTracking` twice results in only one tracking handler being registered.
* Added tests to ensure that the `TenantId` property is correctly set when an entity is attached or added, especially when `TenantNotSetMode` is set to `Throw`.