### PR TITLE
chore: update .NET dependencies management workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "nuget"
-    directories:
-      - "/src/Finbuckle.MultiTenant"
-      - "/src/Finbuckle.MultiTenant.Abstractions"
-      - "/src/Finbuckle.MultiTenant.AspNetCore"
-      - "/src/Finbuckle.MultiTenant.EntityFrameworkCore"
-      - "/src/Finbuckle.MultiTenant.Identity.EntityFrameworkCore"
-      - "/test/Finbuckle.MultiTenant.Test"
-      - "/test/Finbuckle.MultiTenant.AspNetCore.Test"
-      - "/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test"
-      - "/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "Microsoft.*"
-        update-types: [ "version-update:semver-major" ]
-    commit-message:
-      prefix: "fix"
-      include: "scope"
-    groups:
-      "microsoft-packages":
-        patterns:
-          - "Microsoft.*"
-  
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot-clone-legacy.yml
+++ b/.github/workflows/dependabot-clone-legacy.yml
@@ -3,7 +3,7 @@ name: Dependabot Clone Legacy
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 20 * * *' # 8 PM UTC (2 PM MDT / 1 PM MST)
+    - cron: '0 20 * * *'
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-clone-legacy.yml
+++ b/.github/workflows/dependabot-clone-legacy.yml
@@ -3,7 +3,7 @@ name: Dependabot Clone Legacy
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 14 * * *'
+    - cron: '0 20 * * *' # 2 PM Mountain Time (MDT)
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-clone-legacy.yml
+++ b/.github/workflows/dependabot-clone-legacy.yml
@@ -3,7 +3,7 @@ name: Dependabot Clone Legacy
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 20 * * *' # 2 PM Mountain Time (MDT)
+    - cron: '0 20 * * *' # 2 PM Mountain Time during daylight saving
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-clone-legacy.yml
+++ b/.github/workflows/dependabot-clone-legacy.yml
@@ -3,7 +3,7 @@ name: Dependabot Clone Legacy
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 20 * * *' # 2 PM Mountain Time during daylight saving
+    - cron: '0 20 * * *' # 2 PM Mountain Daylight Time / 1 PM Mountain Standard Time
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-clone-legacy.yml
+++ b/.github/workflows/dependabot-clone-legacy.yml
@@ -3,7 +3,7 @@ name: Dependabot Clone Legacy
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 14 * * *'
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-clone-legacy.yml
+++ b/.github/workflows/dependabot-clone-legacy.yml
@@ -3,7 +3,7 @@ name: Dependabot Clone Legacy
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 20 * * *' # 2 PM Mountain Daylight Time / 1 PM Mountain Standard Time
+    - cron: '0 20 * * *' # 8 PM UTC (2 PM MDT / 1 PM MST)
 
 permissions:
   contents: write

--- a/.github/workflows/update-dotnet-dependencies.yml
+++ b/.github/workflows/update-dotnet-dependencies.yml
@@ -2,7 +2,7 @@ name: Update .NET Dependencies
 
 on:
   schedule:
-    - cron: '0 20 * * *' # 2 PM Mountain Time during daylight saving
+    - cron: '0 20 * * *' # 2 PM Mountain Daylight Time / 1 PM Mountain Standard Time
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-dotnet-dependencies.yml
+++ b/.github/workflows/update-dotnet-dependencies.yml
@@ -2,7 +2,7 @@ name: Update .NET Dependencies
 
 on:
   schedule:
-    - cron: '0 14 * * *'
+    - cron: '0 20 * * *' # 2 PM Mountain Time (MDT)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-dotnet-dependencies.yml
+++ b/.github/workflows/update-dotnet-dependencies.yml
@@ -2,7 +2,7 @@ name: Update .NET Dependencies
 
 on:
   schedule:
-    - cron: '0 20 * * *' # 8 PM UTC (2 PM MDT / 1 PM MST)
+    - cron: '0 20 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-dotnet-dependencies.yml
+++ b/.github/workflows/update-dotnet-dependencies.yml
@@ -2,7 +2,7 @@ name: Update .NET Dependencies
 
 on:
   schedule:
-    - cron: '0 20 * * *' # 2 PM Mountain Daylight Time / 1 PM Mountain Standard Time
+    - cron: '0 20 * * *' # 8 PM UTC (2 PM MDT / 1 PM MST)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-dotnet-dependencies.yml
+++ b/.github/workflows/update-dotnet-dependencies.yml
@@ -1,0 +1,69 @@
+name: Update .NET Dependencies
+
+on:
+  schedule:
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.2.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: 10
+
+      - name: Install dotnet-outdated
+        run: dotnet tool install --global dotnet-outdated-tool
+
+      - name: Update dependencies
+        run: dotnet outdated --upgrade Finbuckle.MultiTenant.slnx
+
+      - name: Regenerate lock files
+        run: dotnet restore --force-evaluate
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push branch
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B update-dotnet-dependencies
+          git add -A
+          git commit -m "fix: update .NET dependencies"
+          git push --force origin update-dotnet-dependencies
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create PR only if one doesn't already exist for this branch
+          EXISTING=$(gh pr list --head update-dotnet-dependencies --json number --jq length)
+          if [ "$EXISTING" -eq 0 ]; then
+            gh pr create \
+              --title "fix: update .NET dependencies" \
+              --body "Automated dependency update using [dotnet-outdated](https://github.com/dotnet-outdated/dotnet-outdated).
+
+          Please review the changes and ensure CI passes before merging." \
+              --label dependencies \
+              --base main \
+              --head update-dotnet-dependencies
+          fi
+

--- a/.github/workflows/update-dotnet-dependencies.yml
+++ b/.github/workflows/update-dotnet-dependencies.yml
@@ -2,7 +2,7 @@ name: Update .NET Dependencies
 
 on:
   schedule:
-    - cron: '0 20 * * *' # 2 PM Mountain Time (MDT)
+    - cron: '0 20 * * *' # 2 PM Mountain Time during daylight saving
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates how .NET dependencies are managed and automated in the repository. It removes the previous NuGet configuration from Dependabot and introduces a new GitHub Actions workflow to handle .NET dependency updates, making the process more robust and maintainable. Additionally, it adjusts the schedule for dependency update workflows.

Key changes:

**Dependency management improvements:**

* Removed the NuGet dependency update configuration from `.github/dependabot.yml`, so Dependabot will no longer manage .NET/NuGet dependencies directly.
* Added a new workflow `.github/workflows/update-dotnet-dependencies.yml` that uses `dotnet-outdated` to automatically check for and upgrade .NET dependencies, commit changes, and open a pull request if updates are found.

**Workflow scheduling updates:**

* Changed the scheduled time for the legacy Dependabot workflow in `.github/workflows/dependabot-clone-legacy.yml` from 1:00 AM UTC to 8:00 PM UTC.
* The new `.NET Dependencies` workflow is also scheduled to run daily at 8:00 PM UTC.