### PR TITLE
Fix documentation inconsistencies across README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ MultiTenant is designed to be easy to use and follows standard .NET conventions 
 
 ## Documentation
 
-The library builds on on basic multi-tenant functionality to provide a variety of higher level features. See
+The library builds on basic multi-tenant functionality to provide a variety of higher level features. See
 the [documentation](https://www.finbuckle.com/multitenant/docs) for more details:
 
 * [Per-tenant Options](https://www.finbuckle.com/MultiTenant/Docs/Options)
@@ -112,7 +112,6 @@ From the command line clone the git repository, `cd` into the new directory, and
 
 ```bash
 git clone https://github.com/Finbuckle/Finbuckle.MultiTenant.git
-cd Finbuckle.MultiTenant
 cd Finbuckle.MultiTenant
 dotnet build
 ```

--- a/docs/ConfigurationAndUsage.md
+++ b/docs/ConfigurationAndUsage.md
@@ -39,8 +39,8 @@ chaining method calls.
 
 ### WithStore Variants
 
-Adds and configures an `IMultiTenantStore` for your app. Multiple stores can be configured and each will be used
-in the order registered.
+Adds and configures an `IMultiTenantStore` for your app. Multiple stores can be configured, and they will be consulted
+in the order registered until a tenant is resolved.
 See [MultiTenant Stores](Stores) for more information on each type.
 
 - `WithStore<TStore>`

--- a/docs/ConfigurationAndUsage.md
+++ b/docs/ConfigurationAndUsage.md
@@ -39,7 +39,8 @@ chaining method calls.
 
 ### WithStore Variants
 
-Adds and configures an `IMultiTenantStore` for your app. Only the last store configured will be used.
+Adds and configures an `IMultiTenantStore` for your app. Multiple stores can be configured and each will be used
+in the order registered.
 See [MultiTenant Stores](Stores) for more information on each type.
 
 - `WithStore<TStore>`

--- a/docs/CoreConcepts.md
+++ b/docs/CoreConcepts.md
@@ -29,7 +29,8 @@ when needed via the tenant `Id`.
 
 The `MultiTenantContext<TTenantInfo>` contains information about the current tenant.
 
-* Implements `IMultiTenantContext` and `IMultiTenantContext<TTenantInfo>` which can be obtained from dependency injection.
+* Implements `IMultiTenantContext` and `IMultiTenantContext<TTenantInfo>` and can be accessed through
+  `IMultiTenantContextAccessor` from dependency injection.
 * Includes `TenantInfo`, `StrategyInfo`, and `StoreInfo` properties with details on the current tenant, how it was
   determined, and from where its information was retrieved.
 * The `IsResolved` property indicates whether a tenant was successfully resolved for the current context.
@@ -55,8 +56,8 @@ Responsible for returning a `TenantInfo` object based on a tenant string identif
 strategy).
 
 * Has methods for adding, removing, updating, and retrieving `TenantInfo` objects.
-* Two implementations are provided: a basic `InMemoryTenantStore` based on `ConcurrentDictionary<string, TenantInfo>`
-  and a more advanced Entity Framework Core based implementation.
+* Several implementations are provided, including in-memory, configuration, EF Core, distributed cache, HTTP remote,
+  and echo stores. See [MultiTenant Stores](Stores) for more information.
 * Custom stores implementing `IMultiTenantStore` can be used as well.
 
 ## MultiTenantException

--- a/docs/EFCore.md
+++ b/docs/EFCore.md
@@ -196,7 +196,7 @@ in the EF Core documentation for more details.
 This approach is more flexible than deriving from `MultiTenantDbContext`, but needs more configuration. It requires
 implementing `IMultiTenantDbContext` and following a strict convention of helper method calls.
 
-Start by adding the `MultiTenant.EntityFrameworkCore` package to the project:
+Start by adding the `Finbuckle.MultiTenant.EntityFrameworkCore` package to the project:
 
 ```{.bash}
 dotnet add package Finbuckle.MultiTenant.EntityFrameworkCore
@@ -270,7 +270,7 @@ already have a base class. `MultiTenantDbContext` is a pre-configured implementa
 helper methods as described above in
 [Adding MultiTenant Functionality to an Existing DbContext](#adding-multitenant-functionality-to-an-existing-dbcontext)
 
-Start by adding the `MultiTenant.EntityFrameworkCore` package to the project:
+Start by adding the `Finbuckle.MultiTenant.EntityFrameworkCore` package to the project:
 
 ```{.bash}
 dotnet add package Finbuckle.MultiTenant.EntityFrameworkCore
@@ -309,7 +309,7 @@ Now whenever this database context is used it will only set and query records fo
 It is recommended that the tenant associated with an instance of your DbContext is set at the time of creation and is 
 immutable. MultiTenant is designed with this in mind and `IMultiTenantDbContext` only has a getter for 
 the `TenantInfo` property. It is possible to define a setter on your own `IMultiTenantDbContext` implementation but 
-doing so will make it difficult ensure data isolation and consistency.
+doing so will make it difficult to ensure data isolation and consistency.
 
 ## Dependency Injection Instantiation
 
@@ -335,7 +335,7 @@ var tenantInfo = new MyTenantInfo { Id = "id", Identifier = "identifier" };
 // create a database context instance for the tenant
 var tenantDbContext = MultiTenantDbContext.Create<AppMultiTenantDbContext, AppTenantInfo>(tenantInfo);
 
-// create a database context instance for the tenant with an instance of DbOptions<AppMultiTenantDbContext>
+// create a database context instance for the tenant with an instance of DbContextOptions<AppMultiTenantDbContext>
 var tenantDbContextWithOptions = MultiTenantDbContext.Create<AppMultiTenantDbContext, AppTenantInfo>(tenantInfo, 
 dbOptions);
 
@@ -344,11 +344,11 @@ dbOptions);
 var tenantDbContextWithOptions = MultiTenantDbContext.Create<AppMultiTenantDbContext, AppTenantInfo>(tenantInfo, 
 dep1, dep2, dep3);
 
-// create a database context instance for the tenant with an instance from pulled from a given service provider
+// create a database context instance for the tenant with an instance pulled from a given service provider
 var tenantDbContextWithOptions = MultiTenantDbContext.Create<AppMultiTenantDbContext, AppTenantInfo>(tenantInfo, 
 serviceProvider);
 
-// create a database context instance for the tenant with an instance from pulled from a given service provider
+// create a database context instance for the tenant with an instance pulled from a given service provider
 // and provided explicitly via params object[]
 var tenantDbContextWithOptions = MultiTenantDbContext.Create<AppMultiTenantDbContext, AppTenantInfo>(tenantInfo, 
 serviceProvider, dep1, dep2, dep3);
@@ -379,7 +379,7 @@ as described above.
 
 Added entities are automatically associated with the current `TenantInfo`. If an entity is associated with a different
 `TenantInfo` then a `MultiTenantException` is thrown in `SaveChanges` or `SaveChangesAsync`. This behavior can be
-altered by changing the values of [TenantMisMatchMode](#tenant-mismatch-mode) and
+altered by changing the values of [TenantMismatchMode](#tenant-mismatch-mode) and
 [TenantNotSetMode](#tenant-not-set-mode) on the `IMultiTenantDbContext`.
 
 > EF Core will require a non-null value when adding an entity that has `TenantId` as a part of the primary key.
@@ -405,7 +405,7 @@ await yourDbContext.SaveChangesAsync(); // Throws MultiTenantException.
 
 ## Querying Data
 
-EF Core Queries will only return results associated to the `TenantInfo`.
+EF Core queries will only return results associated with the `TenantInfo`.
 
 ```csharp
 // Will only return "My Blog".
@@ -420,7 +420,7 @@ var yourBlogs = yourDbContext.Blogs.First();
 ```
 > The global query filter is applied only at the root level of a query. Any entity classes loaded via `Include` or
 > `ThenInclude` are not filtered, but if all entity classes involved in a query have the `[MultiTenant]` attribute
-> then all results are associated to the same tenant. See [global query filter limitations](https://learn.microsoft.com/en-us/ef/core/querying/filters#limitations)
+> then all results are associated with the same tenant. See [global query filter limitations](https://learn.microsoft.com/en-us/ef/core/querying/filters#limitations)
 > in the EF Core documentation for more details.
 
 ## Query Without the Tenant Filter
@@ -440,7 +440,7 @@ var tenantBlogs = db.Blogs.IgnoreQueryFilters(Abstractions.Constants.TenantToken
 
 Updated or deleted entities are checked to make sure they are associated with the `TenantInfo`. If an entity is
 associated with a different `TenantInfo` then a `MultiTenantException` is thrown in `SaveChanges` or `SaveChangesAsync`.
-This behavior can be altered by changing the values of [TenantMisMatchMode](#tenant-mismatch-mode) and 
+This behavior can be altered by changing the values of [TenantMismatchMode](#tenant-mismatch-mode) and
 [TenantNotSetMode](#tenant-not-set-mode) on the `IMultiTenantDbContext`.
 
 ```csharp
@@ -475,7 +475,7 @@ methods for this purpose:
 
 * `AdjustKey(IMutableKey, ModelBuilder)` - Alters the existing defined key to add the implicit `TenantId`. Note that
   this will also impact entities with a dependent foreign key and may add an implicit `TenantId` there as well. 
-  This will also require the use of `EnforceMultiTenantOnTracking` as described below in [EFCore Tracking](#efcore-tracking).
+  This will also require the use of `EnforceMultiTenantOnTracking` as described below in [EF Core Tracking](#ef-core-tracking).
 ```csharp
 protected override void OnModelCreating(ModelBuilder builder)
 {
@@ -490,7 +490,7 @@ protected override void OnModelCreating(ModelBuilder builder)
 
 ## EF Core Tracking
 
-When attaching an entity to tracking in EFCore using either `Add` or `Attach`, all primary keys are required 
+When attaching an entity to tracking in EF Core using either `Add` or `Attach`, all primary keys are required
 to be non-null. MultiTenant will ensure a `TenantId` is assigned if you call the 
 `EnforceMultiTenantOnTracking` extension method of `IMultiTenantDbContext` on your db context. If no `TenantId` is 
 initially set then the current `TenantId` of the db context will be used. This applies to both explicit `TenantId` 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -38,7 +38,7 @@ Additional support is provided by the following organizations:
 
 ## License
 
-This project uses the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0). See [LICENSE](LICENSE) file for
+This project uses the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0). See [LICENSE](../LICENSE) file for
 license information.
 
 ## .NET Foundation
@@ -49,7 +49,7 @@ This project is supported by the [.NET Foundation](https://dotnetfoundation.org)
 
 This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our
 community. For more information see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct)
-or the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+or the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
 
 ## Community
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,6 +1,6 @@
 # Per-Tenant Options
 
-> Add the `Finbuckle.MultiTenant.Options` package to your project to use this functionality.
+> This functionality is included in the `Finbuckle.MultiTenant` package.
 
 MultiTenant is designed to emphasize using per-tenant options in your app to drive per-tenant behavior. This
 approach allows your app logic to be written without having to add tenant-dependent or tenant-specific logic directly to the code.
@@ -39,7 +39,7 @@ correct values for the current tenant are used.
 
 ## Options Basics
 
-Consider a typical scenario in ASP.Net Core, starting with a simple class:
+Consider a typical scenario in ASP.NET Core, starting with a simple class:
 
 ```csharp
 public class MyOptions
@@ -88,15 +88,14 @@ This section assumes a standard web application builder is configured and MultiT
 a `TTenantInfo` type of `TenantInfo`.
 See [Getting Started](GettingStarted) for details.
 
-Make sure to add the `Finbuckle.MultiTenant.Options` package to your project.
+Make sure your project references the `Finbuckle.MultiTenant` package.
 
 To configure options per tenant, the standard `Configure` method variants on the service collection now all
 have `PerTenant` equivalents which accept a `Action<TOptions, TTenantInfo>` delegate. When the options are created at
 runtime the delegate will be called with the current tenant details.
 
 ```csharp
-using Finbuckle.MultiTenant.Options.OptionsBuilderExtensions;
-using Finbuckle.MultiTenant.Options.ServiceCollectionExtensions;
+using Finbuckle.MultiTenant.Extensions;
 
 // configure options per tenant
 builder.Services.ConfigurePerTenant<MyOptions, TenantInfo>((options, tenantInfo) =>

--- a/docs/Strategies.md
+++ b/docs/Strategies.md
@@ -156,7 +156,7 @@ builder.Services.AddMultiTenant<TenantInfo>()
     })...
 ```
 
-> ⚠️ **Important**: When using the `PathBase` is adjusted, be aware of the following implications:
+> ⚠️ **Important**: When the `PathBase` is adjusted, be aware of the following implications:
 > 
 > - **Relative URLs**: Any relative URLs in your app (e.g. links, form actions) will be affected by the adjusted `PathBase`.
 > - **Tilde slash (`~/`) URLs**: ASP.NET Core's `~/` path resolution uses the `PathBase`, so `~/images/logo.png` will 
@@ -228,7 +228,7 @@ Uses the `__tenant__` route parameter (or a specified route parameter) to determ
 to "https://www.example.com/initech/home/" and a route configuration of `{__tenant__}/{controller=Home}/{action=Index}`
 would use "initech" as the identifier when resolving the tenant. The tenant parameter can be placed anywhere in
 the route path configuration. If explicitly calling `UseRouting` in your app pipeline make sure to place it
-before `WithRouteStrategy`.
+before `UseMultiTenant`.
 
 By default the route parameter name is `__tenant__`, but a custom name can also be used via an overload. Also by
 default the strategy adds the tenant route value as an ambient value when generating links. This behavior can
@@ -246,7 +246,7 @@ builder.Services.AddMultiTenant<TenantInfo>()
 builder.Services.AddMultiTenant<TenantInfo>()
   .WithRouteStrategy("MyTenantRouteParam", false)...
 
-// UseRouting is optional in ASP.NET Core, but if needed place before UseMultiTenant when the route strategy used
+// UseRouting is optional in ASP.NET Core, but if needed place before UseMultiTenant when the route strategy is used
 app.UseRouting();
 app.UseMultiTenant();
 ```
@@ -311,7 +311,7 @@ builder.Services.AddMultiTenant<TenantInfo>()
 Uses an HTTP request header to determine the tenant identifier. By default, the header with key `__tenant__` is used,
 but a custom key can also be used.
 
-Configure by calling `WithHeaderStrategy` after `AddMultiTenant<TTenantInfo>`. An overload to accept a custom claim type
+Configure by calling `WithHeaderStrategy` after `AddMultiTenant<TTenantInfo>`. An overload to accept a custom header key
 is also available:
 
 ```csharp

--- a/samples/README.md
+++ b/samples/README.md
@@ -14,7 +14,7 @@ A minimal multi-tenant Web API demonstrating the base path strategy and in-memor
 - Custom tenant properties
 - Localized content per tenant
 
-### [Identity Sample App](IdentitySampleApp/)
+### [Identity Sample App](IdentityAppSample/)
 
 An ASP.NET Core MVC application with ASP.NET Core Identity integration showing per-tenant authentication and user management. Each tenant maintains isolated users in separate database contexts.
 


### PR DESCRIPTION
## Summary
- Corrected multiple documentation typos and broken references across the README and docs
- Updated package names, path references, and wording for tenant stores, EF Core, options, and strategies
- Fixed sample README link text and normalized file endings

## Testing
- Not run (not requested)