### PR TITLE
Fix per-tenant options registration and caching behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       matrix:
         dotnet: ['10.0']
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,7 @@ jobs:
       - name: test Finbuckle.MultiTenant.EntityFrameworkCore
         run: dotnet test --no-build -v q -f net${{ matrix.dotnet }}
         working-directory: ./test/Finbuckle.MultiTenant.EntityFrameworkCore.Test
+      - name: test Finbuckle.MultiTenant.Identity.EntityFrameworkCore
+        run: dotnet test --no-build -v q -f net${{ matrix.dotnet }}
+        working-directory: ./test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ permissions:
 
 jobs:
   build-and-test:
-    strategy:
-      matrix:
-        dotnet: ['10.0']
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
@@ -23,15 +20,15 @@ jobs:
       - name: build
         run: dotnet build -p:ContinuousIntegrationBuild=true
       - name: test Finbuckle.MultiTenant
-        run: dotnet test --no-build -v q -f net${{ matrix.dotnet }}
+        run: dotnet test --no-build -v q
         working-directory: ./test/Finbuckle.MultiTenant.Test
       - name: test Finbuckle.MultiTenant.AspNetCore
-        run: dotnet test --no-build -v q -f net${{ matrix.dotnet }}
+        run: dotnet test --no-build -v q
         working-directory: ./test/Finbuckle.MultiTenant.AspNetCore.Test
       - name: test Finbuckle.MultiTenant.EntityFrameworkCore
-        run: dotnet test --no-build -v q -f net${{ matrix.dotnet }}
+        run: dotnet test --no-build -v q
         working-directory: ./test/Finbuckle.MultiTenant.EntityFrameworkCore.Test
       - name: test Finbuckle.MultiTenant.Identity.EntityFrameworkCore
-        run: dotnet test --no-build -v q -f net${{ matrix.dotnet }}
+        run: dotnet test --no-build -v q
         working-directory: ./test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test
         

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -30,12 +30,15 @@ jobs:
           DELIMITER=$(openssl rand -hex 16)
           {
             echo "report<<${DELIMITER}"
-            dotnet outdated --upgrade --version-lock Major Finbuckle.MultiTenant.slnx || true
+            find src -name '*.csproj' -print0 |
+              while IFS= read -r -d '' project; do
+                dotnet outdated --upgrade --version-lock Major "$project" || true
+              done
             echo "${DELIMITER}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Regenerate lock files
-        run: dotnet restore --force-evaluate
+        run: find src -name '*.csproj' -print0 | xargs -0 -n1 dotnet restore --force-evaluate
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -30,10 +30,9 @@ jobs:
           DELIMITER=$(openssl rand -hex 16)
           {
             echo "report<<${DELIMITER}"
-            find src -name '*.csproj' -print0 |
-              while IFS= read -r -d '' project; do
-                dotnet outdated --upgrade --version-lock Major "$project" || true
-              done
+            dotnet outdated --upgrade --version-lock Major --recursive "$GITHUB_WORKSPACE/src" || true
+            dotnet outdated --upgrade --version-lock Major --recursive "$GITHUB_WORKSPACE/samples" || true
+            dotnet outdated --upgrade --version-lock Major --recursive "$GITHUB_WORKSPACE/test" || true
             echo "${DELIMITER}"
           } >> "$GITHUB_OUTPUT"
 
@@ -43,7 +42,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet; then
+          if git diff --quiet -- src samples test; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -59,13 +58,24 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           BRANCH="fix/update-dependencies-${{ github.run_id }}"
           git checkout -b "$BRANCH"
-          git add -A
-          git commit -m "fix(deps): update dependencies"
+          PR_TITLE=""
+          if ! git diff --quiet -- src; then
+            git add src
+            git commit -m "fix(deps): update source dependencies"
+            PR_TITLE="fix(deps): update dependencies"
+          fi
+          if ! git diff --quiet -- samples test; then
+            git add samples test
+            git commit -m "chore(deps): update sample and test dependencies"
+            if [ -z "$PR_TITLE" ]; then
+              PR_TITLE="chore(deps): update sample and test dependencies"
+            fi
+          fi
           git push origin "$BRANCH"
           BODY_FILE=$(mktemp)
           printf 'Automated dependency updates from `update-dependencies` workflow.\n\n<details>\n<summary>dotnet-outdated report</summary>\n\n```\n%s\n```\n\n</details>' "$UPDATE_REPORT" > "$BODY_FILE"
           gh pr create \
             --base main \
             --head "$BRANCH" \
-            --title "fix(deps): update dependencies" \
+            --title "$PR_TITLE" \
             --body-file "$BODY_FILE"

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -176,8 +176,8 @@ Internally .NET caches options, and MultiTenant extends this to cache options pe
 occurs when a `TOptions` instance is retrieved via `Value` or `Get` on the injected `IOptions<TOptions>` (or derived)
 instance for the first time for a tenant.
 
-`IOptions<TOptions>` instances are always regenerated when injected so any caching only lasts as long as the specific
-instance.
+`IOptions<TOptions>` is registered as a singleton. Its per-tenant cache can therefore persist for the lifetime of the
+application service provider.
 
 `IOptionsSnapshot<TOptions>` instances are generated once per HTTP request and caching will last throughout the entire
 request.
@@ -197,3 +197,15 @@ a `Clear()` method that will clear the cache for the current tenant. Casting the
 instance to `MultiTenantOptionsCache<TOptions>` exposes the `Clear(string tenantId)` and `ClearAll()`
 methods. `Clear(string tenantId)` clears cached options for a specific tenant (or the regular non per-tenant options if
 the parameter is empty or null). `ClearAll()` clears all cached options (including regular non per-tenant options).
+
+When an `IOptionsMonitor<TOptions>` change token fires, the named option associated with that token is removed from
+the cache for every tenant and for the regular non per-tenant context. Other named options remain cached. The changed
+option is recreated for each tenant when it is next accessed. An `OnChange` callback is a notification that the named
+option was invalidated globally; the options value supplied to the callback is created using the ambient tenant context
+of the change-token callback (often no tenant) and does not represent the value for every tenant.
+
+Enabling per-tenant options for a `TOptions` type replaces any exact closed registrations for
+`IOptionsMonitorCache<TOptions>`, `IOptions<TOptions>`, and `IOptionsSnapshot<TOptions>` with the Finbuckle
+implementations required for tenant isolation. The standard open generic registrations remain available for other
+options types. Registering a custom exact closed implementation after configuring per-tenant options is unsupported and
+may disable tenant isolation.

--- a/src/Finbuckle.MultiTenant/Extensions/OptionsBuilderExtensions.cs
+++ b/src/Finbuckle.MultiTenant/Extensions/OptionsBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class OptionsBuilderExtensions
         where TOptions : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);
@@ -61,6 +62,7 @@ public static class OptionsBuilderExtensions
         where TDep : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);
@@ -97,6 +99,7 @@ public static class OptionsBuilderExtensions
         where TDep2 : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);
@@ -137,6 +140,7 @@ public static class OptionsBuilderExtensions
         where TDep3 : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);
@@ -180,6 +184,7 @@ public static class OptionsBuilderExtensions
         where TDep4 : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);
@@ -252,6 +257,7 @@ public static class OptionsBuilderExtensions
         where TOptions : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);
@@ -285,6 +291,7 @@ public static class OptionsBuilderExtensions
         where TDep : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);
@@ -321,6 +328,7 @@ public static class OptionsBuilderExtensions
         where TDep2 : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);
@@ -361,6 +369,7 @@ public static class OptionsBuilderExtensions
         where TDep3 : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);
@@ -404,6 +413,7 @@ public static class OptionsBuilderExtensions
         where TDep4 : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(optionsBuilder);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         ServiceCollectionExtensions.ConfigurePerTenantReqs<TOptions>(optionsBuilder.Services);

--- a/src/Finbuckle.MultiTenant/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Finbuckle.MultiTenant/Extensions/ServiceCollectionExtensions.cs
@@ -158,6 +158,9 @@ public static class ServiceCollectionExtensions
         where TOptions : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         ConfigurePerTenantReqs<TOptions>(services);
 
         services.AddTransient<IConfigureOptions<TOptions>>(sp =>
@@ -223,6 +226,9 @@ public static class ServiceCollectionExtensions
         where TOptions : class
         where TTenantInfo : ITenantInfo
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         ConfigurePerTenantReqs<TOptions>(services);
 
         services.AddTransient<IPostConfigureOptions<TOptions>>(sp =>
@@ -286,10 +292,14 @@ public static class ServiceCollectionExtensions
         // Required infrastructure.
         services.AddOptions();
 
-        // TODO: Add check for success
-        services.TryAddSingleton<IOptionsMonitorCache<TOptions>, MultiTenantOptionsCache<TOptions>>();
-        services.TryAddScoped<IOptionsSnapshot<TOptions>>(BuildOptionsManager);
-        services.TryAddSingleton<IOptions<TOptions>>(BuildOptionsManager);
+        // Per-tenant options require these closed registrations. Leave the standard open generic
+        // registrations in place for all other options types.
+        services.RemoveAll<IOptionsMonitorCache<TOptions>>();
+        services.RemoveAll<IOptionsSnapshot<TOptions>>();
+        services.RemoveAll<IOptions<TOptions>>();
+        services.AddSingleton<IOptionsMonitorCache<TOptions>, MultiTenantOptionsCache<TOptions>>();
+        services.AddScoped<IOptionsSnapshot<TOptions>>(BuildOptionsManager);
+        services.AddSingleton<IOptions<TOptions>>(BuildOptionsManager);
         return;
 
         MultiTenantOptionsManager<TOptions> BuildOptionsManager(IServiceProvider sp)

--- a/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsCache.cs
+++ b/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsCache.cs
@@ -79,6 +79,7 @@ public class MultiTenantOptionsCache<
     /// <returns>True if the options was added to the cache for the current tenant.</returns>
     public bool TryAdd(string? name, TOptions options)
     {
+        ArgumentNullException.ThrowIfNull(options);
         name ??= Microsoft.Extensions.Options.Options.DefaultName;
         var tenantId = multiTenantContextAccessor.MultiTenantContext?.TenantInfo?.Id ?? "";
         var cache = map.GetOrAdd(tenantId, static _ => new OptionsCache<TOptions>());

--- a/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsCache.cs
+++ b/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsCache.cs
@@ -2,6 +2,7 @@
 // Refer to the solution LICENSE file for more information.
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using Finbuckle.MultiTenant.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -10,12 +11,14 @@ namespace Finbuckle.MultiTenant.Options;
 /// <summary>
 /// Adds, retrieves, and removes instances of TOptions after adjusting them for the current TenantContext.
 /// </summary>
-public class MultiTenantOptionsCache<TOptions> : IOptionsMonitorCache<TOptions>
+public class MultiTenantOptionsCache<
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>
+    : IOptionsMonitorCache<TOptions>
     where TOptions : class
 {
     private readonly IMultiTenantContextAccessor multiTenantContextAccessor;
 
-    private readonly ConcurrentDictionary<string, IOptionsMonitorCache<TOptions>> map = new();
+    private readonly ConcurrentDictionary<string, OptionsCache<TOptions>> map = new();
 
     /// <summary>
     /// Constructs a new instance of MultiTenantOptionsCache.
@@ -34,30 +37,22 @@ public class MultiTenantOptionsCache<TOptions> : IOptionsMonitorCache<TOptions>
     public void Clear()
     {
         var tenantId = multiTenantContextAccessor.MultiTenantContext?.TenantInfo?.Id ?? "";
-        var cache = map.GetOrAdd(tenantId, new OptionsCache<TOptions>());
-
-        cache.Clear();
+        map.TryRemove(tenantId, out _);
     }
 
     /// <summary>
     /// Clears all cached options for the given tenant.
     /// </summary>
     /// <param name="tenantId">The Id of the tenant which will have its options cleared.</param>
-    public void Clear(string tenantId)
+    public void Clear(string? tenantId)
     {
-        var cache = map.GetOrAdd(tenantId, new OptionsCache<TOptions>());
-
-        cache.Clear();
+        map.TryRemove(tenantId ?? "", out _);
     }
 
     /// <summary>
     /// Clears all cached options for all tenants and no tenant.
     /// </summary>
-    public void ClearAll()
-    {
-        foreach (var cache in map.Values)
-            cache.Clear();
-    }
+    public void ClearAll() => map.Clear();
 
     /// <summary>
     /// Gets a named options instance for the current tenant, or adds a new instance created with createOptions.
@@ -71,7 +66,7 @@ public class MultiTenantOptionsCache<TOptions> : IOptionsMonitorCache<TOptions>
 
         name ??= Microsoft.Extensions.Options.Options.DefaultName;
         var tenantId = multiTenantContextAccessor.MultiTenantContext?.TenantInfo?.Id ?? "";
-        var cache = map.GetOrAdd(tenantId, new OptionsCache<TOptions>());
+        var cache = map.GetOrAdd(tenantId, static _ => new OptionsCache<TOptions>());
 
         return cache.GetOrAdd(name, createOptions);
     }
@@ -84,24 +79,28 @@ public class MultiTenantOptionsCache<TOptions> : IOptionsMonitorCache<TOptions>
     /// <returns>True if the options was added to the cache for the current tenant.</returns>
     public bool TryAdd(string? name, TOptions options)
     {
-        name = name ?? Microsoft.Extensions.Options.Options.DefaultName;
+        name ??= Microsoft.Extensions.Options.Options.DefaultName;
         var tenantId = multiTenantContextAccessor.MultiTenantContext?.TenantInfo?.Id ?? "";
-        var cache = map.GetOrAdd(tenantId, new OptionsCache<TOptions>());
+        var cache = map.GetOrAdd(tenantId, static _ => new OptionsCache<TOptions>());
 
         return cache.TryAdd(name, options);
     }
 
     /// <summary>
-    /// Try to remove an options instance for the current tenant.
+    /// Tries to remove a named options instance for all tenants and no tenant.
+    /// This supports change token invalidation from <see cref="IOptionsMonitor{TOptions}"/>,
+    /// which is not associated with a specific tenant.
     /// </summary>
     /// <param name="name">The options name.</param>
-    /// <returns>True if the options was removed from the cache for the current tenant.</returns>
+    /// <returns>True if the options was removed from at least one tenant cache.</returns>
     public bool TryRemove(string? name)
     {
-        name = name ?? Microsoft.Extensions.Options.Options.DefaultName;
-        var tenantId = multiTenantContextAccessor.MultiTenantContext?.TenantInfo?.Id ?? "";
-        var cache = map.GetOrAdd(tenantId, new OptionsCache<TOptions>());
+        name ??= Microsoft.Extensions.Options.Options.DefaultName;
+        var removed = false;
 
-        return cache.TryRemove(name);
+        foreach (var cache in map.Values)
+            removed |= cache.TryRemove(name);
+
+        return removed;
     }
 }

--- a/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsManager.cs
+++ b/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsManager.cs
@@ -4,6 +4,7 @@
 //    Portions of this file are derived from the .NET Foundation source file located at:
 //    https://github.com/aspnet/Options/blob/dev/src/Microsoft.Extensions.Options/OptionsManager.cs
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Options;
 
 namespace Finbuckle.MultiTenant.Options;
@@ -12,7 +13,9 @@ namespace Finbuckle.MultiTenant.Options;
 /// Implementation of <see cref="IOptions{TOptions}"/> and <see cref="IOptionsSnapshot{TOptions}"/> that uses dependency injection for its private cache.
 /// </summary>
 /// <typeparam name="TOptions">The type of options being configured.</typeparam>
-public class MultiTenantOptionsManager<TOptions> : IOptionsSnapshot<TOptions> where TOptions : class
+public class MultiTenantOptionsManager<
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>
+    : IOptionsSnapshot<TOptions> where TOptions : class
 {
     private readonly IOptionsFactory<TOptions> _factory;
     private readonly IOptionsMonitorCache<TOptions> _cache; // Note: this is a private cache

--- a/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsCacheShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsCacheShould.cs
@@ -1,12 +1,8 @@
 // Copyright Finbuckle LLC, Andrew White, and Contributors.
 // Refer to the solution LICENSE file for more information.
 
-using System.Collections.Concurrent;
-using System.ComponentModel.DataAnnotations;
-using System.Reflection;
 using Finbuckle.MultiTenant.Abstractions;
 using Finbuckle.MultiTenant.Options;
-using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Finbuckle.MultiTenant.Test.Options;
@@ -15,288 +11,253 @@ public class MultiTenantOptionsCacheShould
 {
     public class TestOptions
     {
-        [Required]
-        public string? DefaultConnectionString { get; set; }
+        public string? Value { get; init; }
     }
 
     [Theory]
     [InlineData("")]
     [InlineData(null)]
     [InlineData("name")]
-    public void AddNamedOptionsForCurrentTenantOnlyOnAdd(string? name)
+    public void CacheNamedOptionsForCurrentTenant(string? name)
     {
-        var ti = new TenantInfo { Id = "test-id-123", Identifier = "" };
-        var tc = new MultiTenantContext<TenantInfo>(ti);
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var tcs = (IMultiTenantContextSetter)tca;
-        tcs.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
+        var (cache, setter) = CreateCache();
+        SetTenant(setter, "tenant-1");
+        var tenant1 = new TestOptions();
 
-        var options = new TestOptions();
+        Assert.True(cache.TryAdd(name, tenant1));
+        Assert.False(cache.TryAdd(name, new TestOptions()));
 
-        // Add new options.
-        var result = cache.TryAdd(name, options);
-        Assert.True(result);
+        SetTenant(setter, "tenant-2");
+        var tenant2 = new TestOptions();
+        Assert.True(cache.TryAdd(name, tenant2));
+        Assert.Same(tenant2, cache.GetOrAdd(name, () => new TestOptions()));
 
-        // Fail adding options under same name.
-        result = cache.TryAdd(name, options);
-        Assert.False(result);
-
-        // Change the tenant id and confirm options can be added again.
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(new TenantInfo { Id = "diff", Identifier = "" });
-        result = cache.TryAdd(name, options);
-        Assert.True(result);
+        SetTenant(setter, "tenant-1");
+        Assert.Same(tenant1, cache.GetOrAdd(name, () => new TestOptions()));
     }
 
     [Fact]
-    public void HandleNullMultiTenantContextOnAdd()
+    public void CacheOptionsWithoutResolvedTenant()
     {
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
-
+        var (cache, _) = CreateCache();
         var options = new TestOptions();
 
-        // Add new options, ensure no exception caused by null MultiTenantContext.
-        var result = cache.TryAdd("", options);
-        Assert.True(result);
+        Assert.True(cache.TryAdd(null, options));
+        Assert.Same(options, cache.GetOrAdd(null, () => new TestOptions()));
     }
 
     [Fact]
-    public void HandleNullMultiTenantContextOnGetOrAdd()
+    public void ThrowForNullConstructorParameterFactoryAndOptions()
     {
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
+        var accessor = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
+        var cache = new MultiTenantOptionsCache<TestOptions>(accessor);
 
-        var options = new TestOptions();
-
-        // Add new options, ensure no exception caused by null MultiTenantContext.
-        var result = cache.GetOrAdd("", () => options);
-        Assert.NotNull(result);
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("name")]
-    public void GetOrAddNamedOptionForCurrentTenantOnly(string? name)
-    {
-        var ti = new TenantInfo { Id = "test-id-123", Identifier = "" };
-        var tc = new MultiTenantContext<TenantInfo>(ti);
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var tcs = (IMultiTenantContextSetter)tca;
-        tcs.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
-
-        var options = new TestOptions();
-        var options2 = new TestOptions();
-
-        // Add new options.
-        var result = cache.GetOrAdd(name, () => options);
-        Assert.Same(options, result);
-
-        // Get the existing options if exists.
-        result = cache.GetOrAdd(name, () => options2);
-        Assert.NotSame(options2, result);
-
-        // Confirm different tenant on same object is an add (ie it didn't exist there).
-        ti = new TenantInfo { Id = "diff_id", Identifier = ti.Identifier };
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
-        result = cache.GetOrAdd(name, () => options2);
-        Assert.Same(options2, result);
-    }
-
-    [Fact]
-    public void ThrowsIfGetOrAddFactoryIsNull()
-    {
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
-
-        Assert.Throws<ArgumentNullException>(() => cache.GetOrAdd("", null!));
-    }
-
-    [Fact]
-    public void ThrowIfConstructorParamIsNull()
-    {
         Assert.Throws<ArgumentNullException>(() => new MultiTenantOptionsCache<TestOptions>(null!));
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("name")]
-    public void RemoveNamedOptionsForCurrentTenantOnly(string? name)
-    {
-        var ti = new TenantInfo { Id = "test-id-123", Identifier = "" };
-        var tc = new MultiTenantContext<TenantInfo>(ti);
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var tcs = (IMultiTenantContextSetter)tca;
-        tcs.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
-
-        var options = new TestOptions();
-
-        // Add new options.
-        var result = cache.TryAdd(name, options);
-        Assert.True(result);
-
-        // Add under a different tenant.
-        ti = new TenantInfo { Id = "diff_id", Identifier = ti.Identifier };
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
-        result = cache.TryAdd(name, options);
-        Assert.True(result);
-        result = cache.TryAdd("diffName", options);
-        Assert.True(result);
-
-        // Remove named options for current tenant.
-        result = cache.TryRemove(name);
-        Assert.True(result);
-        var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType()
-            .GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(cache);
-
-        dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType()
-            .GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-
-        // Assert named options removed and other options on tenant left as-is.
-        Assert.False(tenantInternalCache!.Keys.Contains(name));
-        Assert.True(tenantInternalCache.Keys.Contains("diffName"));
-
-        // Assert other tenant not affected.
-        ti = new TenantInfo { Id = "test-id-123", Identifier = ti.Identifier };
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
-        tenantInternalCache = tenantCache?[ti.Id].GetType()
-            .GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.True(tenantInternalCache!.ContainsKey(name ?? Microsoft.Extensions.Options.Options.DefaultName));
+        Assert.Throws<ArgumentNullException>(() => cache.GetOrAdd("name", null!));
+        Assert.Throws<ArgumentNullException>(() => cache.TryAdd("name", null!));
     }
 
     [Fact]
     public void ClearOptionsForCurrentTenantOnly()
     {
-        var ti = new TenantInfo { Id = "test-id-123", Identifier = "" };
-        var tc = new MultiTenantContext<TenantInfo>(ti);
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var tcs = (IMultiTenantContextSetter)tca;
-        tcs.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
+        var (cache, setter) = CreateCache();
+        var tenant1 = Add(cache, setter, "tenant-1", "name");
+        var tenant2 = Add(cache, setter, "tenant-2", "name");
 
-        var options = new TestOptions();
-
-        // Add new options.
-        var result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Add under a different tenant.
-        ti = new TenantInfo { Id = "diff_id", Identifier = ti.Identifier };
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
-        result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Clear options on first tenant.
-        ti = new TenantInfo { Id = "test-id-123", Identifier = ti.Identifier };
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
+        SetTenant(setter, "tenant-1");
         cache.Clear();
 
-        // Assert options cleared on this tenant.
-        var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType()
-            .GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(cache);
-
-        dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType()
-            .GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.True(tenantInternalCache!.IsEmpty);
-
-        // Assert options still exist on other tenant.
-        ti = new TenantInfo { Id = "diff_id", Identifier = ti.Identifier };
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
-        tenantInternalCache = tenantCache?[ti.Id].GetType()
-            .GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.False(tenantInternalCache!.IsEmpty);
+        var replacement = new TestOptions();
+        Assert.Same(replacement, cache.GetOrAdd("name", () => replacement));
+        SetTenant(setter, "tenant-2");
+        Assert.Same(tenant2, cache.GetOrAdd("name", () => new TestOptions()));
+        Assert.NotSame(tenant1, replacement);
     }
 
     [Fact]
-    public void ClearOptionsForTenantIdOnly()
+    public void ClearOptionsForSpecifiedTenantOnly()
     {
-        var ti = new TenantInfo { Id = "test-id-123", Identifier = "" };
-        var tc = new MultiTenantContext<TenantInfo>(ti);
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var tcs = (IMultiTenantContextSetter)tca;
-        tcs.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
+        var (cache, setter) = CreateCache();
+        Add(cache, setter, "tenant-1", "name");
+        var tenant2 = Add(cache, setter, "tenant-2", "name");
 
-        var options = new TestOptions();
+        cache.Clear("tenant-1");
 
-        // Add new options.
-        var result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Add under a different tenant.
-        ti = new TenantInfo { Id = "diff_id", Identifier = ti.Identifier };
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
-        result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Clear options on first tenant.
-        cache.Clear("test-id-123");
-
-        // Assert options cleared on this tenant.
-        var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType()
-            .GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(cache);
-
-        dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType()
-            .GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache["test-id-123"]);
-        Assert.True(tenantInternalCache!.IsEmpty);
-
-        // Assert options still exist on other tenant.
-        tenantInternalCache = tenantCache?["diff_id"].GetType()
-            .GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache["diff_id"]);
-        Assert.False(tenantInternalCache!.IsEmpty);
+        SetTenant(setter, "tenant-1");
+        var replacement = new TestOptions();
+        Assert.Same(replacement, cache.GetOrAdd("name", () => replacement));
+        SetTenant(setter, "tenant-2");
+        Assert.Same(tenant2, cache.GetOrAdd("name", () => new TestOptions()));
     }
 
     [Fact]
-    public void ClearAllOptionsForClearAll()
+    public void TreatNullTenantIdAsNoTenantWhenClearing()
     {
-        var ti = new TenantInfo { Id = "test-id-123", Identifier = "" };
-        var tc = new MultiTenantContext<TenantInfo>(ti);
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var tcs = (IMultiTenantContextSetter)tca;
-        tcs.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
+        var (cache, _) = CreateCache();
+        var original = new TestOptions();
+        cache.TryAdd("name", original);
 
-        var options = new TestOptions();
+        cache.Clear(null);
 
-        // Add new options.
-        var result = cache.TryAdd("", options);
-        Assert.True(result);
+        var replacement = new TestOptions();
+        Assert.Same(replacement, cache.GetOrAdd("name", () => replacement));
+        Assert.NotSame(original, replacement);
+    }
 
-        // Add under a different tenant.
-        ti = new TenantInfo { Id = "diff_id", Identifier = ti.Identifier };
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
-        result = cache.TryAdd("", options);
-        Assert.True(result);
+    [Fact]
+    public void ClearAllOptionsForAllTenantsAndNames()
+    {
+        var (cache, setter) = CreateCache();
+        Add(cache, setter, "tenant-1", "name-1");
+        Add(cache, setter, "tenant-1", "name-2");
+        Add(cache, setter, "tenant-2", "name-1");
 
-        // Clear all options.
         cache.ClearAll();
 
-        // Assert options cleared on this tenant.
-        var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType()
-            .GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(cache);
-
-        ti = new TenantInfo { Id = "test-id-123", Identifier = ti.Identifier };
-        dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType()
-            .GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.True(tenantInternalCache!.IsEmpty);
-
-        // Assert options cleared on other tenant.
-        ti = new TenantInfo { Id = "diff_id", Identifier = ti.Identifier };
-        tcs.MultiTenantContext = new MultiTenantContext<TenantInfo>(ti);
-        tenantInternalCache = tenantCache?[ti.Id].GetType()
-            .GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.True(tenantInternalCache!.IsEmpty);
+        foreach (var tenantId in new[] { "tenant-1", "tenant-2" })
+        {
+            SetTenant(setter, tenantId);
+            var replacement = new TestOptions();
+            Assert.Same(replacement, cache.GetOrAdd("name-1", () => replacement));
+        }
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("target")]
+    public void RemoveNamedOptionsForAllTenantsButPreserveOtherNames(string? name)
+    {
+        var normalizedName = name ?? Microsoft.Extensions.Options.Options.DefaultName;
+        var (cache, setter) = CreateCache();
+        var originals = new Dictionary<string, TestOptions>();
+        var others = new Dictionary<string, TestOptions>();
+
+        foreach (var tenantId in new[] { "tenant-1", "tenant-2" })
+        {
+            originals[tenantId] = Add(cache, setter, tenantId, normalizedName);
+            others[tenantId] = Add(cache, setter, tenantId, "other");
+        }
+
+        SetNoTenant(setter);
+        var noTenantOriginal = new TestOptions();
+        var noTenantOther = new TestOptions();
+        cache.TryAdd(name, noTenantOriginal);
+        cache.TryAdd("other", noTenantOther);
+
+        Assert.True(cache.TryRemove(name));
+        Assert.False(cache.TryRemove(name));
+
+        foreach (var tenantId in new[] { "tenant-1", "tenant-2" })
+        {
+            SetTenant(setter, tenantId);
+            var replacement = new TestOptions();
+            Assert.Same(replacement, cache.GetOrAdd(name, () => replacement));
+            Assert.NotSame(originals[tenantId], replacement);
+            Assert.Same(others[tenantId], cache.GetOrAdd("other", () => new TestOptions()));
+        }
+
+        SetNoTenant(setter);
+        var noTenantReplacement = new TestOptions();
+        Assert.Same(noTenantReplacement, cache.GetOrAdd(name, () => noTenantReplacement));
+        Assert.NotSame(noTenantOriginal, noTenantReplacement);
+        Assert.Same(noTenantOther, cache.GetOrAdd("other", () => new TestOptions()));
+    }
+
+    [Fact]
+    public async Task InvokeFactoryOnceForConcurrentAccessToSameTenantAndName()
+    {
+        var (cache, setter) = CreateCache();
+        var factoryCalls = 0;
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 32).Select(_ => Task.Run(() =>
+        {
+            SetTenant(setter, "tenant-1");
+            return cache.GetOrAdd("name", () =>
+            {
+                Interlocked.Increment(ref factoryCalls);
+                Thread.Sleep(10);
+                return new TestOptions();
+            });
+        })));
+
+        Assert.Equal(1, factoryCalls);
+        Assert.All(results, result => Assert.Same(results[0], result));
+    }
+
+    [Fact]
+    public async Task IsolateParallelTenantContextsAndInvalidateNameAcrossThem()
+    {
+        var (cache, setter) = CreateCache();
+        var tenantIds = Enumerable.Range(1, 20).Select(i => $"tenant-{i}").ToArray();
+
+        var originals = await Task.WhenAll(tenantIds.Select(tenantId => Task.Run(() =>
+        {
+            SetTenant(setter, tenantId);
+            return cache.GetOrAdd("name", () => new TestOptions { Value = tenantId });
+        })));
+
+        Assert.Equal(tenantIds.Order(), originals.Select(o => o.Value).Order());
+        Assert.True(cache.TryRemove("name"));
+
+        var replacements = await Task.WhenAll(tenantIds.Select(tenantId => Task.Run(() =>
+        {
+            SetTenant(setter, tenantId);
+            return cache.GetOrAdd("name", () => new TestOptions { Value = $"new-{tenantId}" });
+        })));
+
+        Assert.All(replacements, replacement => Assert.StartsWith("new-tenant-", replacement.Value));
+    }
+
+    [Fact]
+    public async Task RebuildNameAfterInvalidationOverlapsCreation()
+    {
+        var (cache, setter) = CreateCache();
+        using var creationStarted = new ManualResetEventSlim();
+        using var releaseCreation = new ManualResetEventSlim();
+
+        var getTask = Task.Run(() =>
+        {
+            SetTenant(setter, "tenant-1");
+            return cache.GetOrAdd("name", () =>
+            {
+                creationStarted.Set();
+                releaseCreation.Wait();
+                return new TestOptions { Value = "old" };
+            });
+        });
+
+        Assert.True(creationStarted.Wait(TimeSpan.FromSeconds(5)));
+        var removeTask = Task.Run(() => cache.TryRemove("name"));
+
+        releaseCreation.Set();
+        Assert.Equal("old", (await getTask).Value);
+        Assert.True(await removeTask);
+
+        SetTenant(setter, "tenant-1");
+        Assert.Equal("new", cache.GetOrAdd("name", () => new TestOptions { Value = "new" }).Value);
+    }
+
+    private static (MultiTenantOptionsCache<TestOptions> Cache, IMultiTenantContextSetter Setter) CreateCache()
+    {
+        var accessor = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
+        var setter = (IMultiTenantContextSetter)accessor;
+        SetNoTenant(setter);
+        return (new MultiTenantOptionsCache<TestOptions>(accessor), setter);
+    }
+
+    private static TestOptions Add(MultiTenantOptionsCache<TestOptions> cache,
+        IMultiTenantContextSetter setter, string tenantId, string? name)
+    {
+        SetTenant(setter, tenantId);
+        var options = new TestOptions();
+        Assert.True(cache.TryAdd(name, options));
+        return options;
+    }
+
+    private static void SetTenant(IMultiTenantContextSetter setter, string tenantId) =>
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(
+            new TenantInfo { Id = tenantId, Identifier = tenantId });
+
+    private static void SetNoTenant(IMultiTenantContextSetter setter) =>
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(null);
 }

--- a/test/Finbuckle.MultiTenant.Test/Options/PerTenantOptionsIntegrationShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/PerTenantOptionsIntegrationShould.cs
@@ -1,0 +1,151 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more information.
+
+using Finbuckle.MultiTenant.Abstractions;
+using Finbuckle.MultiTenant.Extensions;
+using Finbuckle.MultiTenant.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Finbuckle.MultiTenant.Test.Options;
+
+public class PerTenantOptionsIntegrationShould
+{
+    [Fact]
+    public void ResolveConfiguredAndValidatedOptionsThroughAllAccessors()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.Configure<TestOptions>(options => options.Value = "base");
+        services.ConfigurePerTenant<TestOptions, TenantInfo>((options, tenant) =>
+            options.Value += $":{tenant.Id}");
+        services.PostConfigurePerTenant<TestOptions, TenantInfo>((options, tenant) =>
+            options.Value += $":post-{tenant.Id}");
+        services.AddOptions<TestOptions>().Validate(options =>
+            options.Value == "base:tenant-1:post-tenant-1");
+
+        using var provider = services.BuildServiceProvider();
+        SetTenant(provider, "tenant-1");
+
+        Assert.Equal("base:tenant-1:post-tenant-1",
+            provider.GetRequiredService<IOptions<TestOptions>>().Value.Value);
+        using var scope = provider.CreateScope();
+        Assert.Equal("base:tenant-1:post-tenant-1",
+            scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<TestOptions>>().Value.Value);
+        Assert.Equal("base:tenant-1:post-tenant-1",
+            provider.GetRequiredService<IOptionsMonitor<TestOptions>>().CurrentValue.Value);
+    }
+
+    [Fact]
+    public void ConfigureNamedOptionsThroughOptionsBuilderDependencies()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.AddSingleton(new TestDependency("dependency"));
+        services.AddOptions<TestOptions>("builder")
+            .ConfigurePerTenant<TestOptions, TestDependency, TenantInfo>((options, dependency, tenant) =>
+                options.Value = $"{dependency.Value}:{tenant.Id}")
+            .PostConfigurePerTenant<TestOptions, TestDependency, TenantInfo>((options, dependency, _) =>
+                options.Value += $":post-{dependency.Value}");
+
+        using var provider = services.BuildServiceProvider();
+        SetTenant(provider, "tenant-1");
+
+        Assert.Equal("dependency:tenant-1:post-dependency",
+            provider.GetRequiredService<IOptionsMonitor<TestOptions>>().Get("builder").Value);
+    }
+
+    [Fact]
+    public void ReloadChangedNameForEveryTenantAndPreserveOtherNames()
+    {
+        var services = new ServiceCollection();
+        var state = new ReloadState();
+        var source = new ManualChangeTokenSource<TestOptions>("changed");
+        services.AddMultiTenant<TenantInfo>();
+        services.AddSingleton<IOptionsChangeTokenSource<TestOptions>>(source);
+        services.ConfigurePerTenant<TestOptions, TenantInfo>("changed", (options, tenant) =>
+            options.Value = $"{tenant.Id}:{state.Version}");
+        services.ConfigurePerTenant<TestOptions, TenantInfo>("unchanged", (options, tenant) =>
+            options.Value = $"unchanged:{tenant.Id}");
+
+        using var provider = services.BuildServiceProvider();
+        var monitor = provider.GetRequiredService<IOptionsMonitor<TestOptions>>();
+
+        SetTenant(provider, "tenant-1");
+        var tenant1Changed = monitor.Get("changed");
+        var tenant1Unchanged = monitor.Get("unchanged");
+        SetTenant(provider, "tenant-2");
+        var tenant2Changed = monitor.Get("changed");
+        var tenant2Unchanged = monitor.Get("unchanged");
+
+        string? notificationName = null;
+        TestOptions? notificationValue = null;
+        using var registration = monitor.OnChange((options, name) =>
+        {
+            notificationName = name;
+            notificationValue = options;
+        });
+
+        state.Version = 2;
+        source.Trigger();
+
+        SetTenant(provider, "tenant-1");
+        var tenant1Reloaded = monitor.Get("changed");
+        Assert.Equal("tenant-1:2", tenant1Reloaded.Value);
+        Assert.NotSame(tenant1Changed, tenant1Reloaded);
+        Assert.Same(tenant1Unchanged, monitor.Get("unchanged"));
+
+        SetTenant(provider, "tenant-2");
+        var tenant2Reloaded = monitor.Get("changed");
+        Assert.Equal("tenant-2:2", tenant2Reloaded.Value);
+        Assert.NotSame(tenant2Changed, tenant2Reloaded);
+        Assert.Same(tenant2Unchanged, monitor.Get("unchanged"));
+
+        Assert.Equal("changed", notificationName);
+        Assert.Equal("tenant-2:2", notificationValue?.Value);
+    }
+
+    private static void SetTenant(IServiceProvider provider, string tenantId)
+    {
+        var setter = provider.GetRequiredService<IMultiTenantContextSetter>();
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>(
+            new TenantInfo { Id = tenantId, Identifier = tenantId });
+    }
+
+    public class TestOptions
+    {
+        public string? Value { get; set; }
+    }
+
+    public record TestDependency(string Value);
+
+    private sealed class ReloadState
+    {
+        public int Version { get; set; } = 1;
+    }
+
+    private sealed class ManualChangeTokenSource<TOptions>(string? name) : IOptionsChangeTokenSource<TOptions>
+    {
+        private CancellationTokenSource source = new();
+
+        public string? Name { get; } = name;
+
+        public IChangeToken GetChangeToken() => new CancellationChangeToken(source.Token);
+
+        public void Trigger()
+        {
+            var previous = Interlocked.Exchange(ref source, new CancellationTokenSource());
+            previous.Cancel();
+            previous.Dispose();
+        }
+    }
+
+    private sealed class CustomOptionsSnapshot : IOptionsSnapshot<TestOptions>
+    {
+        public TestOptions Value { get; } = new();
+
+        public TestOptions Get(string? name) => Value;
+    }
+}

--- a/test/Finbuckle.MultiTenant.Test/Options/PerTenantOptionsRegistrationShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/PerTenantOptionsRegistrationShould.cs
@@ -1,0 +1,95 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more information.
+
+using Finbuckle.MultiTenant.Abstractions;
+using Finbuckle.MultiTenant.Extensions;
+using Finbuckle.MultiTenant.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Finbuckle.MultiTenant.Test.Options;
+
+public class PerTenantOptionsRegistrationShould
+{
+    [Fact]
+    public void ReplaceExactClosedOptionsRegistrationsAndKeepOpenGenericDefaults()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.AddOptions();
+        services.AddSingleton<IOptionsMonitorCache<TestOptions>, OptionsCache<TestOptions>>();
+        services.AddSingleton<IOptions<TestOptions>>(Microsoft.Extensions.Options.Options.Create(new TestOptions()));
+        services.AddScoped<IOptionsSnapshot<TestOptions>, CustomOptionsSnapshot>();
+
+        services.ConfigurePerTenant<TestOptions, TenantInfo>((_, _) => { });
+
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(IOptions<>));
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(IOptionsSnapshot<>));
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(IOptionsMonitorCache<>));
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IOptions<TestOptions>));
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IOptionsSnapshot<TestOptions>));
+        var cacheDescriptor = Assert.Single(services,
+            descriptor => descriptor.ServiceType == typeof(IOptionsMonitorCache<TestOptions>));
+        Assert.Equal(typeof(MultiTenantOptionsCache<TestOptions>), cacheDescriptor.ImplementationType);
+
+        using var provider = services.BuildServiceProvider();
+        Assert.IsType<MultiTenantOptionsManager<TestOptions>>(
+            provider.GetRequiredService<IOptions<TestOptions>>());
+        using var scope = provider.CreateScope();
+        Assert.IsType<MultiTenantOptionsManager<TestOptions>>(
+            scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<TestOptions>>());
+    }
+
+    [Fact]
+    public void LeaveOneClosedRegistrationAfterRepeatedConfiguration()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.ConfigurePerTenant<TestOptions, TenantInfo>((_, _) => { });
+        services.AddSingleton<IOptionsMonitorCache<TestOptions>, OptionsCache<TestOptions>>();
+
+        services.PostConfigurePerTenant<TestOptions, TenantInfo>((_, _) => { });
+
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IOptions<TestOptions>));
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IOptionsSnapshot<TestOptions>));
+        var cacheDescriptor = Assert.Single(services,
+            descriptor => descriptor.ServiceType == typeof(IOptionsMonitorCache<TestOptions>));
+        Assert.Equal(typeof(MultiTenantOptionsCache<TestOptions>), cacheDescriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void ValidateNullArgumentsLikeMicrosoftOptionsExtensions()
+    {
+        var services = new ServiceCollection();
+        Action<TestOptions, TenantInfo> configure = (_, _) => { };
+        OptionsBuilder<TestOptions>? builder = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+            ServiceCollectionExtensions.ConfigurePerTenant<TestOptions, TenantInfo>(null!, configure));
+        Assert.Throws<ArgumentNullException>(() =>
+            services.ConfigurePerTenant<TestOptions, TenantInfo>(null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            ServiceCollectionExtensions.PostConfigurePerTenant<TestOptions, TenantInfo>(null!, configure));
+        Assert.Throws<ArgumentNullException>(() =>
+            services.PostConfigurePerTenant<TestOptions, TenantInfo>(null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            Finbuckle.MultiTenant.Extensions.OptionsBuilderExtensions
+                .ConfigurePerTenant<TestOptions, TenantInfo>(builder!, configure));
+        Assert.Throws<ArgumentNullException>(() =>
+            Finbuckle.MultiTenant.Extensions.OptionsBuilderExtensions
+                .PostConfigurePerTenant<TestOptions, TenantInfo>(builder!, configure));
+    }
+
+    public class TestOptions
+    {
+        public string? Value { get; set; }
+    }
+
+    private sealed class CustomOptionsSnapshot : IOptionsSnapshot<TestOptions>
+    {
+        public TestOptions Value { get; } = new();
+
+        public TestOptions Get(string? name) => Value;
+    }
+}


### PR DESCRIPTION
## Summary
- Correct per-tenant options registration so tenant-specific options are resolved consistently
- Update the options manager and cache to respect per-tenant behavior
- Add and adjust tests covering cache behavior, registration, and integration scenarios
- Refresh the options documentation to match the new behavior

## Testing
- Added/updated unit tests for multi-tenant options cache behavior
- Added/updated registration and integration tests for per-tenant options
- Not run (not requested)

## CI
- tweaked some ci workflow stuff