### PR TITLE
fix: backport post-v10.1.1 fixes to v9

### DIFF
--- a/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Strategies/RemoteAuthenticationCallbackStrategy.cs
@@ -90,8 +90,15 @@ public class RemoteAuthenticationCallbackStrategy : IMultiTenantStrategy
                         var formOptions = new FormOptions { BufferBody = true, MemoryBufferThreshold = 1048576 };
 
                         var form = await httpContext.Request.ReadFormAsync(formOptions).ConfigureAwait(false);
-                        state = form.Single(i => string.Equals(i.Key, "state", StringComparison.OrdinalIgnoreCase))
-                            .Value;
+                        if (form.TryGetValue("state", out var formState))
+                            state = formState;
+                    }
+
+                    if (string.IsNullOrEmpty(state))
+                    {
+                        logger?.LogWarning(
+                            "A tenant could not be determined because no state parameter passed with the remote authentication callback.");
+                        return null;
                     }
 
                     var properties = ((dynamic)options).StateDataFormat.Unprotect(state) as AuthenticationProperties;

--- a/src/Finbuckle.MultiTenant/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Finbuckle.MultiTenant/DependencyInjection/ServiceCollectionExtensions.cs
@@ -59,94 +59,79 @@ public static class FinbuckleServiceCollectionExtensions
         return services.AddMultiTenant<TTenantInfo>(_ => { });
     }
 
-    
     /// <summary>
-    /// Decorates an existing service registration with a new implementation that wraps the original.
+    /// Decorates existing unkeyed service registrations with a new implementation that wraps the original.
     /// </summary>
-    /// <typeparam name="TService">The service type to decorate.</typeparam>
-    /// <typeparam name="TImpl">The decorator implementation type.</typeparam>
-    /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
-    /// <param name="parameters">Additional parameters to pass to the decorator constructor after the inner service.</param>
-    /// <returns><c>true</c> if the service was successfully decorated.</returns>
-    /// <exception cref="ArgumentException">Thrown when no service of type <typeparamref name="TService"/> is found.</exception>
-    /// <exception cref="Exception">Thrown when the service cannot be instantiated.</exception>
     public static bool DecorateService<TService, TImpl>(this IServiceCollection services, params object[] parameters)
     {
-        var existingServices = services.Where(s => s.ServiceType == typeof(TService)).ToList();
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        if (!typeof(TService).IsAssignableFrom(typeof(TImpl)))
+            throw new ArgumentException(
+                $"Decorator type {typeof(TImpl).Name} must implement or inherit from {typeof(TService).Name}.",
+                nameof(TImpl));
+
+        var parametersCopy = parameters.ToArray();
+        var existingServices = services.Select((descriptor, index) => (descriptor, index))
+            .Where(item => item.descriptor.ServiceType == typeof(TService)
+#if NET8_0_OR_GREATER
+                           && !item.descriptor.IsKeyedService
+#endif
+            )
+            .ToList();
         if (existingServices.Count == 0)
             throw new ArgumentException($"No service of type {typeof(TService).Name} found.");
 
-        ServiceDescriptor? newService;
+        var replacements = existingServices.Select(item =>
+            (item.index, descriptor: CreateDecoratedDescriptor<TService, TImpl>(item.descriptor, parametersCopy)))
+            .ToList();
 
-        foreach (var existingService in existingServices)
-        {
-            if (existingService.ImplementationType is not null)
-            {
-                newService = new ServiceDescriptor(existingService.ServiceType,
-                    sp =>
-                    {
-                        TService inner =
-                            (TService)ActivatorUtilities.CreateInstance(sp, existingService.ImplementationType);
- 
-                        if (inner is null)
-                            throw new ArgumentException(
-                                $"Unable to instantiate decorated type via implementation type {existingService.ImplementationType.Name}.");
-
-                        var parameters2 = new object[parameters.Length + 1];
-                        Array.Copy(parameters, 0, parameters2, 1, parameters.Length);
-                        parameters2[0] = inner;
-
-                        return ActivatorUtilities.CreateInstance<TImpl>(sp, parameters2)!;
-                    },
-                    existingService.Lifetime);
-            }
-            else if (existingService.ImplementationInstance is not null)
-            {
-                newService = new ServiceDescriptor(existingService.ServiceType,
-                    sp =>
-                    {
-                        TService inner = (TService)existingService.ImplementationInstance;
-                        if (inner is null)
-                            throw new ArgumentException(
-                                $"Unable to instantiate decorated type via implementation instance of type {existingService.ImplementationInstance.GetType().Name}.");
-                        
-                        var parameters2 = new object[parameters.Length + 1];
-                        Array.Copy(parameters, 0, parameters2, 1, parameters.Length);
-                        parameters2[0] = inner;
-                        
-                        return ActivatorUtilities.CreateInstance<TImpl>(sp, parameters2)!;
-                    },
-                    existingService.Lifetime);
-            }
-            else if (existingService.ImplementationFactory is not null)
-            {
-                newService = new ServiceDescriptor(existingService.ServiceType,
-                    sp =>
-                    {
-                        TService inner = (TService)existingService.ImplementationFactory(sp);
-                        if (inner is null)
-                            throw new ArgumentException(
-                                $"Unable to instantiate decorated type via implementation factory for type {existingService.ServiceType}.");
-
-                        var parameters2 = new object[parameters.Length + 1];
-                        Array.Copy(parameters, 0, parameters2, 1, parameters.Length);
-                        parameters2[0] = inner;
-                        
-                        return ActivatorUtilities.CreateInstance<TImpl>(sp, parameters2)!;
-                    },
-                    existingService.Lifetime);
-            }
-            else
-            {
-                throw new  ArgumentException(
-                    "Unable to instantiate decorated type.");
-            }
-
-            services.Remove(existingService);
-            services.Add(newService);
-        }
+        foreach (var replacement in replacements)
+            services[replacement.index] = replacement.descriptor;
 
         return true;
+    }
+
+    private static ServiceDescriptor CreateDecoratedDescriptor<TService, TImpl>(
+        ServiceDescriptor existingService, object[] parameters)
+    {
+        Func<IServiceProvider, object?> createInner;
+
+        if (existingService.ImplementationType is not null)
+        {
+            var implementationType = existingService.ImplementationType;
+            createInner = sp => ActivatorUtilities.CreateInstance(sp, implementationType);
+        }
+        else if (existingService.ImplementationInstance is not null)
+        {
+            var implementationInstance = existingService.ImplementationInstance;
+            createInner = _ => implementationInstance;
+        }
+        else if (existingService.ImplementationFactory is not null)
+        {
+            createInner = existingService.ImplementationFactory;
+        }
+        else
+        {
+            throw new ArgumentException("Unable to instantiate decorated type.");
+        }
+
+        return new ServiceDescriptor(existingService.ServiceType,
+            sp =>
+            {
+                var innerObject = createInner(sp);
+                if (innerObject is not TService inner)
+                    throw new ArgumentException(
+                        $"Unable to instantiate decorated service of type {typeof(TService).Name}.");
+
+                var constructorParameters = new object[parameters.Length + 1];
+                constructorParameters[0] = inner;
+                Array.Copy(parameters, 0, constructorParameters, 1, parameters.Length);
+
+                return ActivatorUtilities.CreateInstance<TImpl>(sp, constructorParameters)!;
+            },
+            existingService.Lifetime);
     }
 
     /// <summary>
@@ -164,6 +149,9 @@ public static class FinbuckleServiceCollectionExtensions
         where TOptions : class
         where TTenantInfo : class, ITenantInfo, new()
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         ConfigurePerTenantReqs<TOptions>(services);
 
         services.AddTransient<IConfigureOptions<TOptions>>(sp =>
@@ -229,6 +217,9 @@ public static class FinbuckleServiceCollectionExtensions
         where TOptions : class
         where TTenantInfo : class, ITenantInfo, new()
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         ConfigurePerTenantReqs<TOptions>(services);
 
         services.AddTransient<IPostConfigureOptions<TOptions>>(sp =>
@@ -292,10 +283,12 @@ public static class FinbuckleServiceCollectionExtensions
         // Required infrastructure.
         services.AddOptions();
 
-        // TODO: Add check for success
-        services.TryAddSingleton<IOptionsMonitorCache<TOptions>, MultiTenantOptionsCache<TOptions>>();
-        services.TryAddScoped<IOptionsSnapshot<TOptions>>(BuildOptionsManager);
-        services.TryAddSingleton<IOptions<TOptions>>(BuildOptionsManager);
+        services.RemoveAll<IOptionsMonitorCache<TOptions>>();
+        services.RemoveAll<IOptionsSnapshot<TOptions>>();
+        services.RemoveAll<IOptions<TOptions>>();
+        services.AddSingleton<IOptionsMonitorCache<TOptions>, MultiTenantOptionsCache<TOptions>>();
+        services.AddScoped<IOptionsSnapshot<TOptions>>(BuildOptionsManager);
+        services.AddSingleton<IOptions<TOptions>>(BuildOptionsManager);
         return;
 
         MultiTenantOptionsManager<TOptions> BuildOptionsManager(IServiceProvider sp)

--- a/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsCache.cs
+++ b/src/Finbuckle.MultiTenant/Options/MultiTenantOptionsCache.cs
@@ -34,9 +34,7 @@ public class MultiTenantOptionsCache<TOptions> : IOptionsMonitorCache<TOptions>
     public void Clear()
     {
         var tenantId = multiTenantContextAccessor.MultiTenantContext?.TenantInfo?.Id ?? "";
-        var cache = map.GetOrAdd(tenantId, new OptionsCache<TOptions>());
-
-        cache.Clear();
+        map.TryRemove(tenantId, out _);
     }
 
     /// <summary>
@@ -45,19 +43,13 @@ public class MultiTenantOptionsCache<TOptions> : IOptionsMonitorCache<TOptions>
     /// <param name="tenantId">The Id of the tenant which will have its options cleared.</param>
     public void Clear(string tenantId)
     {
-        var cache = map.GetOrAdd(tenantId, new OptionsCache<TOptions>());
-
-        cache.Clear();
+        map.TryRemove(tenantId, out _);
     }
 
     /// <summary>
     /// Clears all cached options for all tenants and no tenant.
     /// </summary>
-    public void ClearAll()
-    {
-        foreach (var cache in map.Values)
-            cache.Clear();
-    }
+    public void ClearAll() => map.Clear();
 
     /// <summary>
     /// Gets a named options instance for the current tenant, or adds a new instance created with createOptions.
@@ -84,7 +76,9 @@ public class MultiTenantOptionsCache<TOptions> : IOptionsMonitorCache<TOptions>
     /// <returns>True if the options was added to the cache for the current tenant.</returns>
     public bool TryAdd(string? name, TOptions options)
     {
-        name = name ?? Microsoft.Extensions.Options.Options.DefaultName;
+        ArgumentNullException.ThrowIfNull(options);
+
+        name ??= Microsoft.Extensions.Options.Options.DefaultName;
         var tenantId = multiTenantContextAccessor.MultiTenantContext?.TenantInfo?.Id ?? "";
         var cache = map.GetOrAdd(tenantId, new OptionsCache<TOptions>());
 
@@ -92,16 +86,18 @@ public class MultiTenantOptionsCache<TOptions> : IOptionsMonitorCache<TOptions>
     }
 
     /// <summary>
-    /// Try to remove an options instance for the current tenant.
+    /// Tries to remove a named options instance for all tenants and no tenant.
     /// </summary>
     /// <param name="name">The options name.</param>
-    /// <returns>True if the options was removed from the cache for the current tenant.</returns>
+    /// <returns>True if the options was removed from at least one tenant cache.</returns>
     public bool TryRemove(string? name)
     {
-        name = name ?? Microsoft.Extensions.Options.Options.DefaultName;
-        var tenantId = multiTenantContextAccessor.MultiTenantContext?.TenantInfo?.Id ?? "";
-        var cache = map.GetOrAdd(tenantId, new OptionsCache<TOptions>());
+        name ??= Microsoft.Extensions.Options.Options.DefaultName;
+        var removed = false;
 
-        return cache.TryRemove(name);
+        foreach (var cache in map.Values)
+            removed |= cache.TryRemove(name);
+
+        return removed;
     }
 }

--- a/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
+++ b/src/Finbuckle.MultiTenant/Stores/InMemoryStore/InMemoryStore.cs
@@ -15,6 +15,7 @@ public class InMemoryStore<TTenantInfo> : IMultiTenantStore<TTenantInfo>
     where TTenantInfo : class, ITenantInfo, new()
 {
     private readonly ConcurrentDictionary<string, TTenantInfo> _tenantMap;
+    private readonly object _tenantMapLock = new();
     // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
     private readonly InMemoryStoreOptions<TTenantInfo> _options;
 
@@ -46,24 +47,31 @@ public class InMemoryStore<TTenantInfo> : IMultiTenantStore<TTenantInfo>
     }
 
     /// <inheritdoc />
-    public async Task<TTenantInfo?> TryGetAsync(string id)
+    public Task<TTenantInfo?> TryGetAsync(string id)
     {
-        var result = _tenantMap.Values.SingleOrDefault(ti => ti.Id == id);
-        return await Task.FromResult(result).ConfigureAwait(false);
+        lock (_tenantMapLock)
+        {
+            return Task.FromResult(_tenantMap.Values.SingleOrDefault(ti => ti.Id == id));
+        }
     }
 
     /// <inheritdoc />
-    public async Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
+    public Task<TTenantInfo?> TryGetByIdentifierAsync(string identifier)
     {
-        _tenantMap.TryGetValue(identifier, out var result);
-
-        return await Task.FromResult(result).ConfigureAwait(false);
+        lock (_tenantMapLock)
+        {
+            _tenantMap.TryGetValue(identifier, out var result);
+            return Task.FromResult(result);
+        }
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<TTenantInfo>> GetAllAsync()
+    public Task<IEnumerable<TTenantInfo>> GetAllAsync()
     {
-        return await Task.FromResult(_tenantMap.Select(x => x.Value).ToList()).ConfigureAwait(false);
+        lock (_tenantMapLock)
+        {
+            return Task.FromResult<IEnumerable<TTenantInfo>>(_tenantMap.Select(x => x.Value).ToList());
+        }
     }
 
     /// <summary>
@@ -76,32 +84,51 @@ public class InMemoryStore<TTenantInfo> : IMultiTenantStore<TTenantInfo>
     }
 
     /// <inheritdoc />
-    public async Task<bool> TryAddAsync(TTenantInfo tenantInfo)
+    public Task<bool> TryAddAsync(TTenantInfo tenantInfo)
     {
-        var result = tenantInfo.Identifier != null && _tenantMap.TryAdd(tenantInfo.Identifier, tenantInfo);
-
-        return await Task.FromResult(result).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> TryRemoveAsync(string identifier)
-    {
-        var result = _tenantMap.TryRemove(identifier, out var _);
-
-        return await Task.FromResult(result).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc />
-    public async Task<bool> TryUpdateAsync(TTenantInfo tenantInfo)
-    {
-        var existingTenantInfo = tenantInfo.Id != null ? await TryGetAsync(tenantInfo.Id).ConfigureAwait(false) : null;
-
-        if (existingTenantInfo?.Identifier != null)
+        lock (_tenantMapLock)
         {
-            var result =  _tenantMap.TryUpdate(existingTenantInfo.Identifier, tenantInfo, existingTenantInfo);
-            return await Task.FromResult(result).ConfigureAwait(false);
+            return Task.FromResult(tenantInfo.Identifier != null &&
+                                   _tenantMap.TryAdd(tenantInfo.Identifier, tenantInfo));
         }
+    }
 
-        return await Task.FromResult(false).ConfigureAwait(false);
+    /// <inheritdoc />
+    public Task<bool> TryRemoveAsync(string identifier)
+    {
+        lock (_tenantMapLock)
+        {
+            return Task.FromResult(_tenantMap.TryRemove(identifier, out _));
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<bool> TryUpdateAsync(TTenantInfo tenantInfo)
+    {
+        lock (_tenantMapLock)
+        {
+            if (tenantInfo.Id is null || tenantInfo.Identifier is null)
+                return Task.FromResult(false);
+
+            var existingTenantInfo = _tenantMap.Values.SingleOrDefault(ti => ti.Id == tenantInfo.Id);
+            if (existingTenantInfo?.Identifier is null)
+                return Task.FromResult(false);
+
+            if (_tenantMap.Comparer.Equals(existingTenantInfo.Identifier, tenantInfo.Identifier))
+                return Task.FromResult(
+                    _tenantMap.TryUpdate(existingTenantInfo.Identifier, tenantInfo, existingTenantInfo));
+
+            if (_tenantMap.ContainsKey(tenantInfo.Identifier))
+                return Task.FromResult(false);
+
+            if (!_tenantMap.TryRemove(existingTenantInfo.Identifier, out var removedTenantInfo))
+                return Task.FromResult(false);
+
+            if (_tenantMap.TryAdd(tenantInfo.Identifier, tenantInfo))
+                return Task.FromResult(true);
+
+            _tenantMap.TryAdd(existingTenantInfo.Identifier, removedTenantInfo);
+            return Task.FromResult(false);
+        }
     }
 }

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/RemoteAuthenticationCallbackStrategyShould.cs
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Strategies/RemoteAuthenticationCallbackStrategyShould.cs
@@ -1,28 +1,207 @@
 // Copyright Finbuckle LLC, Andrew White, and Contributors.
 // Refer to the solution LICENSE file for more information.
 
-// TODO: Implement more tests.
-
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
 using Finbuckle.MultiTenant.AspNetCore.Strategies;
+using Finbuckle.MultiTenant.Internal;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
 
 namespace Finbuckle.MultiTenant.AspNetCore.Test.Strategies;
 
 public class RemoteAuthenticationCallbackStrategyShould
 {
+    public sealed class FakeRemoteOptions : RemoteAuthenticationOptions
+    {
+        public PathString SignedOutCallbackPath { get; set; }
+        public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; } = null!;
+    }
+
+    public sealed class FakeRemoteHandler : IAuthenticationRequestHandler
+    {
+        public FakeRemoteOptions Options { get; } = null!;
+
+        public Task<AuthenticateResult> AuthenticateAsync() => throw new NotImplementedException();
+        public Task ChallengeAsync(AuthenticationProperties? properties) => throw new NotImplementedException();
+        public Task ForbidAsync(AuthenticationProperties? properties) => throw new NotImplementedException();
+        public Task InitializeAsync(AuthenticationScheme scheme, HttpContext context) => throw new NotImplementedException();
+        public Task<bool> HandleRequestAsync() => throw new NotImplementedException();
+    }
+
+    public sealed class RequestHandlerWithoutOptions : IAuthenticationRequestHandler
+    {
+        public Task<AuthenticateResult> AuthenticateAsync() => throw new NotImplementedException();
+        public Task ChallengeAsync(AuthenticationProperties? properties) => throw new NotImplementedException();
+        public Task ForbidAsync(AuthenticationProperties? properties) => throw new NotImplementedException();
+        public Task InitializeAsync(AuthenticationScheme scheme, HttpContext context) => throw new NotImplementedException();
+        public Task<bool> HandleRequestAsync() => throw new NotImplementedException();
+    }
+
+    private static (RemoteAuthenticationCallbackStrategy Strategy, DefaultHttpContext Context,
+        Mock<ISecureDataFormat<AuthenticationProperties>> StateDataFormat) CreateStrategy(
+        string requestPath = "/signin-remote", string method = "GET", bool includeSecondScheme = false)
+    {
+        var stateDataFormat = new Mock<ISecureDataFormat<AuthenticationProperties>>();
+        var options = new FakeRemoteOptions
+        {
+            CallbackPath = "/signin-remote",
+            SignedOutCallbackPath = "/signout-remote",
+            StateDataFormat = stateDataFormat.Object
+        };
+        var optionsMonitor = new Mock<IOptionsMonitor<FakeRemoteOptions>>();
+        optionsMonitor.Setup(o => o.Get(It.IsAny<string>())).Returns(options);
+
+        var schemes = new List<AuthenticationScheme>();
+        if (includeSecondScheme)
+            schemes.Add(new AuthenticationScheme("first", null, typeof(RequestHandlerWithoutOptions)));
+        schemes.Add(new AuthenticationScheme("remote", null, typeof(FakeRemoteHandler)));
+
+        var schemeProvider = new Mock<IAuthenticationSchemeProvider>();
+        schemeProvider.Setup(s => s.GetRequestHandlerSchemesAsync()).ReturnsAsync(schemes);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(schemeProvider.Object);
+        services.AddSingleton(optionsMonitor.Object);
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        context.Request.Path = requestPath;
+        context.Request.Method = method;
+
+        return (new RemoteAuthenticationCallbackStrategy(
+            Mock.Of<ILogger<RemoteAuthenticationCallbackStrategy>>()), context, stateDataFormat);
+    }
+
+    private static AuthenticationProperties CreateProperties(string? identifier = "initech")
+    {
+        var properties = new AuthenticationProperties();
+        if (identifier is not null)
+            properties.Items[Constants.TenantToken] = identifier;
+        return properties;
+    }
+
     [Fact]
     public void HavePriorityNeg900()
     {
         var strategy = new RemoteAuthenticationCallbackStrategy(null!);
         Assert.Equal(-900, strategy.Priority);
     }
-    
+
     [Fact]
     public async Task ReturnNullIfContextIsNotHttpContext()
     {
-        var context = new object();
         var strategy = new RemoteAuthenticationCallbackStrategy(null!);
 
+        Assert.Null(await strategy.GetIdentifierAsync(new object()));
+    }
+
+    [Fact]
+    public async Task ResolveIdentifierFromGetCallbackState()
+    {
+        var (strategy, context, stateDataFormat) = CreateStrategy();
+        context.Request.QueryString = new QueryString("?state=protected-state");
+        stateDataFormat.Setup(f => f.Unprotect("protected-state")).Returns(CreateProperties());
+
+        Assert.Equal("initech", await strategy.GetIdentifierAsync(context));
+    }
+
+    [Fact]
+    public async Task ResolveIdentifierFromPostCallbackState()
+    {
+        var (strategy, context, stateDataFormat) = CreateStrategy(method: "POST");
+        context.Request.ContentType = "application/x-www-form-urlencoded";
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("state=protected-state"));
+        stateDataFormat.Setup(f => f.Unprotect("protected-state")).Returns(CreateProperties());
+
+        Assert.Equal("initech", await strategy.GetIdentifierAsync(context));
+    }
+
+    [Fact]
+    public async Task ResolveIdentifierFromSignedOutCallbackState()
+    {
+        var (strategy, context, stateDataFormat) = CreateStrategy("/signout-remote");
+        context.Request.QueryString = new QueryString("?state=protected-state");
+        stateDataFormat.Setup(f => f.Unprotect("protected-state")).Returns(CreateProperties());
+
+        Assert.Equal("initech", await strategy.GetIdentifierAsync(context));
+    }
+
+    [Fact]
+    public async Task ContinueToSupportedRemoteScheme()
+    {
+        var (strategy, context, stateDataFormat) = CreateStrategy(includeSecondScheme: true);
+        context.Request.QueryString = new QueryString("?state=protected-state");
+        stateDataFormat.Setup(f => f.Unprotect("protected-state")).Returns(CreateProperties());
+
+        Assert.Equal("initech", await strategy.GetIdentifierAsync(context));
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("POST")]
+    public async Task ReturnNullIfCallbackStateMissing(string method)
+    {
+        var (strategy, context, stateDataFormat) = CreateStrategy(method: method);
+        if (method == "POST")
+        {
+            context.Request.ContentType = "application/x-www-form-urlencoded";
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("other=value"));
+        }
+
         Assert.Null(await strategy.GetIdentifierAsync(context));
+        stateDataFormat.Verify(f => f.Unprotect(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReturnNullForUnrelatedPath()
+    {
+        var (strategy, context, stateDataFormat) = CreateStrategy("/unrelated");
+        context.Request.QueryString = new QueryString("?state=protected-state");
+
+        Assert.Null(await strategy.GetIdentifierAsync(context));
+        stateDataFormat.Verify(f => f.Unprotect(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReturnNullIfStateDoesNotContainAuthenticationProperties()
+    {
+        var (strategy, context, stateDataFormat) = CreateStrategy();
+        context.Request.QueryString = new QueryString("?state=protected-state");
+        stateDataFormat.Setup(f => f.Unprotect("protected-state")).Returns((AuthenticationProperties?)null);
+
+        Assert.Null(await strategy.GetIdentifierAsync(context));
+    }
+
+    [Fact]
+    public async Task ReturnNullIfAuthenticationPropertiesDoNotContainTenant()
+    {
+        var (strategy, context, stateDataFormat) = CreateStrategy();
+        context.Request.QueryString = new QueryString("?state=protected-state");
+        stateDataFormat.Setup(f => f.Unprotect("protected-state")).Returns(CreateProperties(null));
+
+        Assert.Null(await strategy.GetIdentifierAsync(context));
+    }
+
+    [Fact]
+    public async Task WrapInvalidProtectedStateException()
+    {
+        var (strategy, context, stateDataFormat) = CreateStrategy();
+        context.Request.QueryString = new QueryString("?state=invalid");
+        var innerException = new InvalidOperationException("invalid state");
+        stateDataFormat.Setup(f => f.Unprotect("invalid")).Throws(innerException);
+
+        var exception = await Assert.ThrowsAsync<MultiTenantException>(() => strategy.GetIdentifierAsync(context));
+
+        Assert.Same(innerException, exception.InnerException);
     }
 }

--- a/test/Finbuckle.MultiTenant.Test/DependencyInjection/ServiceCollectionExtensionsShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/DependencyInjection/ServiceCollectionExtensionsShould.cs
@@ -2,6 +2,7 @@
 // Refer to the solution LICENSE file for more information.
 
 using Finbuckle.MultiTenant.Abstractions;
+using Finbuckle.MultiTenant.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -125,78 +126,164 @@ public class ServiceCollectionExtensionsShould
             Assert.Single(config);
             Assert.Null(config.Select(c => (ConfigureNamedOptions<TestOptions, IMultiTenantContextAccessor<TenantInfo>>)c).Single().Name);
         }
-        
     [Fact]
-    public void DecorateService_WithImplementationType_WrapsService()
+    public void ReplaceExactClosedOptionsRegistrationsAndKeepOpenGenericDefaults()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.AddOptions();
+        services.AddSingleton<IOptionsMonitorCache<TestOptions>, OptionsCache<TestOptions>>();
+        services.AddSingleton<IOptions<TestOptions>>(Microsoft.Extensions.Options.Options.Create(new TestOptions()));
+        services.AddScoped<IOptionsSnapshot<TestOptions>, CustomOptionsSnapshot>();
+
+        services.ConfigurePerTenant<TestOptions, TenantInfo>((_, _) => { });
+
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(IOptions<>));
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(IOptionsSnapshot<>));
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(IOptionsMonitorCache<>));
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IOptions<TestOptions>));
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IOptionsSnapshot<TestOptions>));
+        var cacheDescriptor = Assert.Single(services,
+            descriptor => descriptor.ServiceType == typeof(IOptionsMonitorCache<TestOptions>));
+        Assert.Equal(typeof(MultiTenantOptionsCache<TestOptions>), cacheDescriptor.ImplementationType);
+
+        using var provider = services.BuildServiceProvider();
+        Assert.IsType<MultiTenantOptionsManager<TestOptions>>(provider.GetRequiredService<IOptions<TestOptions>>());
+        using var scope = provider.CreateScope();
+        Assert.IsType<MultiTenantOptionsManager<TestOptions>>(
+            scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<TestOptions>>());
+    }
+
+    [Fact]
+    public void LeaveOneClosedRegistrationAfterRepeatedPerTenantConfiguration()
+    {
+        var services = new ServiceCollection();
+        services.AddMultiTenant<TenantInfo>();
+        services.ConfigurePerTenant<TestOptions, TenantInfo>((_, _) => { });
+        services.AddSingleton<IOptionsMonitorCache<TestOptions>, OptionsCache<TestOptions>>();
+
+        services.PostConfigurePerTenant<TestOptions, TenantInfo>((_, _) => { });
+
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IOptions<TestOptions>));
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IOptionsSnapshot<TestOptions>));
+        var cacheDescriptor = Assert.Single(services,
+            descriptor => descriptor.ServiceType == typeof(IOptionsMonitorCache<TestOptions>));
+        Assert.Equal(typeof(MultiTenantOptionsCache<TestOptions>), cacheDescriptor.ImplementationType);
+    }
+
+    [Fact]
+    public void DecorateImplementationTypeInstanceAndFactoryRegistrations()
+    {
+        var services = new ServiceCollection();
+        var instance = new TestService();
+        services.AddSingleton<ITestService, TestService>();
+        services.AddSingleton<ITestService>(instance);
+        services.AddSingleton<ITestService>(_ => new TestService());
+
+        Assert.True(services.DecorateService<ITestService, DecoratedTestService>());
+
+        using var provider = services.BuildServiceProvider();
+        var decorated = provider.GetServices<ITestService>().Cast<DecoratedTestService>().ToList();
+        Assert.Equal(3, decorated.Count);
+        Assert.All(decorated, service => Assert.IsType<TestService>(service.Inner));
+        Assert.Same(instance, decorated[1].Inner);
+    }
+
+    [Fact]
+    public void PreserveRegistrationOrderAndStackDecorators()
+    {
+        var services = new ServiceCollection();
+        var first = new TestService();
+        var second = new TestService();
+        services.AddSingleton<IOtherService, OtherService>();
+        services.AddSingleton<ITestService>(first);
+        services.AddSingleton<IOtherService, OtherService>();
+        services.AddSingleton<ITestService>(second);
+        var serviceTypesBefore = services.Select(s => s.ServiceType).ToArray();
+
+        services.DecorateService<ITestService, DecoratedTestService>();
+        services.DecorateService<ITestService, SecondDecoratedTestService>();
+
+        Assert.Equal(serviceTypesBefore, services.Select(s => s.ServiceType).ToArray());
+        using var provider = services.BuildServiceProvider();
+        var outer = Assert.IsType<SecondDecoratedTestService>(provider.GetRequiredService<ITestService>());
+        var inner = Assert.IsType<DecoratedTestService>(outer.Inner);
+        Assert.Same(second, inner.Inner);
+    }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void LeaveKeyedRegistrationsUntouched()
+    {
+        var services = new ServiceCollection();
+        var unkeyed = new TestService();
+        services.AddKeyedSingleton<ITestService, TestService>("key");
+        services.AddSingleton<ITestService>(unkeyed);
+
+        services.DecorateService<ITestService, DecoratedTestService>();
+
+        using var provider = services.BuildServiceProvider();
+        var decorated = Assert.IsType<DecoratedTestService>(provider.GetRequiredService<ITestService>());
+        Assert.Same(unkeyed, decorated.Inner);
+        Assert.IsType<TestService>(provider.GetKeyedService<ITestService>("key"));
+    }
+#endif
+
+    [Fact]
+    public void RejectInvalidDecoratorArgumentsBeforeChangingRegistrations()
     {
         var services = new ServiceCollection();
         services.AddSingleton<ITestService, TestService>();
-        bool result = services.DecorateService<ITestService, DecoratedTestService>();
-        Assert.True(result);
-        var provider = services.BuildServiceProvider();
-        var service = provider.GetRequiredService<ITestService>();
-        Assert.IsType<DecoratedTestService>(service);
-        Assert.IsType<TestService>(((DecoratedTestService)service).Inner);
+        var serviceCount = services.Count;
+
+        Assert.Throws<ArgumentException>(() => services.DecorateService<ITestService, IncompatibleDecorator>());
+        Assert.Equal(serviceCount, services.Count);
+        Assert.Equal(typeof(TestService), services.Single().ImplementationType);
+        Assert.Throws<ArgumentNullException>(() =>
+            FinbuckleServiceCollectionExtensions.DecorateService<ITestService, DecoratedTestService>(
+                null!, Array.Empty<object>()));
+        Assert.Throws<ArgumentNullException>(() =>
+            FinbuckleServiceCollectionExtensions.DecorateService<ITestService, DecoratedTestService>(
+                services, (object[])null!));
     }
 
-    [Fact]
-    public void DecorateService_WithImplementationInstance_WrapsService()
+    private sealed class CustomOptionsSnapshot : IOptionsSnapshot<TestOptions>
     {
-        var instance = new TestService();
-        var services = new ServiceCollection();
-        services.AddSingleton<ITestService>(instance);
-        bool result = services.DecorateService<ITestService, DecoratedTestService>();
-        Assert.True(result);
-        var provider = services.BuildServiceProvider();
-        var service = provider.GetRequiredService<ITestService>();
-        Assert.IsType<DecoratedTestService>(service);
-        Assert.Same(instance, ((DecoratedTestService)service).Inner);
+        public TestOptions Value { get; } = new();
+        public TestOptions Get(string? name) => Value;
     }
 
-    [Fact]
-    public void DecorateService_WithImplementationFactory_WrapsService()
+    public interface ITestService
     {
-        var services = new ServiceCollection();
-        services.AddSingleton<ITestService>(sp => new TestService());
-        bool result = services.DecorateService<ITestService, DecoratedTestService>();
-        Assert.True(result);
-        var provider = services.BuildServiceProvider();
-        var service = provider.GetRequiredService<ITestService>();
-        Assert.IsType<DecoratedTestService>(service);
-        Assert.IsType<TestService>(((DecoratedTestService)service).Inner);
     }
 
-    [Fact]
-    public void DecorateService_ThrowsIfNoServiceFound()
+    public sealed class TestService : ITestService
     {
-        var services = new ServiceCollection();
-        Assert.Throws<ArgumentException>(() => services.DecorateService<ITestService, DecoratedTestService>());
     }
 
-    [Fact]
-    public void DecorateService_WrapsAllServicesOfSameType()
-    {
-        var services = new ServiceCollection();
-        var instance1 = new TestService();
-        var instance2 = new TestService();
-        services.AddSingleton<ITestService>(instance1);
-        services.AddSingleton<ITestService>(instance2);
-        bool result = services.DecorateService<ITestService, DecoratedTestService>();
-        Assert.True(result);
-        var provider = services.BuildServiceProvider();
-        var all = provider.GetServices<ITestService>().ToList();
-        Assert.Equal(2, all.Count);
-        Assert.All(all, s => Assert.IsType<DecoratedTestService>(s));
-        var inners = all.Cast<DecoratedTestService>().Select(d => d.Inner).ToList();
-        Assert.Contains(instance1, inners);
-        Assert.Contains(instance2, inners);
-    }
-
-    public interface ITestService { }
-    public class TestService : ITestService { }
-    public class DecoratedTestService : ITestService
+    public sealed class DecoratedTestService : ITestService
     {
         public ITestService Inner { get; }
         public DecoratedTestService(ITestService inner) => Inner = inner;
+    }
+    public sealed class SecondDecoratedTestService : ITestService
+    {
+        public ITestService Inner { get; }
+        public SecondDecoratedTestService(ITestService inner) => Inner = inner;
+    }
+
+    public sealed class IncompatibleDecorator
+    {
+        public IncompatibleDecorator(ITestService inner)
+        {
+        }
+    }
+
+    public interface IOtherService
+    {
+    }
+
+    public sealed class OtherService : IOtherService
+    {
     }
 }

--- a/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsCacheShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/MultiTenantOptionsCacheShould.cs
@@ -1,12 +1,8 @@
 // Copyright Finbuckle LLC, Andrew White, and Contributors.
 // Refer to the solution LICENSE file for more information.
 
-using System.Collections.Concurrent;
-using System.ComponentModel.DataAnnotations;
-using System.Reflection;
 using Finbuckle.MultiTenant.Internal;
 using Finbuckle.MultiTenant.Options;
-using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Finbuckle.MultiTenant.Test.Options;
@@ -15,280 +11,154 @@ public class MultiTenantOptionsCacheShould
 {
     internal class TestOptions
     {
-        [Required]
-        public string? DefaultConnectionString { get; set; }
-    }
-        
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("name")]
-    public void AddNamedOptionsForCurrentTenantOnlyOnAdd(string? name)
-    {
-        var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
-
-        var options = new TestOptions();
-
-        // Add new options.
-        var result = cache.TryAdd(name, options);
-        Assert.True(result);
-
-        // Fail adding options under same name.
-        result = cache.TryAdd(name, options);
-        Assert.False(result);
-
-        // Change the tenant id and confirm options can be added again.
-        ti.Id = "diff_id";
-        result = cache.TryAdd(name, options);
-        Assert.True(result);
+        public string? Value { get; set; }
     }
 
-    [Fact]
-    public void HandleNullMultiTenantContextOnAdd()
+    private static (MultiTenantOptionsCache<TestOptions> Cache,
+        AsyncLocalMultiTenantContextAccessor<TenantInfo> Accessor) CreateCache()
     {
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
-
-        var options = new TestOptions();
-
-        // Add new options, ensure no exception caused by null MultiTenantContext.
-        var result = cache.TryAdd("", options);
-        Assert.True(result);
+        var accessor = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
+        return (new MultiTenantOptionsCache<TestOptions>(accessor), accessor);
     }
 
-    [Fact]
-    public void HandleNullMultiTenantContextOnGetOrAdd()
+    private static void SetTenant(AsyncLocalMultiTenantContextAccessor<TenantInfo> accessor, string tenantId)
     {
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
-
-        var options = new TestOptions();
-
-        // Add new options, ensure no exception caused by null MultiTenantContext.
-        var result = cache.GetOrAdd("", () => options);
-        Assert.NotNull(result);
+        accessor.MultiTenantContext = new MultiTenantContext<TenantInfo>
+        {
+            TenantInfo = new TenantInfo { Id = tenantId }
+        };
     }
 
     [Theory]
     [InlineData("")]
     [InlineData(null)]
     [InlineData("name")]
-    public void GetOrAddNamedOptionForCurrentTenantOnly(string? name)
+    public void CacheNamedOptionsForCurrentTenant(string? name)
     {
-        var ti = new TenantInfo { Id = "test-id-123"};
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
+        var (cache, accessor) = CreateCache();
+        SetTenant(accessor, "tenant-1");
+        var tenant1 = new TestOptions();
 
+        Assert.True(cache.TryAdd(name, tenant1));
+        Assert.False(cache.TryAdd(name, new TestOptions()));
+
+        SetTenant(accessor, "tenant-2");
+        var tenant2 = new TestOptions();
+        Assert.True(cache.TryAdd(name, tenant2));
+        Assert.Same(tenant2, cache.GetOrAdd(name, () => new TestOptions()));
+
+        SetTenant(accessor, "tenant-1");
+        Assert.Same(tenant1, cache.GetOrAdd(name, () => new TestOptions()));
+    }
+
+    [Fact]
+    public void CacheOptionsWithoutResolvedTenant()
+    {
+        var (cache, _) = CreateCache();
         var options = new TestOptions();
-        var options2 = new TestOptions();
 
-        // Add new options.
-        var result = cache.GetOrAdd(name, () => options);
-        Assert.Same(options, result);
-
-        // Get the existing options if exists.
-        result = cache.GetOrAdd(name, () => options2);
-        Assert.NotSame(options2, result);
-
-        // Confirm different tenant on same object is an add (ie it didn't exist there).
-        ti.Id = "diff_id";
-        result = cache.GetOrAdd(name, () => options2);
-        Assert.Same(options2, result);
+        Assert.True(cache.TryAdd(null, options));
+        Assert.Same(options, cache.GetOrAdd(null, () => new TestOptions()));
     }
 
     [Fact]
-    public void ThrowsIfGetOrAddFactoryIsNull()
+    public void ThrowForNullConstructorParameterFactoryAndOptions()
     {
-        var tc = new MultiTenantContext<TenantInfo>();
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
-
-        Assert.Throws<ArgumentNullException>(() => cache.GetOrAdd("", null!));
-    }
-
-    [Fact]
-    public void ThrowIfConstructorParamIsNull()
-    {
-        var tc = new MultiTenantContext<TenantInfo>();
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
+        var (cache, _) = CreateCache();
 
         Assert.Throws<ArgumentNullException>(() => new MultiTenantOptionsCache<TestOptions>(null!));
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("name")]
-    public void RemoveNamedOptionsForCurrentTenantOnly(string? name)
-    {
-        var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
-
-        var options = new TestOptions();
-
-        // Add new options.
-        var result = cache.TryAdd(name, options);
-        Assert.True(result);
-
-        // Add under a different tenant.
-        ti.Id = "diff_id";
-        result = cache.TryAdd(name, options);
-        Assert.True(result);
-        result = cache.TryAdd("diffName", options);
-        Assert.True(result);
-
-        // Remove named options for current tenant.
-        result = cache.TryRemove(name);
-        Assert.True(result);
-        var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType().
-            GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.
-            GetValue(cache);
-
-        dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-
-        // Assert named options removed and other options on tenant left as-is.
-        Assert.False(tenantInternalCache!.Keys.Contains(name));
-        Assert.True(tenantInternalCache.Keys.Contains("diffName"));
-
-        // Assert other tenant not affected.
-        ti.Id = "test-id-123";
-        tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.True(tenantInternalCache!.ContainsKey(name ?? Microsoft.Extensions.Options.Options.DefaultName));
+        Assert.Throws<ArgumentNullException>(() => cache.GetOrAdd("name", null!));
+        Assert.Throws<ArgumentNullException>(() => cache.TryAdd("name", null!));
     }
 
     [Fact]
     public void ClearOptionsForCurrentTenantOnly()
     {
-        var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
+        var (cache, accessor) = CreateCache();
+        SetTenant(accessor, "tenant-1");
+        var tenant1 = new TestOptions();
+        cache.TryAdd("name", tenant1);
+        SetTenant(accessor, "tenant-2");
+        var tenant2 = new TestOptions();
+        cache.TryAdd("name", tenant2);
 
-        var options = new TestOptions();
-
-        // Add new options.
-        var result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Add under a different tenant.
-        ti.Id = "diff_id";
-        result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Clear options on first tenant.
-        ti.Id = "test-id-123";
+        SetTenant(accessor, "tenant-1");
         cache.Clear();
 
-        // Assert options cleared on this tenant.
-        var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType().
-            GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.
-            GetValue(cache);
-
-        dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.True(tenantInternalCache!.IsEmpty);
-
-        // Assert options still exist on other tenant.
-        ti.Id = "diff_id";
-        tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.False(tenantInternalCache!.IsEmpty);
+        var replacement = new TestOptions();
+        Assert.Same(replacement, cache.GetOrAdd("name", () => replacement));
+        SetTenant(accessor, "tenant-2");
+        Assert.Same(tenant2, cache.GetOrAdd("name", () => new TestOptions()));
+        Assert.NotSame(tenant1, replacement);
     }
 
     [Fact]
-    public void ClearOptionsForTenantIdOnly()
+    public void ClearOptionsForSpecifiedTenantOnly()
     {
-        var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
+        var (cache, accessor) = CreateCache();
+        SetTenant(accessor, "tenant-1");
+        cache.TryAdd("name", new TestOptions());
+        SetTenant(accessor, "tenant-2");
+        var tenant2 = new TestOptions();
+        cache.TryAdd("name", tenant2);
 
-        var options = new TestOptions();
+        cache.Clear("tenant-1");
 
-        // Add new options.
-        var result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Add under a different tenant.
-        ti.Id = "diff_id";
-        result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Clear options on first tenant.
-        cache.Clear("test-id-123");
-
-        // Assert options cleared on this tenant.
-        var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType().
-            GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.
-            GetValue(cache);
-
-        dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache["test-id-123"]);
-        Assert.True(tenantInternalCache!.IsEmpty);
-
-        // Assert options still exist on other tenant.
-        tenantInternalCache = tenantCache?["diff_id"].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache["diff_id"]);
-        Assert.False(tenantInternalCache!.IsEmpty);
+        SetTenant(accessor, "tenant-1");
+        var replacement = new TestOptions();
+        Assert.Same(replacement, cache.GetOrAdd("name", () => replacement));
+        SetTenant(accessor, "tenant-2");
+        Assert.Same(tenant2, cache.GetOrAdd("name", () => new TestOptions()));
     }
 
     [Fact]
-    public void ClearAllOptionsForClearAll()
+    public void ClearAllOptionsForAllTenants()
     {
-        var ti = new TenantInfo { Id = "test-id-123" };
-        var tc = new MultiTenantContext<TenantInfo>();
-        tc.TenantInfo = ti;
-        var tca = new AsyncLocalMultiTenantContextAccessor<TenantInfo>();
-        tca.MultiTenantContext = tc;
-        var cache = new MultiTenantOptionsCache<TestOptions>(tca);
+        var (cache, accessor) = CreateCache();
+        foreach (var tenantId in new[] { "tenant-1", "tenant-2" })
+        {
+            SetTenant(accessor, tenantId);
+            cache.TryAdd("name", new TestOptions());
+        }
 
-        var options = new TestOptions();
-
-        // Add new options.
-        var result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Add under a different tenant.
-        ti.Id = "diff_id";
-        result = cache.TryAdd("", options);
-        Assert.True(result);
-
-        // Clear all options.
         cache.ClearAll();
 
-        // Assert options cleared on this tenant.
-        var tenantCache = (ConcurrentDictionary<string, IOptionsMonitorCache<TestOptions>>?)cache.GetType().
-            GetField("map", BindingFlags.NonPublic | BindingFlags.Instance)?.
-            GetValue(cache);
+        foreach (var tenantId in new[] { "tenant-1", "tenant-2" })
+        {
+            SetTenant(accessor, tenantId);
+            var replacement = new TestOptions();
+            Assert.Same(replacement, cache.GetOrAdd("name", () => replacement));
+        }
+    }
 
-        dynamic? tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.True(tenantInternalCache!.IsEmpty);
+    [Theory]
+    [InlineData(null)]
+    [InlineData("target")]
+    public void RemoveNamedOptionsForAllTenantsButPreserveOtherNames(string? name)
+    {
+        var (cache, accessor) = CreateCache();
+        var originals = new Dictionary<string, TestOptions>();
+        var others = new Dictionary<string, TestOptions>();
 
-        // Assert options cleared on other tenant.
-        ti.Id = "diff_id";
-        tenantInternalCache = tenantCache?[ti.Id].GetType().GetField("_cache", BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(tenantCache[ti.Id]);
-        Assert.True(tenantInternalCache!.IsEmpty);
+        foreach (var tenantId in new[] { "tenant-1", "tenant-2" })
+        {
+            SetTenant(accessor, tenantId);
+            originals[tenantId] = new TestOptions();
+            others[tenantId] = new TestOptions();
+            cache.TryAdd(name, originals[tenantId]);
+            cache.TryAdd("other", others[tenantId]);
+        }
+
+        Assert.True(cache.TryRemove(name));
+        Assert.False(cache.TryRemove(name));
+
+        foreach (var tenantId in new[] { "tenant-1", "tenant-2" })
+        {
+            SetTenant(accessor, tenantId);
+            var replacement = new TestOptions();
+            Assert.Same(replacement, cache.GetOrAdd(name, () => replacement));
+            Assert.NotSame(originals[tenantId], replacement);
+            Assert.Same(others[tenantId], cache.GetOrAdd("other", () => new TestOptions()));
+        }
     }
 }

--- a/test/Finbuckle.MultiTenant.Test/Options/PerTenantOptionsIntegrationShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Options/PerTenantOptionsIntegrationShould.cs
@@ -1,0 +1,92 @@
+// Copyright Finbuckle LLC, Andrew White, and Contributors.
+// Refer to the solution LICENSE file for more information.
+
+using Finbuckle.MultiTenant.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Finbuckle.MultiTenant.Test.Options;
+
+public class PerTenantOptionsIntegrationShould
+{
+    [Fact]
+    public void ReloadChangedNameForEveryTenantAndPreserveOtherNames()
+    {
+        var services = new ServiceCollection();
+        var state = new ReloadState();
+        var source = new ManualChangeTokenSource<TestOptions>("changed");
+        services.AddMultiTenant<TenantInfo>();
+        services.AddSingleton<IOptionsChangeTokenSource<TestOptions>>(source);
+        services.ConfigurePerTenant<TestOptions, TenantInfo>("changed", (options, tenant) =>
+            options.Value = $"{tenant.Id}:{state.Version}");
+        services.ConfigurePerTenant<TestOptions, TenantInfo>("unchanged", (options, tenant) =>
+            options.Value = $"unchanged:{tenant.Id}");
+
+        using var provider = services.BuildServiceProvider();
+        var monitor = provider.GetRequiredService<IOptionsMonitor<TestOptions>>();
+
+        SetTenant(provider, "tenant-1");
+        var tenant1Changed = monitor.Get("changed");
+        var tenant1Unchanged = monitor.Get("unchanged");
+        SetTenant(provider, "tenant-2");
+        var tenant2Changed = monitor.Get("changed");
+        var tenant2Unchanged = monitor.Get("unchanged");
+
+        state.Version = 2;
+        source.Trigger();
+
+        SetTenant(provider, "tenant-1");
+        var tenant1Reloaded = monitor.Get("changed");
+        Assert.Equal("tenant-1:2", tenant1Reloaded.Value);
+        Assert.NotSame(tenant1Changed, tenant1Reloaded);
+        Assert.Same(tenant1Unchanged, monitor.Get("unchanged"));
+
+        SetTenant(provider, "tenant-2");
+        var tenant2Reloaded = monitor.Get("changed");
+        Assert.Equal("tenant-2:2", tenant2Reloaded.Value);
+        Assert.NotSame(tenant2Changed, tenant2Reloaded);
+        Assert.Same(tenant2Unchanged, monitor.Get("unchanged"));
+    }
+
+    private static void SetTenant(IServiceProvider provider, string tenantId)
+    {
+        var setter = provider.GetRequiredService<IMultiTenantContextSetter>();
+        setter.MultiTenantContext = new MultiTenantContext<TenantInfo>
+        {
+            TenantInfo = new TenantInfo { Id = tenantId, Identifier = tenantId }
+        };
+    }
+
+    public class TestOptions
+    {
+        public string? Value { get; set; }
+    }
+
+    private sealed class ReloadState
+    {
+        public int Version { get; set; } = 1;
+    }
+
+    private sealed class ManualChangeTokenSource<TOptions> : IOptionsChangeTokenSource<TOptions>
+    {
+        private CancellationTokenSource source = new();
+
+        public ManualChangeTokenSource(string? name)
+        {
+            Name = name;
+        }
+
+        public string? Name { get; }
+
+        public IChangeToken GetChangeToken() => new CancellationChangeToken(source.Token);
+
+        public void Trigger()
+        {
+            var previous = Interlocked.Exchange(ref source, new CancellationTokenSource());
+            previous.Cancel();
+            previous.Dispose();
+        }
+    }
+}

--- a/test/Finbuckle.MultiTenant.Test/Stores/InMemoryStoreShould.cs
+++ b/test/Finbuckle.MultiTenant.Test/Stores/InMemoryStoreShould.cs
@@ -54,6 +54,37 @@ public class InMemoryStoreShould : MultiTenantStoreTestBase
     }
 
     [Fact]
+    public async Task MoveIdentifierWhenUpdatingTenant()
+    {
+        var store = CreateTestStore();
+
+        Assert.True(await store.TryUpdateAsync(new TenantInfo { Id = "initech-id", Identifier = "initech2" }));
+        Assert.Null(await store.TryGetByIdentifierAsync("initech"));
+        Assert.Equal("initech2", (await store.TryGetByIdentifierAsync("initech2"))?.Identifier);
+        Assert.Equal("initech2", (await store.TryGetAsync("initech-id"))?.Identifier);
+    }
+
+    [Fact]
+    public async Task RejectIdentifierCollisionWhenUpdatingTenant()
+    {
+        var store = CreateTestStore();
+
+        Assert.False(await store.TryUpdateAsync(new TenantInfo { Id = "initech-id", Identifier = "lol" }));
+        Assert.Equal("initech", (await store.TryGetAsync("initech-id"))?.Identifier);
+        Assert.Equal("lol-id", (await store.TryGetByIdentifierAsync("lol"))?.Id);
+    }
+
+    [Fact]
+    public async Task MoveCaseOnlyIdentifierWhenCaseSensitive()
+    {
+        var store = CreateCaseSensitiveTestStore();
+
+        Assert.True(await store.TryUpdateAsync(new TenantInfo { Id = "initech", Identifier = "INITECH" }));
+        Assert.Null(await store.TryGetByIdentifierAsync("initech"));
+        Assert.Equal("INITECH", (await store.TryGetByIdentifierAsync("INITECH"))?.Identifier);
+    }
+
+    [Fact]
     public async Task FailIfAddingDuplicateCaseSensitive()
     {
         var store = CreateCaseSensitiveTestStore();


### PR DESCRIPTION
## Summary

- keep in-memory identifier lookup consistent when a tenant identifier changes, with collision handling
- return no tenant for remote authentication callbacks that omit state
- invalidate named options across every tenant and replace conflicting closed per-tenant option registrations
- validate null option cache values
- harden service decoration for multiple and keyed registrations, registration order, and invalid decorators

This adapts the behavior from 16dcf33, 4b5ac9f, 8799019, b308761, 2775977, and 15474ff to the v9 APIs and net8.0/net9.0 targets.

## Testing

- DOTNET_ROLL_FORWARD=Major dotnet test Finbuckle.MultiTenant.slnx
- all core, ASP.NET Core, and Entity Framework Core tests pass on net8.0 and net9.0