### PR TITLE
chore: clean up docs

### DIFF
--- a/docs/AspNetCore.md
+++ b/docs/AspNetCore.md
@@ -11,8 +11,8 @@ For most ASP.NET Core apps install the `Finbuckle.MultiTenant.AspNetCore` packag
 dotnet add package Finbuckle.MultiTenant.AspNetCore
 ```
 
-This package depends on `Finbuckle.MultiTenant` and transitively brings in everything needed for
-ASP.NET Core integration, including [ASP.NET Core-specific strategies](#asp.net-core-strategies).
+This package depends on `Finbuckle.MultiTenant` and includes everything needed for ASP.NET Core integration,
+including [ASP.NET Core-specific strategies](#asp.net-core-strategies).
 
 ## Configuring the Middleware
 
@@ -103,7 +103,7 @@ For most cases the middleware sets the `TenantInfo` automatically and this metho
 explicitly overriding the `TenantInfo` set by the middleware.
 
 Sets the current tenant to the provided `TenantInfo`. Optionally resets the service provider scope so that
-any scoped services already resolved will be resolved again under the current tenant. This has no effect on
+any scoped services that have already been resolved will be resolved again under the current tenant. This has no effect on
 singleton or transient services. Setting the `TenantInfo` with this method sets both the `StoreInfo` and
 `StrategyInfo` properties on the `MultiTenantContext<TTenantInfo>` to `null`.
 
@@ -247,7 +247,7 @@ builder.Services.AddMultiTenant<TenantInfo>()
     .WithConfigurationStore()
     .ShortCircuitWhen(config =>
     {
-        config.Predicate = context => context.StrategyInfo is IMyCustomObsoleteStrategy || !context.IsResolved;
+        config.Predicate = context => context.StrategyInfo?.Strategy is IMyCustomObsoleteStrategy || !context.IsResolved;
     });
 
 // Including a redirect.
@@ -256,7 +256,7 @@ builder.Services.AddMultiTenant<TenantInfo>()
     .WithConfigurationStore()
     .ShortCircuitWhen(config =>
     {
-        config.Predicate = context => context.StrategyInfo is IMyCustomObsoleteStrategy || !context.IsResolved;
+        config.Predicate = context => context.StrategyInfo?.Strategy is IMyCustomObsoleteStrategy || !context.IsResolved;
         config.RedirectTo = new Uri("/tenant/notfound", UriKind.Relative);
     });
 ```

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -39,19 +39,19 @@ The following also happens if the `TenantInfo` derived class has the appropriate
 
 - The default challenge scheme is set to the `ChallengeScheme` property
   of the `TenantInfo` derived class.
-- 'LoginPath' for cookie authentication is set to the `CookieLoginPath` property
+- `LoginPath` for cookie authentication is set to the `CookieLoginPath` property
   of the `TenantInfo` derived class.
-- 'LogoutPath' for cookie authentication is set to the `CookieLogoutPath`
+- `LogoutPath` for cookie authentication is set to the `CookieLogoutPath`
   property of the `TenantInfo` derived class.
-- 'AccessDeniedPath' for cookie authentication is set to the
+- `AccessDeniedPath` for cookie authentication is set to the
   `CookieAccessDeniedPath` property of the `TenantInfo` derived class.
 - Several internal services are registered to support remote authentication such
   as OAuth 2.0 and OpenID Connect.
-- `Authority` for OpenID connect authentication is set to the
+- `Authority` for OpenID Connect authentication is set to the
   `OpenIdConnectAuthority` property of the `TenantInfo` derived class.
-- `ClientId` for OpenID connect authentication is set to the
+- `ClientId` for OpenID Connect authentication is set to the
   `OpenIdConnectClientId` property of the `TenantInfo` derived class.
-- `ClientSecret` for OpenID connect authentication is set to the
+- `ClientSecret` for OpenID Connect authentication is set to the
   `OpenIdConnectClientSecret` property of the `TenantInfo` derived class.
 
 If the `TenantInfo` derived class lacks one of these properties there is no
@@ -66,9 +66,9 @@ authentication. This behavior means only a single tenant sign-in can be active.
 See [other authentication options](#other-authentication-options) below if a
 separate sign-in cookie for each tenant is required.
 
-By changing the default challenge per-tenant, the user can be redirected to a
+By changing the default challenge per tenant, users can be redirected to a
 different scheme as needed. Combined with a per-tenant OpenID Connect authority,
-this can route to shared or tenant specific authentication infrastructure.
+this can route to shared or tenant-specific authentication infrastructure.
 
 The `CookieLoginPath`, `CookieLogoutPath`, `CookieAccessDeniedPath`, `OpenIdConnectAuthority`, `OpenIdConnectClientId`
 , `OpenIdConnectClientSecret` properties can use a template format where `__tenant__`
@@ -131,7 +131,6 @@ work.
 {
   "Finbuckle:MultiTenant:Stores:ConfigurationStore": {
     "Defaults": {
-      "ConnectionString": "",
       "CookieLoginPath": "/__tenant__/home/login",
       "CookieLogoutPath": "/__tenant__/home/logout"
     },

--- a/docs/ConfigurationAndUsage.md
+++ b/docs/ConfigurationAndUsage.md
@@ -2,7 +2,7 @@
 
 ## Configuration
 
-MultiTenant uses the standard application builder pattern for its configuration. In addition to adding the
+MultiTenant uses the standard application builder pattern. In addition to registering the
 services, configuration for one or more [MultiTenant Stores](Stores) and [MultiTenant Strategies](Strategies) are
 required. A typical configuration for your ASP.NET Core app might look like this:
 
@@ -32,8 +32,8 @@ app.Run();
 
 Use the `AddMultiTenant<TTenantInfo>` extension method on `IServiceCollection` to register the basic dependencies needed
 by the library. It returns a `MultiTenantBuilder<TTenantInfo>` instance on which the methods below can be called for
-further configuration. Each of these methods returns the same `MultiTenantBuilder<TTenantInfo>` instance allowing for
-chaining method calls.
+further configuration. Each method returns the same `MultiTenantBuilder<TTenantInfo>` instance, so calls can be
+chained.
 
 ## Configuring the Service
 
@@ -52,8 +52,8 @@ See [MultiTenant Stores](Stores) for more information on each type.
 
 ### WithStrategy Variants
 
-Adds and configures an `IMultiTenantStrategy` for your app. Multiple strategies can be configured and each will be used
-in the order registered. See [MultiTenant Strategies](Strategies) for more information on each type.
+Adds and configures an `IMultiTenantStrategy` for your app. Multiple strategies can be configured and are tried in
+registration order. See [MultiTenant Strategies](Strategies) for more information on each type.
 
 - `WithStrategy<TStrategy>`
 - `WithBasePathStrategy`
@@ -85,17 +85,16 @@ lets apps customize options distinctly for each tenant. See [Per-Tenant Options]
 
 MultiTenant will perform tenant resolution using the context, strategies, and stores as configured.
 
-The context will depend on the type of app. For an ASP.NET Core web app the context is the `HttpContext` for each
-request and a tenant will be resolved for each request. For other types of apps the context will be different. For
+The context depends on the type of app. For an ASP.NET Core web app, the context is the `HttpContext` and a tenant is
+resolved for each request. For other app types, the context will differ. For
 example, a console app might resolve the tenant once at startup or a background service monitoring a queue might resolve
 the tenant for each message it receives.
 
-Tenant resolution is performed by the `TenantResolver` class. The class requires a list of strategies and a list of
-stores as well as some options. The class will try each strategy generally in the order added, but static and per-tenant
-authentication strategies will run at a lower priority. If a strategy returns a tenant identifier then each store will
-be queried in the order they were added. The first store to return a `TenantInfo`
-object will determine the resolved tenant. If no store returns a `TenantInfo` object then the next strategy will be
-tried and so on. The `UseMultiTenant` middleware for ASP.NET Core uses `TenantResolver`
+Tenant resolution is performed by the `TenantResolver` class. It requires a list of strategies, a list of stores, and
+options. It generally tries strategies in the order added, although static and per-tenant authentication strategies run
+at a lower priority. When a strategy returns a tenant identifier, each store is queried in registration order. The first
+store to return a `TenantInfo` determines the resolved tenant. If no store returns a `TenantInfo`, the resolver tries
+the next strategy. The `UseMultiTenant` middleware for ASP.NET Core uses `TenantResolver`
 internally.
 
 The `TenantResolver` options are configured in the `AddMultiTenant<TTenantInfo>` method with the following properties:
@@ -121,8 +120,8 @@ There are several ways your app can read the current tenant:
 
 `IMultiTenantContextAccessor<TTenantInfo>` (and its non-generic variant `IMultiTenantContextAccessor`) are available
 via dependency injection and behave similarly to `IHttpContextAccessor`. Internally an `AsyncLocal<T>` is used to track
-state. Note that in parent async contexts any changes in tenant will not be reflected — for example, the accessor will
-not reflect a tenant in the post-endpoint processing of ASP.NET Core middleware registered prior to `UseMultiTenant`.
+state. Changes made in a child async context do not flow back to its parent. For example, the accessor will not reflect
+a tenant during post-endpoint processing in ASP.NET Core middleware registered before `UseMultiTenant`.
 Use the `HttpContext` extension `GetMultiTenantContext<TTenantInfo>` to avoid this caveat.
 
 > Prior versions of MultiTenant also exposed `IMultiTenantContext`, `TenantInfo`, and their implementations

--- a/docs/CoreConcepts.md
+++ b/docs/CoreConcepts.md
@@ -1,24 +1,24 @@
 # Core Concepts
 
-The library uses standard .NET Core conventions and most of the internal details are abstracted away from app code.
+The library uses standard .NET conventions, and most internal details are abstracted away from app code.
 However, there are a few important specifics to be aware of. The items below make up the foundation of the library.
 
 ## `ITenantInfo` and `TenantInfo`
 
-A `TenantInfo` instance contains information about a tenant. Often this will be the "current" tenant in the context of
-an app. The type of these instances must implement `ITenantInfo`, which defines properties
-for `Id` and `Identifier`. `TenantInfo` is a basic implementation provided by the library which also includes a `Name` property.
+A `TenantInfo` instance contains information about a tenant, often the current tenant for an app. The type must implement
+`ITenantInfo`, which defines `Id` and `Identifier`. The library provides `TenantInfo`, a basic implementation that also
+includes `Name`.
 
-When calling `AddMultiTenant<TTenantInfo>` the type passed into the
-type parameter defines the `ITenantInfo` implementation used throughout the library and app.
+When calling `AddMultiTenant<TTenantInfo>`, the type parameter defines the `ITenantInfo` implementation used throughout
+the library and app.
 
 * `Id` is a unique id for a tenant in your app and should never change.
-* `Identifier` is the value used to actually resolve a tenant and should have a syntax compatible for your app (i.e. no
-  crazy symbols in a web app where the identifier will be part of the URL). Unlike `Id`, `Identifier` can be changed if
+* `Identifier` is the value used to resolve a tenant and should use a syntax appropriate for your app (for example, URL-safe
+  characters when it is part of a web address). Unlike `Id`, `Identifier` can be changed if
   necessary.
 
-The library provides `TenantInfo` as a base implementation. Your app can and should define a custom class implementing `ITenantInfo` (or inheriting from `TenantInfo`) and add custom 
-properties as needed. It is recommended to keep these
+The library provides `TenantInfo` as a base implementation. Your app can define a custom class that implements
+`ITenantInfo` or inherits from `TenantInfo`, adding properties as needed. Keep these
 classes lightweight since they are often queried. Keep heavier associated data in an external area that can be pulled in
 when needed via the tenant `Id`.
 

--- a/docs/EFCore.md
+++ b/docs/EFCore.md
@@ -4,7 +4,7 @@
 
 Data isolation is one of the most important considerations in a multi-tenant app. Whether each tenant has its own
 database, a shared database, or a hybrid approach can make a significant difference in app design. MultiTenant
-supports each of these models by associating a connection string with each tenant.
+supports each of these models through per-tenant connection strings and shared-database query filtering.
 
 ## Separate Databases
 
@@ -13,28 +13,25 @@ implementation and use it in the `OnConfiguring` method of the database context 
 by injecting an `IMultiTenantContextAccessor<TTenantInfo>` into the database context class constructor.
 
 ```csharp
-public class AppTenantInfo : ITenantInfo
+public class AppTenantInfo : TenantInfo
 {
-    public required string Id { get; init; }
-    public required string Identifier { get; init; }
-    public string? Name { get; init; }
     public string? ConnectionString { get; init; }
 }
 
 public class MyAppDbContext : DbContext
 {
-   private AppTenantInfo? TenantInfo { get; set; }
+   private AppTenantInfo? _tenantInfo;
 
    public MyAppDbContext(IMultiTenantContextAccessor<AppTenantInfo> multiTenantContextAccessor)
    {
        // get the current tenant info at the time of construction
-       TenantInfo = multiTenantContextAccessor.MultiTenantContext.TenantInfo;
+       _tenantInfo = multiTenantContextAccessor.MultiTenantContext.TenantInfo;
    } 
 
    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
    {
        // use the connection string to connect to the per-tenant database
-       optionsBuilder.UseSqlServer(TenantInfo?.ConnectionString);
+       optionsBuilder.UseSqlServer(_tenantInfo?.ConnectionString);
    }
    ...
 }
@@ -66,7 +63,7 @@ flexibility. These approaches are both explained in detail further below.
 ## Hybrid Per-tenant and Shared Databases
 
 When using a shared database context based on `IMultiTenantDbContext`, it is simple to extend into a hybrid approach by
-assigning some tenants to a separate shared database (or its own completely isolated database) via a tenant info
+assigning some tenants to a separate database (or their own completely isolated databases) via a tenant info
 connection string property as described above in [separate databases](#separate-databases).
 
 ## Configuring and Using a Shared Database
@@ -145,8 +142,8 @@ protected override void OnModelCreating(ModelBuilder builder)
 This approach is more flexible than using the `[MultiTenant]` attribute because it can be used for types which do not
 have the attribute, e.g. from another assembly.
 
-`IsMultiTenant()` returns a `MultiTenantEntityTypeBuilder` instance which enables further multi-tenant configuration of
-the entity type via `AdjustKey`,`AdjustIndex`, `AdjustIndexes`, and `AdjustUniqueIndexes`. See [Keys and Indexes](#keys-and-indexes) for
+`IsMultiTenant()` returns a `MultiTenantEntityTypeBuilder` instance that enables further multi-tenant configuration of
+the entity type through `AdjustKey`, `AdjustIndex`, `AdjustIndexes`, and `AdjustUniqueIndexes`. See [Keys and Indexes](#keys-and-indexes) for
 more details.
 
 ### Excluding Entities from Multi-Tenancy
@@ -276,7 +273,7 @@ Start by adding the `Finbuckle.MultiTenant.EntityFrameworkCore` package to the p
 dotnet add package Finbuckle.MultiTenant.EntityFrameworkCore
 ```
 
-The `MultiTenantDbContext` has two constructors which should be called from any derived database context. Make sure to
+`MultiTenantDbContext` provides constructors that should be called from any derived database context. Make sure to
 forward the `IMultiTenantContextAccessor` and, if applicable the `DbContextOptions<T>` into the base constructor.
 
 ```csharp
@@ -314,7 +311,7 @@ doing so will make it difficult to ensure data isolation and consistency.
 ## Dependency Injection Instantiation
 
 For many cases, such as typical ASP.NET Core apps, normal dependency injection registration of a database context is
-sufficient. The `AddDbContext` will register the context as a service and provide the necessary dependencies. Injected
+sufficient. `AddDbContext` registers the context as a service and provides the necessary dependencies. Injected
 instances will automatically be associated with the current tenant.
 
 When registering the database context as a service for use with dependency injection it is important to take into
@@ -370,9 +367,9 @@ variable. This factory supplies an `IMultiTenantContextAccessor` to the database
 Given that a multi-tenant database context usually requires a tenant to function, design time instantiation can be
 challenging. By default, for things like migrations and command line tools Entity Framework core attempts to create an
 instance of the context using dependency injection, however usually no valid tenant exists in these cases and DI fails.
-For this reason it is recommended to use
-a [design time factory](https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dbcontext-creation#from-a-design-time-factory)
-passes a dummy `TenantInfo` with the desired connection string to the database context creation factory
+For this reason, it is recommended to use
+a [design-time factory](https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dbcontext-creation#from-a-design-time-factory)
+that passes a dummy `TenantInfo` with the desired connection string to the database context creation factory
 as described above.
 
 ## Adding Data
@@ -388,7 +385,7 @@ altered by changing the values of [TenantMismatchMode](#tenant-mismatch-mode) an
 > [EF Core Tracking](#ef-core-tracking) for more details.
 
 ```csharp
-Blog  myBlog = new Blog{ TenantId = "1", Title = "My Blog" };
+var myBlog = new Blog { TenantId = "1", Title = "My Blog" };
 
 // Add the blog to a db context for a tenant.
 var myTenantInfo = new TenantInfo { Id = "1", Identifier = "tenant-1" };
@@ -447,7 +444,7 @@ This behavior can be altered by changing the values of [TenantMismatchMode](#ten
 
 ```csharp
 // Add a blog for a tenant.
-Blog  myBlog = new Blog{ TenantId = "1", Title = "My Blog" };
+var myBlog = new Blog { TenantId = "1", Title = "My Blog" };
 var myTenantInfo = new TenantInfo { Id = "1", Identifier = "tenant-1" };
 var myDbContext = MultiTenantDbContext.Create<BloggingDbContext, TenantInfo>(myTenantInfo);
 myDbContext.Blogs.Add(myBlog);
@@ -475,7 +472,7 @@ When configuring a multi-tenant entity type it is often useful to include the im
 key and/or indexes. The `MultiTenantEntityTypeBuilder` instance returned from `IsMultiTenant()` provides the following
 methods for this purpose:
 
-* `AdjustKey(IMutableKey, ModelBuilder)` - Alters the existing defined key to add the implicit `TenantId`. Note that
+* `AdjustKey(IMutableKey, ModelBuilder)` - Alters the existing key to add the implicit `TenantId`. Note that
   this will also impact entities with a dependent foreign key and may add an implicit `TenantId` there as well. 
   This will also require the use of `EnforceMultiTenantOnTracking` as described below in [EF Core Tracking](#ef-core-tracking).
 ```csharp
@@ -488,7 +485,7 @@ protected override void OnModelCreating(ModelBuilder builder)
 ```
 * `AdjustIndex(IMutableIndex)` - Alters an existing index to include the implicit `TenantId`.
 * `AdjustIndexes()` - Alters all existing indexes to include the implicit `TenantId`.
-* `AdjustUniqueIndexes()` - Alters only all existing unique indexes to include the implicit `TenantId`.
+* `AdjustUniqueIndexes()` - Alters all existing unique indexes to include the implicit `TenantId`.
 
 ## EF Core Tracking
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -15,7 +15,7 @@ dotnet add package Finbuckle.MultiTenant.AspNetCore
 
 ## Basic Configuration
 
-MultiTenant is simple to get started with. Below is a sample app configured to use the subdomain as the tenant
+MultiTenant is quick to set up. The following sample app uses the subdomain as the tenant
 identifier and the app's [configuration](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/) (
 most likely from an `appsettings.json` file) as the source of tenant details.
 
@@ -41,22 +41,22 @@ app.UseMultiTenant();
 app.Run();
 ```
 
-That's all that is needed to get going. Let's break down each line:
+That is all that is needed to get started. Here is what each part does:
 
 `builder.Services.AddMultiTenant<TenantInfo>()`
 
 This line registers the base services and designates `TenantInfo` as the class that will hold tenant information at
 runtime.
 
-The type parameter for `AddMultiTenant<TTenantInfo>` must implement `ITenantInfo` and holds
-basic information about the tenant such as its id and an identifier. `TenantInfo` is provided as a basic
-implementation class, but any implementation of `ITenantInfo` can be used if more properties are needed.
+The type parameter for `AddMultiTenant<TTenantInfo>` must implement `ITenantInfo`. It holds
+basic tenant information such as an ID and identifier. `TenantInfo` is the provided basic
+implementation, but you can use any `ITenantInfo` implementation when you need additional properties.
 
 See [Core Concepts](CoreConcepts) for more information on `TenantInfo`.
 
 `.WithHostStrategy()`
 
-The line tells the app that our "strategy" to determine the request tenant will be to look at the request host, which
+This tells the app to use the request host as its tenant-resolution strategy, which
 defaults to extracting the subdomain as a tenant identifier.
 
 See [Strategies](Strategies) for more information.
@@ -96,13 +96,13 @@ settings. Be sure to call it before other middleware which will use per-tenant f
 
 ## Basic Usage
 
-With the services and middleware configured, access information for the current tenant from the `TenantInfo` property on
-the `MultiTenantContext<TTenantInfo>` object accessed from the `GetMultiTenantContext<TTenantInfo>` extension method:
+With the services and middleware configured, use the `GetMultiTenantContext<TTenantInfo>` extension method to access the
+current tenant's `TenantInfo`:
 
 ```csharp
 var tenantInfo = HttpContext.GetMultiTenantContext<TenantInfo>().TenantInfo;
 
-if(tenantInfo != null)
+if (tenantInfo != null)
 {
     var tenantId = tenantInfo.Id;
     var identifier = tenantInfo.Identifier;
@@ -113,8 +113,8 @@ if(tenantInfo != null)
 The type of the `TenantInfo` property depends on the type passed when calling `AddMultiTenant<TTenantInfo>` during
 configuration. If the current tenant could not be determined then `TenantInfo` will be null.
 
-The `TenantInfo` instance and the typed instance are also available using the
-`IMultiTenantContextAccessor<TTenantInfo>` interface which is available via dependency injection.
+The multi-tenant context and its typed `TenantInfo` are also available through the
+`IMultiTenantContextAccessor<TTenantInfo>` interface via dependency injection.
 
 See [Configuration and Usage](ConfigurationAndUsage) for more information.
 

--- a/docs/Identity.md
+++ b/docs/Identity.md
@@ -21,7 +21,7 @@ from `IdentityDbContext`) and configure Identity to use the derived context.
 If for some reason you do not want an Identity entity to be multi-tenant you can override the behavior by
 calling the `IsNotMultiTenant` extension method in `OnModelCreating` after calling the base class method.
 
-If not deriving from `MultiTenantIdentityDbContext` make sure to implement `IMultiTenantDbContext` and call the
+If not deriving from `MultiTenantIdentityDbContext`, make sure to implement `IMultiTenantDbContext` and call the
 appropriate extension methods as described in [Data Isolation with Entity Framework Core](EFCore). In this case it is
 required that base class `OnModelCreating` method is called **before** any multi-tenant extension methods.
 
@@ -114,6 +114,6 @@ Deriving from
 will use all provided parameters. All entity types will be configured as multi-tenant, and `TUserPasskey` is configured
 only when the Identity schema version is set to 3.
 
-When providing non-default parameters it is recommended that the provided entity types have the `[MultiTenant]`
-attribute or call the `IsMultiTenant` builder extension method for each type in `OnModelCreating` **after** calling the
-base class `OnModelCreating`.
+When providing non-default parameters, the `MultiTenantIdentityDbContext` variants configure the supplied Identity
+entity types as multi-tenant by default. Use `[MultiTenant]` or `IsMultiTenant` only when configuring entities outside
+the supplied Identity types.

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -3,7 +3,7 @@
 > This functionality is included in the `Finbuckle.MultiTenant` package.
 
 MultiTenant is designed to emphasize using per-tenant options in your app to drive per-tenant behavior. This
-approach allows your app logic to be written without having to add tenant-dependent or tenant-specific logic directly to the code.
+approach lets you write app logic without adding tenant-specific branching directly to the code.
 
 By using per-tenant options, the options values used within app logic will automatically
 reflect the per-tenant values as configured for the current tenant. Any code already using the Options pattern will gain
@@ -100,9 +100,9 @@ See [Getting Started](GettingStarted) for details.
 
 Make sure your project references the `Finbuckle.MultiTenant` package.
 
-To configure options per tenant, the standard `Configure` method variants on the service collection now all
-have `PerTenant` equivalents which accept a `Action<TOptions, TTenantInfo>` delegate. When the options are created at
-runtime the delegate will be called with the current tenant details.
+To configure options per tenant, the standard `Configure` method variants on the service collection have `PerTenant`
+equivalents that accept an `Action<TOptions, TTenantInfo>` delegate. When options are created at runtime, the delegate
+is called with the current tenant details.
 
 ```csharp
 using Finbuckle.MultiTenant.Extensions;
@@ -177,7 +177,7 @@ normally supports up to five dependencies, MultiTenant support only supports fou
 builder.Services.AddOptions<MyOptions>("optionalName")
     .ConfigurePerTenant<ExampleService, AppTenantInfo>(
         (options, es, tenantInfo) =>
-            options.Property = DoSomethingWith(es, tenantInfo));
+            options.Option1 = DoSomethingWith(es, tenantInfo));
 ```
 
 ## Options and Caching

--- a/docs/Stores.md
+++ b/docs/Stores.md
@@ -9,8 +9,8 @@ implementing `IMultiTenantStore`.
 
 ## Custom TenantInfo Support
 
-MultiTenant stores support custom `ITenantInfo` implementations, but complex implementations may require special
-handling. For best results ensure the class works well with the underlying store approach—for example, that it can be
+MultiTenant stores support custom `ITenantInfo` implementations, but complex types may require special
+handling. For best results, ensure the type works well with the underlying store approach—for example, that it can be
 serialized from JSON for the configuration store if using JSON file configuration sources.
 
 The examples in this documentation use the `TenantInfo` basic implementation.
@@ -37,7 +37,7 @@ decorates any `IMultiTenantStore<TTenantInfo>` at runtime with a wrapper providi
 builder.Services.AddMultiTenant<TenantInfo>()
     .WithStore<MyStore>(ServiceLifetime.Singleton, myParam1, myParam2)...
 
-// or register a custom store with the non-templated method which accepts a factory method
+// or register a custom store with the non-generic method, which accepts a factory method
 builder.Services.AddMultiTenant<TenantInfo>()
     .WithStore(ServiceLifetime.Singleton, sp => new MyStore())...
 ```
@@ -66,7 +66,7 @@ public MyService(IEnumerable<IMultiTenantStore<TenantInfo>> stores)
 ## Getting All Tenants from Store
 
 If implemented, `GetAllAsync` will return an `IEnumerable<TTenantInfo>` listing of all tenants in the store.
-Currently `InMemoryStore`, `ConfigurationStore`, and `EFCoreStore` implement `GetAllAsync`.
+Currently `InMemoryStore`, `ConfigurationStore`, `EFCoreStore`, and `HttpRemoteStore` implement `GetAllAsync`.
 
 ### Pagination of GetAllAsync
 
@@ -90,14 +90,13 @@ of `WithInMemoryStore` accepts an `Action<InMemoryStoreOptions>` delegate to con
 builder.Services.AddMultiTenant<TenantInfo>()
     .WithInMemoryStore()...
 
-// or make it case sensitive and/or add some tenants.
+// or make it case-sensitive and add tenants.
 builder.Services.AddMultiTenant<TenantInfo>()
     .WithInMemoryStore(options =>
     {
         options.IsCaseSensitive = true;
-        options.Tenants.Add(new TenantInfo{...});
-        options.Tenants.Add(new TenantInfo{...});
-        options.Tenants.Add(new TenantInfo{...});
+        options.Tenants.Add(new TenantInfo { Id = "1", Identifier = "initech" });
+        options.Tenants.Add(new TenantInfo { Id = "2", Identifier = "acme" });
     })...
 ```
 
@@ -134,7 +133,7 @@ builder.Services.AddMultiTenant<TenantInfo>()
 
 The configuration section should use this JSON format shown below. Any fields in the `Defaults` section will be
 automatically copied into each tenant unless the tenant specifies its own value. For a custom implementation
-of `TenantInfo` properties are mapped from the JSON automatically.
+of `TenantInfo`, its properties are mapped from the JSON automatically.
 
 ```json
 {
@@ -188,14 +187,14 @@ builder.Services.AddMultiTenant<TenantInfo>()
 
 > NuGet package: Finbuckle.MultiTenant
 
-Sends the tenant identifier, provided by the multitenant strategy, to an http(s) endpoint to get a `TenantInfo` object
+Sends the tenant identifier, provided by the multi-tenant strategy, to an HTTP(S) endpoint to get a `TenantInfo` object
 in return.
 
 This store is usually case-insensitive when retrieving tenant information by tenant identifier, but the remote server
 might be more restrictive.
 
 Make sure the tenant info type will support basic JSON serialization and deserialization via `System.Text.Json`.
-This strategy will attempt to deserialize the tenant using
+This store attempts to deserialize the tenant using
 the [System.Text.Json web defaults](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-configure-options?pivots=dotnet-6-0#web-defaults-for-jsonserializeroptions).
 
 For a successful request, the store expects a 2xx response code and a JSON body with properties `Id`, `Identifier`,
@@ -204,11 +203,11 @@ passed to `AddMultiTenant<TTenantInfo>`.
 
 Any non-2xx response code results in a null `TenantInfo`.
 
-This store is read-only and calls to `AddAsync`, `UpdateAsync`, and `RemoveAsync` will throw
-a `NotImplementedException`.
+This store is read-only. `AddAsync`, `GetAsync`, `UpdateAsync`, and `RemoveAsync` throw a
+`NotImplementedException`.
 
 Configure by calling `WithHttpRemoteStore` after `AddMultiTenant<TTenantInfo>`. A URI template string must be passed to the
-method. At runtime the tenant identifier will replace the substring `{__tenant__}` in the uri template. If the template
+method. At runtime the tenant identifier replaces the substring `{__tenant__}` in the URI template. If the template
 provided does not contain `{__tenant__}`, the identifier is appended to the template. An overload
 of `WithHttpRemoteStore` allows for a lambda function to further configure the internal `HttpClient`:
 
@@ -250,7 +249,7 @@ Uses the [distributed cache](https://docs.microsoft.com/en-us/aspnet/core/perfor
 mechanism. The distributed cache can use Redis, SQL Server, NCache, or an in-memory (for testing purposes)
 implementation. A sliding expiration is also supported. The store does not interact with any other stores by default.
 Make sure the tenant info type will support basic JSON serialization and deserialization via `System.Text.Json`.
-This strategy will attempt to deserialize the tenant using
+This store attempts to deserialize the tenant using
 the [System.Text.Json web defaults](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-configure-options?pivots=dotnet-6-0#web-defaults-for-jsonserializeroptions).
 
 Each tenant info instance is actually stored twice in the cache, once using the Tenant ID as the key and another using
@@ -283,8 +282,8 @@ without any additional settings. It's particularly suited for applications that 
 tenant identification without the need for persistence, such as during testing phases or in environments where tenant
 information is static and predefined elsewhere.
 
-This store is read-only and calls to `AddAsync`, `UpdateAsync`, and `RemoveAsync` will throw
-a `NotImplementedException`. Because no stores are saved, a call to `GetAllAsync` will also throw an Exception.
+This store is read-only. `AddAsync`, `UpdateAsync`, `RemoveAsync`, and `GetAllAsync` throw a
+`NotImplementedException`.
 
 Configure by calling `WithEchoStore` after `AddMultiTenant<TTenantInfo>`.
 

--- a/docs/Strategies.md
+++ b/docs/Strategies.md
@@ -4,7 +4,7 @@ A multi-tenant strategy is responsible for defining how the tenant is determined
 string which is used to resolve an `ITenantInfo` object with information from the [MultiTenant store](Stores).
 
 MultiTenant supports several "out-of-the-box" strategies for resolving the tenant. Custom strategies can be
-created by implementing `IMultiTenantStrategy` or using `DelegateStrategy`.
+created by implementing `IMultiTenantStrategy` or using a delegate strategy.
 
 > Not sure which one to pick? As a rule of thumb:
 > 
@@ -41,8 +41,8 @@ builder.Services.AddMultiTenant<TenantInfo>()
 
 ## Using Multiple Strategies
 
-Multiple strategies can be registered after `AddMultiTenant<TTenantInfo>` and each strategy will be tried in the order
-configured until a non-null identifier is returned and any remaining strategies are skipped.
+Multiple strategies can be registered after `AddMultiTenant<TTenantInfo>`. They are tried in registration order. When a
+strategy returns an identifier, the configured stores are queried; if none resolves a tenant, the next strategy is tried.
 
 Most out-of-the-box strategies are registered as singleton services so configuring them multiple times
 after `AddMultiTenant<TTenantInfo>` is not recommended. The main use for configuring multiple strategies of the same
@@ -68,7 +68,7 @@ builder.Services.AddMultiTenant<TenantInfo>()
 > NuGet package: Finbuckle.MultiTenant
 
 Uses a provided `Func<object, Task<string?>>` to determine the tenant. For example, the lambda
-function `async context => "initech"` would use "initech" as the identifier when resolving the tenant for every request.
+`context => Task.FromResult<string?>("initech")` uses "initech" as the identifier for every request.
 This strategy is good to use for testing or simple logic. This strategy can be used multiple times and will run
 in the order configured.
 
@@ -80,24 +80,16 @@ variant, the delegate will run when the runtime context instance is assignable t
 resolution falls through to the next strategy.
 
 ```csharp
-// use async logic to get the tenant identifier
+// use custom logic to get the tenant identifier
 builder.Services.AddMultiTenant<TenantInfo>()
-    .WithDelegateStrategy(async context =>
-    {
-        string? tenantIdentifier = await DoSomethingAsync(context);
-        return tenantIdentifier;
-    })...
+    .WithDelegateStrategy(context => Task.FromResult<string?>("initech"))...
 
 // or register with a typed lambda, HttpContext in this case; derived runtime types are also supported
 builder.Services.AddMultiTenant<TenantInfo>()
     .WithDelegateStrategy<HttpContext, TenantInfo>(httpContext =>
-    {      
-        httpContext.Request.Query.TryGetValue("tenant", out StringValues tenantIdentifier);
-        
-        if (tenantIdentifier == StringValues.Empty)
-            return Task.FromResult<string?>(null);
-        
-        return Task.FromResult<string?>(tenantIdentifier.ToString());
+    {
+        var tenantIdentifier = httpContext.Request.Query["tenant"].FirstOrDefault();
+        return Task.FromResult(tenantIdentifier);
     })...
 ```
 
@@ -138,7 +130,7 @@ to `https://www.example.com/initech` would use `initech` as the identifier when 
 
 By default the strategy modifies the ASP.NET Core `PathBase` and `Path` so that the tenant segment is added to the `PathBase` and removed from the `Path`.
 This allows subsequent app logic to operate as if the tenant segment was never there. For example, a request to
-`https://mydomain.com/mytenant/mypath` by default has a `PathBase` of `/` and
+`https://mydomain.com/mytenant/mypath` by default has an empty `PathBase` and
 a `Path` of `/mytenant/mypath`. This behavior will adjust these values to `/mytenant` and `/mypath`
 respectively when a tenant is successfully resolved. If you do not want this behavior, use the overload that accepts options and set `RebaseAspNetCorePathBase` to false.
 
@@ -219,8 +211,8 @@ builder.Services.AddMultiTenant<TenantInfo>()
 Note that your app will have
 to [configure session state](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/app-state#session-state)
 accordingly and then actually set the session variable. A typical use case is to register the session strategy before a
-more expensive strategy. The expensive strategy can set the session value so that for subsequent requests resolve the
-tenant without invoking the expensive strategy.
+more expensive strategy. The expensive strategy can set the session value so subsequent requests resolve the
+tenant without invoking it.
 
 ## Route Strategy
 
@@ -274,7 +266,7 @@ builder.Services.AddMultiTenant<TenantInfo>()
 
 > NuGet package: Finbuckle.MultiTenant.AspNetCore
 
-Uses request's host value to determine the tenant. By default, the first host segment is used. For example, a request
+Uses the request host to determine the tenant. By default, the first host segment is used. For example, a request
 to `https://initech.example.com/abc123` would use "initech" as the identifier when resolving the tenant. This strategy
 can be difficult to use in a development environment. Make sure the development system is configured properly to allow
 subdomains on `localhost`. This strategy is configured as a singleton.


### PR DESCRIPTION
## Summary
- Tighten wording across the ASP.NET Core, authentication, configuration, EF Core, getting started, identity, options, and stores docs.
- Update examples and terminology for consistency, including `OpenID Connect`, `TenantInfo`, and multi-tenant resolution descriptions.
- Remove outdated or confusing phrasing and align several code samples with current APIs and conventions.

## Testing
- Not run (not requested)