### PR TITLE
Update sample and test dependencies to latest package versions

### DIFF
--- a/samples/IdentityAppSample/IdentityAppSample.csproj
+++ b/samples/IdentityAppSample/IdentityAppSample.csproj
@@ -16,8 +16,8 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Finbuckle.MultiTenant.AspNetCore" Version="10.1.1" />
-        <PackageReference Include="Finbuckle.MultiTenant.Identity.EntityFrameworkCore" Version="10.1.1" />
+        <PackageReference Include="Finbuckle.MultiTenant.AspNetCore" Version="10.1.2" />
+        <PackageReference Include="Finbuckle.MultiTenant.Identity.EntityFrameworkCore" Version="10.1.2" />
     </ItemGroup>
 
 </Project>

--- a/samples/WebApiSample/WebApiSample.csproj
+++ b/samples/WebApiSample/WebApiSample.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-        <PackageReference Include="Finbuckle.MultiTenant.AspNetCore" Version="10.1.1" />
-        <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
+        <PackageReference Include="Finbuckle.MultiTenant.AspNetCore" Version="10.1.2" />
+        <PackageReference Include="Microsoft.OpenApi" Version="3.9.0" />
     </ItemGroup>
     
 </Project>

--- a/src/Finbuckle.MultiTenant.AspNetCore/packages.lock.json
+++ b/src/Finbuckle.MultiTenant.AspNetCore/packages.lock.json
@@ -75,7 +75,7 @@
       "finbuckle.multitenant": {
         "type": "Project",
         "dependencies": {
-          "Finbuckle.MultiTenant.Abstractions": "[10.1.1, )"
+          "Finbuckle.MultiTenant.Abstractions": "[10.1.2, )"
         }
       },
       "finbuckle.multitenant.abstractions": {

--- a/src/Finbuckle.MultiTenant.EntityFrameworkCore/packages.lock.json
+++ b/src/Finbuckle.MultiTenant.EntityFrameworkCore/packages.lock.json
@@ -173,7 +173,7 @@
       "finbuckle.multitenant": {
         "type": "Project",
         "dependencies": {
-          "Finbuckle.MultiTenant.Abstractions": "[10.1.1, )",
+          "Finbuckle.MultiTenant.Abstractions": "[10.1.2, )",
           "Microsoft.Extensions.Caching.Abstractions": "[10.0.10, )",
           "Microsoft.Extensions.Configuration": "[10.0.10, )",
           "Microsoft.Extensions.DependencyInjection": "[10.0.10, )",

--- a/src/Finbuckle.MultiTenant.Identity.EntityFrameworkCore/packages.lock.json
+++ b/src/Finbuckle.MultiTenant.Identity.EntityFrameworkCore/packages.lock.json
@@ -217,7 +217,7 @@
       "finbuckle.multitenant": {
         "type": "Project",
         "dependencies": {
-          "Finbuckle.MultiTenant.Abstractions": "[10.1.1, )",
+          "Finbuckle.MultiTenant.Abstractions": "[10.1.2, )",
           "Microsoft.Extensions.Caching.Abstractions": "[10.0.10, )",
           "Microsoft.Extensions.Configuration": "[10.0.10, )",
           "Microsoft.Extensions.DependencyInjection": "[10.0.10, )",
@@ -233,7 +233,7 @@
       "finbuckle.multitenant.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
-          "Finbuckle.MultiTenant": "[10.1.1, )",
+          "Finbuckle.MultiTenant": "[10.1.2, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )"
         }
       }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0"/>
-        <PackageReference Include="Moq" Version="4.20.70"/>
-    </ItemGroup>
-</Project>

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Finbuckle.MultiTenant.AspNetCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Finbuckle.MultiTenant.AspNetCore.Test.csproj
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-        <ProjectReference Include="../../src/Finbuckle.MultiTenant.AspNetCore/Finbuckle.MultiTenant.AspNetCore.csproj"/>
+        <ProjectReference Include="../../src/Finbuckle.MultiTenant.AspNetCore/Finbuckle.MultiTenant.AspNetCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
         <PrivateAssets>all</PrivateAssets>

--- a/test/Finbuckle.MultiTenant.AspNetCore.Test/Finbuckle.MultiTenant.AspNetCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.AspNetCore.Test/Finbuckle.MultiTenant.AspNetCore.Test.csproj
@@ -13,12 +13,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-      <PackageReference Update="xunit" Version="2.9.3" />
-      <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5">
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+      <PackageReference Include="xunit" Version="2.9.3" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Update="Moq" Version="4.20.72" />
+      <PackageReference Include="Moq" Version="4.20.72" />
     </ItemGroup>
 </Project>

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Finbuckle.MultiTenant.EntityFrameworkCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Finbuckle.MultiTenant.EntityFrameworkCore.Test.csproj
@@ -12,12 +12,12 @@
 
         <ProjectReference Include="../../src/Finbuckle.MultiTenant.EntityFrameworkCore/Finbuckle.MultiTenant.EntityFrameworkCore.csproj" />
         <ProjectReference Include="../Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj" />
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-        <PackageReference Update="xunit" Version="2.9.3" />
-        <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Update="Moq" Version="4.20.72" />
+        <PackageReference Include="Moq" Version="4.20.72" />
     </ItemGroup>
 </Project>

--- a/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Finbuckle.MultiTenant.EntityFrameworkCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.EntityFrameworkCore.Test/Finbuckle.MultiTenant.EntityFrameworkCore.Test.csproj
@@ -12,7 +12,7 @@
 
         <ProjectReference Include="../../src/Finbuckle.MultiTenant.EntityFrameworkCore/Finbuckle.MultiTenant.EntityFrameworkCore.csproj" />
         <ProjectReference Include="../Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test.csproj
@@ -12,7 +12,7 @@
 
         <ProjectReference Include="..\..\src\Finbuckle.MultiTenant.Identity.EntityFrameworkCore\Finbuckle.MultiTenant.Identity.EntityFrameworkCore.csproj" />
 
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 
         <PackageReference Include="xunit" Version="2.9.3" />
 

--- a/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test.csproj
+++ b/test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test/Finbuckle.MultiTenant.Identity.EntityFrameworkCore.Test.csproj
@@ -12,15 +12,15 @@
 
         <ProjectReference Include="..\..\src\Finbuckle.MultiTenant.Identity.EntityFrameworkCore\Finbuckle.MultiTenant.Identity.EntityFrameworkCore.csproj" />
 
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
-        <PackageReference Update="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit" Version="2.9.3" />
 
-        <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
 
-        <PackageReference Update="Moq" Version="4.20.72" />
+        <PackageReference Include="Moq" Version="4.20.72" />
     </ItemGroup>
 </Project>

--- a/test/Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj
+++ b/test/Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj
@@ -18,7 +18,7 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
 
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 
         <PackageReference Include="xunit" Version="2.9.3" />
 

--- a/test/Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj
+++ b/test/Finbuckle.MultiTenant.Test/Finbuckle.MultiTenant.Test.csproj
@@ -18,16 +18,16 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
 
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
-        <PackageReference Update="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit" Version="2.9.3" />
 
-        <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
 
-        <PackageReference Update="Moq" Version="4.20.72" />
+        <PackageReference Include="Moq" Version="4.20.72" />
 
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bump Finbuckle.MultiTenant package references in the sample apps to `10.1.2`
- Update `Microsoft.OpenApi` in the Web API sample to `3.9.0`
- Refresh test project package references to use explicit `Include` entries and upgrade `Microsoft.NET.Test.Sdk` to `18.8.1`
- Remove the shared `test/Directory.Build.props` so test dependencies are declared per project
- Regenerate affected package lock files to match the updated dependency graph

## Testing
- Not run (not requested)
- Validation is covered by the updated project and lockfile references; test projects now resolve their packages directly from each `.csproj`