### PR TITLE
fix: ensure created service scope get disposed

### DIFF
--- a/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -53,7 +53,11 @@ public static class FinbuckleHttpContextExtensions
         where TTenantInfo : ITenantInfo
     {
         if (resetServiceProviderScope)
-            httpContext.RequestServices = httpContext.RequestServices.CreateScope().ServiceProvider;
+        {
+            var scope = httpContext.RequestServices.CreateScope();
+            httpContext.RequestServices = scope.ServiceProvider;
+            httpContext.Response.RegisterForDispose(scope);
+        }
 
         var multiTenantContext =
             new MultiTenantContext<TTenantInfo>(tenantInfo: tenantInfo, strategyInfo: null, storeInfo: null);


### PR DESCRIPTION
This pull request makes a small but important improvement to the way service scopes are managed when setting tenant information in `HttpContextExtensions`. Specifically, it ensures that the created service scope is properly disposed at the end of the HTTP response, preventing potential memory leaks.

Resource management improvement:

* [`src/Finbuckle.MultiTenant.AspNetCore/Extensions/HttpContextExtensions.cs`](diffhunk://#diff-f4ba5c4b4e5943e5feffebe75f17df3480a26b07e5aa7b3494fbc4de481b4f52L56-R60): When `resetServiceProviderScope` is true, the created service scope is now registered for disposal with the HTTP response, ensuring proper cleanup of resources.